### PR TITLE
Fix Dig's version inconsistency

### DIFF
--- a/dig/chain.json
+++ b/dig/chain.json
@@ -25,8 +25,8 @@
   },
   "codebase": {
     "git_repo": "https://github.com/notional-labs/dig",
-    "recommended_version": "MainNet",
-    "compatible_versions": ["MainNet"]
+    "recommended_version": "v1.0.0",
+    "compatible_versions": ["v1.0.0"]
   },
   "peers": {
     "seeds": [


### PR DESCRIPTION
Changed Github release `name` to release `tag_name`.

[`MainNet` is the name of their release tag `v1.0.0`](https://github.com/notional-labs/dig/releases/tag/v1.0.0).

