### PR TITLE
Fix dig home directory

### DIFF
--- a/dig/chain.json
+++ b/dig/chain.json
@@ -7,7 +7,7 @@
   "chain_id": "dig-1",
   "bech32_prefix": "dig",
   "daemon_name": "digd",
-  "node_home": "$HOME/.digd",
+  "node_home": "$HOME/.dig",
   "genesis": {
     "genesis_url":  "https://raw.githubusercontent.com/notional-labs/dig/master/networks/mainnets/dig-1/genesis.json"
   },


### PR DESCRIPTION
Found to be `.dig` while adding to Omnibus https://github.com/ovrclk/cosmos-omnibus/pull/112