### PR TITLE
Fix Regen Network versions

### DIFF
--- a/regen/chain.json
+++ b/regen/chain.json
@@ -13,9 +13,9 @@
     },
     "codebase": {
         "git_repo": "https://github.com/regen-network/regen-ledger",
-        "recommended_version": "1d7351d3fdad2e15ab16892d8961f9a23a6d3014",
+        "recommended_version": "v2.1.0",
         "compatible_versions": [
-            "1d7351d3fdad2e15ab16892d8961f9a23a6d3014"
+            "v2.1.0"
         ]
     },
     "peers": {


### PR DESCRIPTION
https://github.com/cosmos/chain-registry/blob/6a82418682d3e3196aadb1cba16b233849192a63/regen/chain.json#L15-L19

Very strange that this commit hash doesn't even exist.

I updated the version(s) with [latest release tag on their repo](https://github.com/regen-network/regen-ledger/releases/tag/v2.1.0).