### PR TITLE
Updated explorer link for cheqd network

### DIFF
--- a/cheqd/chain.json
+++ b/cheqd/chain.json
@@ -88,8 +88,8 @@
     "explorers": [
         {
             "kind": "bigdipper",
-            "url": "https://cheqd.didx.co.za/",
-            "tx_page": "https://cheqd.didx.co.za/transactions/${txHash}"
+            "url": "https://explorer.cheqd.io/",
+            "tx_page": "https://explorer.cheqd.io/transactions/${txHash}"
         }
     ]
 }

--- a/cheqd/chain.json
+++ b/cheqd/chain.json
@@ -1,0 +1,75 @@
+{
+    "$schema": "../chain.schema.json",
+    "chain_name": "cheqd",
+    "status": "live",
+    "network_type": "mainnet",
+    "pretty_name": "Cheqd",
+    "chain_id": "cheqd-mainnet-1",
+    "bech32_prefix": "cheqd",
+    "daemon_name": "cheqd-noded",
+    "node_home": "$HOME/.cheqdnode",
+    "genesis": {
+        "genesis_url": "https://github.com/cheqd/cheqd-node/blob/main/persistent_chains/mainnet/genesis.json"
+    },
+    "slip44": 118,
+    "fees": {
+        "fee_tokens": [
+            {
+                "denom": "ncheq",
+                "fixed_min_gas_price": 0
+            }
+        ]
+    },
+    "codebase": {
+        "git_repo": "https://github.com/cheqd/cheqd-node",
+        "recommended_version": "v0.3.1",
+        "compatible_versions": [
+            "v0.3.1"
+        ],
+        "binaries": {
+            "linux/amd64": "https://github.com/cheqd/cheqd-node/releases/download/v0.3.1/cheqd-node_0.3.1_amd64.deb"
+        }
+    },
+    "peers": {
+        "seeds": [
+            {
+                "id": "258a9bfb822637bfca87daaab6181c10e7fd0910",
+                "address": "seed1.eu.cheqd.network:26656",
+                "provider": "cheqd"
+            },
+            {
+                "id": "f565ff792b20977face9817df6acb268d41d4092",
+                "address": "seed2.eu.cheqd.net:26656",
+                "provider": "cheqd"
+            },
+            {
+                "id": "388947cc7d901c5c06fedc4c26751634564d68e6",
+                "address": "seed3.eu.cheqd.net:26656",
+                "provider": "cheqd"
+            },
+            {
+                "id": "9b30307a2a2819790d68c04bb62f5cf4028f447e",
+                "address": "seed1.ap.cheqd.net:26656",
+                "provider": "cheqd"
+            }
+        ],
+        "persistent_peers": [
+        ]
+    },
+    "apis": {
+        "rpc": [
+            {
+                "address": "https://rpc.cheqd.network",
+                "provider": "cheqdnetwork"
+            }
+        ],
+        "rest": [
+            {
+                "address": "https://api.cheqd.network",
+                "provider": "cheqdnetwork"
+            }
+        ]
+    },
+    "explorers": [
+    ]
+}

--- a/cheqd/chain.json
+++ b/cheqd/chain.json
@@ -3,13 +3,13 @@
     "chain_name": "cheqd",
     "status": "live",
     "network_type": "mainnet",
-    "pretty_name": "Cheqd",
+    "pretty_name": "cheqd",
     "chain_id": "cheqd-mainnet-1",
     "bech32_prefix": "cheqd",
     "daemon_name": "cheqd-noded",
     "node_home": "$HOME/.cheqdnode",
     "genesis": {
-        "genesis_url": "https://github.com/cheqd/cheqd-node/blob/main/persistent_chains/mainnet/genesis.json"
+        "genesis_url": "https://raw.githubusercontent.com/cheqd/cheqd-node/main/persistent_chains/mainnet/genesis.json"
     },
     "slip44": 118,
     "fees": {
@@ -34,7 +34,7 @@
         "seeds": [
             {
                 "id": "258a9bfb822637bfca87daaab6181c10e7fd0910",
-                "address": "seed1.eu.cheqd.network:26656",
+                "address": "seed1.eu.cheqd.net:26656",
                 "provider": "cheqd"
             },
             {
@@ -51,25 +51,45 @@
                 "id": "9b30307a2a2819790d68c04bb62f5cf4028f447e",
                 "address": "seed1.ap.cheqd.net:26656",
                 "provider": "cheqd"
+            },
+            {
+                "id": "debcb3fa7d40e681d98bcc7d22278fd58a34b73a",
+                "address": "144.76.183.180:1234",
+                "provider": "notional"
             }
         ],
         "persistent_peers": [
+            {
+                "id": "d1ebb60825e2c29181b499f93493dd440fb87997",
+                "address": "sentry1.eu.cheqd.net:26656",
+                "provider": "cheqd"
+            },
+            {
+                "id": "c3885b3a24e4928ce50f8c8007c9a70462fa4c8d",
+                "address": "sentry2.eu.cheqd.net:26656",
+                "provider": "cheqd"
+            }
         ]
     },
     "apis": {
         "rpc": [
             {
-                "address": "https://rpc.cheqd.network",
-                "provider": "cheqdnetwork"
+                "address": "https://rpc.cheqd.net",
+                "provider": "cheqd"
             }
         ],
         "rest": [
             {
-                "address": "https://api.cheqd.network",
-                "provider": "cheqdnetwork"
+                "address": "https://api.cheqd.net",
+                "provider": "cheqd"
             }
         ]
     },
     "explorers": [
+        {
+            "kind": "bigdipper",
+            "url": "https://cheqd.didx.co.za/",
+            "tx_page": "https://cheqd.didx.co.za/transactions/${txHash}"
+        }
     ]
 }

--- a/cheqd/chain.json
+++ b/cheqd/chain.json
@@ -65,7 +65,7 @@
                 "provider": "cheqd"
             },
             {
-                "id": "c3885b3a24e4928ce50f8c8007c9a70462fa4c8d",
+                "id": "513d334bb044296796939e57b522fef7fd4b9c6c",
                 "address": "sentry2.eu.cheqd.net:26656",
                 "provider": "cheqd"
             }

--- a/secretnetwork/chain.json
+++ b/secretnetwork/chain.json
@@ -58,6 +58,10 @@
       {
         "address": "https://lcd-secret.scrtlabs.com/",
         "provider": "SCRT Labs"
+      },
+      {
+        "address": "https://api.secretapi.io/",
+        "provider": "chainofsecrets"
       }
     ]
   },


### PR DESCRIPTION
I'm updating the link for the cheqd network explorer from https://cheqd.didx.co.za to https://explorer.cheqd.io. The previous link does an HTTP 301 redirect to the new link, but I wanted to mention the new link regardless.