### PR TITLE
Update sentinel genesis.json

### DIFF
--- a/sentinel/chain.json
+++ b/sentinel/chain.json
@@ -8,7 +8,7 @@
     "bech32_prefix": "sent",
     "slip44": 750,
     "genesis": {
-        "genesis_url": "https://transfer.sh/get/cKOdRE/genesis.json"
+        "genesis_url": "https://raw.githubusercontent.com/sentinel-official/networks/main/sentinelhub-2/genesis.zip"
     },
     "codebase": {
         "git_repo": "https://github.com/sentinel-official/hub",


### PR DESCRIPTION
Update expired transfer.sh URL and use version from [Sentinel docs](https://docs.sentinel.co/sentinelhub/running-a-full-node/). Unfortunately there isn't an extracted genesis available.