### PR TITLE
feat: add package.json to allow imports

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "cosmos-chain-registry",
+  "version": "1.0.0",
+  "description": "Chain info and assets list of cosmos-sdk based chains.",
+  "exports": {
+    "./*": "./*"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git@github.com:cosmos/chain-registry.git"
+  },
+  "author": "",
+  "license": "ISC"
+}


### PR DESCRIPTION
Fixes #94. This allows embedding it into any JS app that uses npm.

To test:
1) create an empty project: `npm init --yes`
2) install the dependency: `npm install git@github.com:cosmos/chain-registry.git`
3) have a index.js files that does the following:
```
$ cat index.js
const sentinelChain = require('cosmos-chain-registry/sentinel/chain.json')
console.log(sentinelChain)
```

4) run it:
```
node index.js
{
  '$schema': '../chain.schema.json',
  chain_name: 'sentinel',
  status: 'live',
  network_type: 'mainnet',
  pretty_name: 'Sentinel',
  chain_id: 'sentinelhub-2',
  bech32_prefix: 'sent',
  slip44: 750,
  genesis: { genesis_url: 'https://transfer.sh/get/cKOdRE/genesis.json' },
  codebase: {
    git_repo: 'https://github.com/sentinel-official/hub',
    recommended_version: 'v0.6.2',
    compatible_versions: [ 'v0.6.2' ]
  },
  daemon_name: 'sentinelhub',
  node_home: '$HOME/.sentinelhub',
  key_algos: [ 'secp256k1' ],
  peers: {
    seeds: [ [Object] ],
    persistent_peers: [
      [Object], [Object],
      [Object], [Object],
      [Object], [Object],
      [Object], [Object],
      [Object], [Object],
      [Object], [Object],
      [Object], [Object]
    ]
  },
  apis: { rpc: [ [Object] ], rest: [ [Object] ] }
}
```