### PR TITLE
CRO token renaming

### DIFF
--- a/cronos/assetlist.json
+++ b/cronos/assetlist.json
@@ -15,7 +15,7 @@
           }
         ],
         "base": "basecro",
-        "name": "Crypto.com Coin",
+        "name": "Cronos",
         "display": "cro",
         "symbol": "CRO",
         "logo_URIs": {

--- a/cryptoorgchain/assetlist.json
+++ b/cryptoorgchain/assetlist.json
@@ -15,7 +15,7 @@
           }
         ],
         "base": "basecro",
-        "name": "Crypto.com Coin",
+        "name": "Cronos",
         "display": "cro",
         "symbol": "CRO",
         "logo_URIs": {


### PR DESCRIPTION
Updated `CRO` token full name from  `Crypto.org Chain Coin (CRO)` to `Cronos (CRO)`

Ref: [Re-branding announcement](https://twitter.com/cronos_chain/status/1494556389951172617?s=20&t=a2Qyr7FJ_sLEPdi2HCcgrQ)