### PR TITLE
Update for gravity-bridge-2

### DIFF
--- a/gravitybridge/chain.json
+++ b/gravitybridge/chain.json
@@ -4,7 +4,7 @@
     "status": "live",
     "network_type": "mainnet",
     "pretty_name": "Gravity Bridge",
-    "chain_id": "gravity-bridge-1",
+    "chain_id": "gravity-bridge-2",
     "bech32_prefix": "graviton",
     "daemon_name": "gravity",
     "node_home": "$HOME/.gravity",
@@ -25,16 +25,16 @@
     },
     "codebase": {
         "git_repo": "https://github.com/Gravity-Bridge/Gravity-Bridge",
-        "recommended_version": "v1.0.8",
+        "recommended_version": "v1.2.1",
         "compatible_versions": [
-            "v1.0.7",
-            "v1.0.8"
+            "v1.2.0",
+            "v1.2.1"
         ],
         "binaries": {
-            "linux/amd64": "https://github.com/Gravity-Bridge/Gravity-Bridge/releases/download/v1.0.8/gravity-linux-amd64",
-            "linux/arm64": "https://github.com/Gravity-Bridge/Gravity-Bridge/releases/download/v1.0.8/gravity-linux-arm64",
-            "darwin/amd64": "https://github.com/Gravity-Bridge/Gravity-Bridge/releases/download/v1.0.8/gravity-darwin-amd64",
-            "windows/amd64": "https://github.com/Gravity-Bridge/Gravity-Bridge/releases/download/v1.0.8/gravity-windows-amd64.exe"
+            "linux/amd64": "https://github.com/Gravity-Bridge/Gravity-Bridge/releases/download/v1.2.1/gravity-linux-amd64",
+            "linux/arm64": "https://github.com/Gravity-Bridge/Gravity-Bridge/releases/download/v1.2.1/gravity-linux-arm64",
+            "darwin/amd64": "https://github.com/Gravity-Bridge/Gravity-Bridge/releases/download/v1.2.1/gravity-darwin-amd64",
+            "windows/amd64": "https://github.com/Gravity-Bridge/Gravity-Bridge/releases/download/v1.2.1/gravity-windows-amd64.exe"
         }
     },
     "peers": {
@@ -48,7 +48,6 @@
                 "id": "63e662f5e048d4902c7c7126291cf1fc17687e3c",
                 "address": "95.211.103.175:26656",
                 "provider": "amhost"
-
             }
         ],
         "persistent_peers": [
@@ -67,12 +66,12 @@
     "apis": {
         "rpc": [
             {
-                "address": "http://gravity-rpc.qwoyn.com:26657",
-                "provider": "qwoyn"
+                "address": "https://gravitychain.io:26657",
+                "provider": "althea"
             },
             {
-                "address": "chainripper-2.althea.net:26657",
-                "provider": "althea"
+                "address": "http://gravity-rpc.qwoyn.com:26657",
+                "provider": "qwoyn"
             },
             {
                 "address": "gravity-bridge-1-08.nodes.amhost.net:26657",
@@ -85,11 +84,19 @@
         ],
         "rest": [
             {
+                "address": "https://gravitychain.io:1317",
+                "provider": "althea"
+            },
+            {
                 "address": "http://gravity-rpc.qwoyn.com:1317",
                 "provider": "qwoyn"
             }
         ],
         "grpc": [
+            {
+                "address": "https://gravitychain.io:9090",
+                "provider": "althea"
+            },
             {
                 "address": "gravity-bridge-1-08.nodes.amhost.net:9090",
                 "provider": "amhost"


### PR DESCRIPTION
This patch updates details for gravity-bridge-2 and also updates the rpc endpoints lists to include Althea's gravitychain.io service. 