### PR TITLE
change port from 80 to 443

### DIFF
--- a/sifchain/chain.json
+++ b/sifchain/chain.json
@@ -60,20 +60,20 @@
     "apis": {
         "rpc": [
             {
-                "address": "https://rpc.sifchain.finance:80"
+                "address": "https://rpc.sifchain.finance:443"
             },
             {
-                "address": "https://rpc-archive.sifchain.finance:80"
+                "address": "https://rpc-archive.sifchain.finance:443"
             }
         ],
         "grpc": [
             {
-                "address": "https://grpc.sifchain.finance:80"
+                "address": "https://grpc.sifchain.finance:443"
             }
         ],
         "rest": [
             {
-                "address": "https://api.sifchain.finance:80"
+                "address": "https://api.sifchain.finance:443"
             }
         ]
     }


### PR DESCRIPTION
I checked the api on port 80 and it doesn't work. So I guess the right port is 443 since it works and is https anyway.