### PR TITLE
Update cosmoshub genesis_url

### DIFF
--- a/cosmoshub/chain.json
+++ b/cosmoshub/chain.json
@@ -9,7 +9,7 @@
     "daemon_name": "gaiad",
     "node_home": "$HOME/.gaia",
     "genesis": {
-        "genesis_url": "https://transfer.sh/get/jERP1k/genesis.cosmoshub-4.json"
+        "genesis_url": "https://github.com/cosmos/mainnet/raw/master/genesis.cosmoshub-4.json.gz"
     },
     "slip44": 118,
     "codebase": {


### PR DESCRIPTION
The transfer.sh URL is returning an error currently, and this is the URL given in https://github.com/cosmos/mainnet. Note the change from .json to .json.gz