### PR TITLE
feat: add additional native Kava assets - HARD and SWP

### DIFF
--- a/kava/assetlist.json
+++ b/kava/assetlist.json
@@ -22,6 +22,40 @@
         "svg": "https://raw.githubusercontent.com/Kava-Labs/kava/master/kava-logo.svg"
       },
       "coingecko_id": "kava"
+    },
+    {
+      "description": "Governance token of Kava Lend Protocol",
+      "denom_units": [
+        {
+          "denom": "hard",
+          "exponent": 6
+        }
+      ],
+      "base": "hard",
+      "name": "Hard",
+      "display": "hard",
+      "symbol": "HARD",
+      "logo_URIs": {
+        "svg": "https://raw.githubusercontent.com/Kava-Labs/kava/master/hard.svg"
+      },
+      "coingecko_id": "hard-protocol"
+    },
+    {
+      "description": "Governance token of Kava Swap Protocol",
+      "denom_units": [
+        {
+          "denom": "swp",
+          "exponent": 6
+        }
+      ],
+      "base": "swp",
+      "name": "Swap",
+      "display": "Swap",
+      "symbol": "SWP",
+      "logo_URIs": {
+        "svg": "https://raw.githubusercontent.com/Kava-Labs/kava/master/swp.svg"
+      },
+      "coingecko_id": "kava-swap"
     }
   ]
 }

--- a/kava/chain.json
+++ b/kava/chain.json
@@ -83,13 +83,19 @@
     "apis": {
         "rpc": [
             {
-                "address": "https://rpc.kava.io",
+                "address": "https://rpc.data.kava.io",
                 "provider": "kava"
             }
         ],
         "rest": [
             {
                 "address": "https://api.data.kava.io/",
+                "provider": "kava"
+            }
+        ],
+        "grpc": [
+            {
+                "address": "https://grpc.data.kava.io/",
                 "provider": "kava"
             }
         ]


### PR DESCRIPTION
Question: How should I handle `denom_units`?

For HARD and SWP, the native chain unit is `hard`, and `swp`, and they are each equivalent to 1^10-6 of 1 HARD, 1 SWP token. 