### PR TITLE
Update validator.network seed node addresses

### DIFF
--- a/emoney/chain.json
+++ b/emoney/chain.json
@@ -47,13 +47,13 @@
     "peers": {
         "seeds": [
             {
-                "id": "17533be7691494a0bc2dbd174930fa6a57b5b98c",
-                "address": "3.69.44.220:28656",
+                "id": "6420ef5087accdff4a87df5331d07da5de568743",
+                "address": "18.194.208.47:28656",
                 "provider": "validator.network"
             },
             {
-                "id": "3f6ce97077a9bddd6dd637cd64c140eabdebbda5",
-                "address": "3.68.159.237:28656",
+                "id": "f49bf0e3d6d6057499ceb6613854af37a3da532a",
+                "address": "3.121.126.177:28656",
                 "provider": "validator.network"
             },
             {


### PR DESCRIPTION
The seed nodes provided by validator.network for emoney-3 have changed their addresses.