### PR TITLE
update terra v0.5.14 -> v0.5.15

### DIFF
--- a/terra/chain.json
+++ b/terra/chain.json
@@ -13,14 +13,14 @@
     },
     "codebase": {
         "git_repo": "https://github.com/terra-money/core/",
-        "recommended_version": "v0.5.14",
+        "recommended_version": "v0.5.15",
         "compatible_versions": [
+            "v0.5.15",
             "v0.5.14"
         ],
         "binaries": {
-            "linux/amd64": "https://github.com/terra-money/core/releases/download/v0.5.14/terra_0.5.14_Linux_x86_64.tar.gz",
-            "linux/arm64": "https://github.com/terra-money/core/releases/download/v0.5.14/terra_0.5.14-oracle_Linux_x86_64.tar.gz",
-            "darwin/amd64": "https://github.com/terra-money/core/releases/download/v0.5.14/terra_0.5.14_Darwin_x86_64.tar.gz"
+            "linux/amd64": "https://github.com/terra-money/core/releases/download/v0.5.15/terra_0.5.15_Linux_x86_64.tar.gz",
+            "darwin/amd64": "https://github.com/terra-money/core/releases/download/v0.5.15/terra_0.5.15_Darwin_x86_64.tar.gz"
         }
     },
     "peers": {


### PR DESCRIPTION
https://github.com/terra-money/core/releases/tag/v0.5.15
Note: Looks that they have dropped a support for arm64 architecture (no oracle_Linux_x86_64.tar.gz anymore in assets)