### PR TITLE
[carbon] v2.1.0 -> v2.2.0, fix seed IPs

### DIFF
--- a/carbon/chain.json
+++ b/carbon/chain.json
@@ -25,28 +25,28 @@
     },
     "codebase": {
         "git_repo": "https://github.com/Switcheo/carbon-bootstrap",
-        "recommended_version": "v2.1.0",
+        "recommended_version": "v2.2.0",
         "compatible_versions": [],
         "binaries": {
-            "linux/amd64": "https://github.com/Switcheo/carbon-bootstrap/releases/download/v2.1.0/carbond2.1.0-mainnet.linux-amd64.tar.gz",
-            "linux/arm64": "https://github.com/Switcheo/carbon-bootstrap/releases/download/v2.1.0/carbond2.1.0-mainnet.linux-ard64.tar.gz"
+            "linux/amd64": "https://github.com/Switcheo/carbon-bootstrap/releases/download/v2.2.0/carbond2.2.0-mainnet.linux-amd64.tar.gz",
+            "linux/arm64": "https://github.com/Switcheo/carbon-bootstrap/releases/download/v2.2.0/carbond2.2.0-mainnet.linux-ard64.tar.gz"
         }
     },
     "peers": {
         "seeds": [
             {
                 "id": "d93ed6a1f43dd0904dc5e2ab8680d4049b057b17",
-                "address": "54.151.250.242:26656",
+                "address": "13.215.17.91:26656",
                 "provider": "switcheo-labs"
             },
             {
                 "id": "70581c625fc1933bc273ca7a8d5e9ded3d1bcc97",
-                "address": "13.250.4.243:26656",
+                "address": "13.213.113.113:26656",
                 "provider": "switcheo-labs"
             },
             {
                 "id": "e3f02a9f3ca22724b3a67bba9183113645c9c7d9",
-                "address": "3.1.210.63:26656",
+                "address": "54.179.11.177:26656",
                 "provider": "switcheo-labs"
             }
         ],


### PR DESCRIPTION
- Update carbon binaries to v2.2.0
- Use static IPs for seeds (could previously change)