### PR TITLE
More Terra Chain API Endpoints

### DIFF
--- a/terra/chain.json
+++ b/terra/chain.json
@@ -46,14 +46,26 @@
     "apis": {
         "rpc": [
             {
+                "address": "https://terra-rpc.easy2stake.com:443",
+                "provider": "Easy2stake"
+            },
+            {
                 "address": "http://64.227.72.101:26657",
                 "provider": "cryptocrew"
+            },
+            {
+                "address": "http://public-node.terra.dev:26657",
+                "provider": "Terra"
             }
         ],
         "rest": [
             {
                 "address": "http://64.227.72.101:1317",
                 "provider": "cryptocrew"
+            },
+            {
+                "address": "https://blockdaemon-terra-lcd.api.bdnodes.net:1317",
+                "provider": "Blockdaemon"
             }
         ]
     }


### PR DESCRIPTION
Found at [Terra docs](https://docs.terra.money/Reference/endpoints.html).

Although the listed `public-node.terra.dev` does not work, I did not remove any broken (or old) endpoints.