### PR TITLE
Crypto.org Chain DRACO II network upgrade 

### DIFF
--- a/cryptoorgchain/chain.json
+++ b/cryptoorgchain/chain.json
@@ -20,14 +20,14 @@
   },
   "codebase": {
     "git_repo": "https://github.com/crypto-org-chain/chain-main",
-    "recommended_version": "v2.1.2",
-    "compatible_versions": ["v2.1.2"],
+    "recommended_version": "v3.3.3",
+    "compatible_versions": ["v3.3.3"],
     "binaries": {
-      "linux/amd64": "https://github.com/crypto-org-chain/chain-main/releases/download/v2.1.2/chain-main_2.1.2_Linux_x86_64.tar.gz",
-      "linux/arm64": "https://github.com/crypto-org-chain/chain-main/releases/download/v2.1.2/chain-main_2.1.2_Linux_arm64.tar.gz",
-      "darwin/amd64": "https://github.com/crypto-org-chain/chain-main/releases/download/v2.1.2/chain-main_2.1.2_Darwin_x86_64.tar.gz",
-      "darwin/arm64": "https://github.com/crypto-org-chain/chain-main/releases/download/v2.1.2/chain-main_2.1.2_Darwin_arm64.tar.gz",
-      "windows/amd64": "https://github.com/crypto-org-chain/chain-main/releases/download/v2.1.2/chain-main_2.1.2_Windows_x86_64.zip"
+      "linux/amd64": "https://github.com/crypto-org-chain/chain-main/releases/download/v3.3.3/chain-main_3.3.3_Linux_x86_64.tar.gz",
+      "linux/arm64": "https://github.com/crypto-org-chain/chain-main/releases/download/v3.3.3/chain-main_3.3.3_Linux_arm64.tar.gz",
+      "darwin/amd64": "https://github.com/crypto-org-chain/chain-main/releases/download/v3.3.3/chain-main_3.3.3_Darwin_x86_64.tar.gz",
+      "darwin/arm64": "https://github.com/crypto-org-chain/chain-main/releases/download/v3.3.3/chain-main_3.3.3_Darwin_arm64.tar.gz",
+      "windows/amd64": "https://github.com/crypto-org-chain/chain-main/releases/download/v3.3.3/chain-main_3.3.3_Windows_x86_64.zip"
     }
   },
   "peers": {
@@ -138,6 +138,11 @@
       "kind": "mintscan",
       "url": "https://www.mintscan.io/crypto-org",
       "tx_page": "https://www.mintscan.io/crypto-org/txs/${txHash}"
+    },
+    {
+      "kind": "crypto.org",
+      "url": "https://crypto.org/explorer",
+      "tx_page": "https://crypto.org/explorer/tx/${txHash}"
     }
   ]
 }


### PR DESCRIPTION
The Crypto.org chain has been successfully upgraded at block height `3,526,800` (see [proposal 6])(https://crypto.org/explorer/proposal/6), in this PR, we have:

- Updated the binary version and the links from `v2.1.2` to `v3.3.3`;
- Added link to [Crypto.org explorer](https://crypto.org/explorer).