### PR TITLE
[osmosis] v6.1.0 -> v6.3.0

### DIFF
--- a/osmosis/chain.json
+++ b/osmosis/chain.json
@@ -25,16 +25,16 @@
     },
     "codebase": {
         "git_repo": "https://github.com/osmosis-labs/osmosis",
-        "recommended_version": "v6.1.0",
+        "recommended_version": "v6.3.0",
         "compatible_versions": [
-            "v6.1.0",
-            "v6.0.0"
+            "v6.3.0",
+            "v6.1.0"
         ],
         "binaries": {
-            "linux/amd64": "https://github.com/osmosis-labs/osmosis/releases/download/v6.1.0/osmosisd-6.1.0-linux-amd64",
-            "linux/arm64": "https://github.com/osmosis-labs/osmosis/releases/download/v6.1.0/osmosisd-6.1.0-linux-arm64",
-            "darwin/amd64": "https://github.com/osmosis-labs/osmosis/releases/download/v6.1.0/osmosisd-6.1.0-darwin-amd64",
-            "windows/amd64": "https://github.com/osmosis-labs/osmosis/releases/download/v6.1.0/osmosisd-6.1.0-windows-amd64.exe"
+            "linux/amd64": "https://github.com/osmosis-labs/osmosis/releases/download/v6.3.0/osmosisd-6.3.0-linux-amd64",
+            "linux/arm64": "https://github.com/osmosis-labs/osmosis/releases/download/v6.3.0/osmosisd-6.3.0-linux-arm64",
+            "darwin/amd64": "https://github.com/osmosis-labs/osmosis/releases/download/v6.3.0/osmosisd-6.3.0-darwin-amd64",
+            "windows/amd64": "https://github.com/osmosis-labs/osmosis/releases/download/v6.3.0/osmosisd-6.3.0-windows-amd64.exe"
         }
     },
     "peers": {


### PR DESCRIPTION
https://github.com/osmosis-labs/osmosis/releases/tag/v6.3.0
v6.2.0 was skipped for some reason