### PR TITLE
Removal of faulty RPC and REST URLs

### DIFF
--- a/bandchain/chain.json
+++ b/bandchain/chain.json
@@ -1,69 +1,63 @@
 {
-    "$schema": "../chain.schema.json",
-    "chain_name": "bandchain",
-    "status": "live",
-    "network_type": "mainnet",
-    "pretty_name": "BandChain",
-    "chain_id": "laozi-mainnet",
-    "daemon_name": "bandd",
-    "node_home": "$HOME/.band",
-    "bech32_prefix": "band",
-    "slip44": 494,
-    "genesis": {
-        "genesis_url": "https://raw.githubusercontent.com/bandprotocol/launch/master/laozi-mainnet/genesis.json"
-    },
-    "codebase": {
-        "git_repo": "https://github.com/bandprotocol/chain",
-        "recommended_version": "v2.3.2",
-        "compatible_versions": [
-            "v2.3.2"
-        ]
-    },
-    "peers": {
-        "seeds": [
-            {
-                "id": "8d42bdcb6cced03e0b67fa3957e4e9c8fd89015a",
-                "address": "34.87.86.195:26656"
-            },
-            {
-                "id": "543e0cab9c3016a0e99775443a17bcf163038912",
-                "address": "34.150.156.78:26656"
-            }
-        ],
-        "persistent_peers": [
-            {
-                "id": "98823087b61d442a4ab86998709c77b2e517ee78",
-                "address": "35.240.152.216:26656"
-            },
-            {
-                "id": "3ea84babead3d6bc488810a0f2cf0744cf5c68fe",
-                "address": "34.86.22.251:26656"
-            }
-        ]
-    },
-    "apis": {
-        "rpc": [
-            {
-                "address": "http://rpc.laozi1.bandchain.org:80",
-                "provider": "bandprotocol"
-            },
-            {
-                "address": "https://rpc.laozi3.bandchain.org:80",
-                "provider": "bandprotocol"
-            }
-        ],
-        "rest": [
-            {
-                "address": "https://laozi1.bandchain.org/api",
-                "provider": "bandprotocol"
-            }
-        ]
-    },
-    "explorers": [
-        {
-            "kind": "cosmoscan",
-            "url": "https://cosmoscan.io",
-            "tx_page": "https://cosmoscan.io/tx/{txHash}"
-        }
+  "$schema": "../chain.schema.json",
+  "chain_name": "bandchain",
+  "status": "live",
+  "network_type": "mainnet",
+  "pretty_name": "BandChain",
+  "chain_id": "laozi-mainnet",
+  "daemon_name": "bandd",
+  "node_home": "$HOME/.band",
+  "bech32_prefix": "band",
+  "slip44": 494,
+  "genesis": {
+    "genesis_url": "https://raw.githubusercontent.com/bandprotocol/launch/master/laozi-mainnet/genesis.json"
+  },
+  "codebase": {
+    "git_repo": "https://github.com/bandprotocol/chain",
+    "recommended_version": "v2.3.2",
+    "compatible_versions": ["v2.3.2"]
+  },
+  "peers": {
+    "seeds": [
+      {
+        "id": "8d42bdcb6cced03e0b67fa3957e4e9c8fd89015a",
+        "address": "34.87.86.195:26656"
+      },
+      {
+        "id": "543e0cab9c3016a0e99775443a17bcf163038912",
+        "address": "34.150.156.78:26656"
+      }
+    ],
+    "persistent_peers": [
+      {
+        "id": "98823087b61d442a4ab86998709c77b2e517ee78",
+        "address": "35.240.152.216:26656"
+      },
+      {
+        "id": "3ea84babead3d6bc488810a0f2cf0744cf5c68fe",
+        "address": "34.86.22.251:26656"
+      }
     ]
+  },
+  "apis": {
+    "rpc": [
+      {
+        "address": "http://rpc.laozi1.bandchain.org:80",
+        "provider": "bandprotocol"
+      }
+    ],
+    "rest": [
+      {
+        "address": "https://laozi1.bandchain.org/api",
+        "provider": "bandprotocol"
+      }
+    ]
+  },
+  "explorers": [
+    {
+      "kind": "cosmoscan",
+      "url": "https://cosmoscan.io",
+      "tx_page": "https://cosmoscan.io/tx/{txHash}"
+    }
+  ]
 }

--- a/bitcanna/chain.json
+++ b/bitcanna/chain.json
@@ -101,10 +101,6 @@
                 "provider": "bitcanna"
               },
               {
-                "address": "http://bitcana.paranorm.pro:26657/",
-                "provider": "ParanormalBrothers"
-              },
-              {
                 "address": "https://rpc.bitcanna.ezstaking.io/",
                 "provider": "ezstaking.io"
               },
@@ -131,10 +127,6 @@
             {
                 "address": "https://lcd-bitcanna.itastakers.com/",
                 "provider": "itastaker"
-            },
-            {
-                "address": "http://bitcanna.stakelab.fr/",
-                "provider": "stakelab"
             }
         ]
     },

--- a/dig/chain.json
+++ b/dig/chain.json
@@ -84,9 +84,6 @@
     "rest": [
       {
         "address": "https://api-1-dig.notional.ventures"
-      },
-      {
-        "address": "https://api-2-dig.notional.ventures"
       }
     ]
   },

--- a/dig/chain.json
+++ b/dig/chain.json
@@ -9,12 +9,9 @@
   "daemon_name": "digd",
   "node_home": "$HOME/.dig",
   "genesis": {
-    "genesis_url":  "https://raw.githubusercontent.com/notional-labs/dig/master/networks/mainnets/dig-1/genesis.json"
+    "genesis_url": "https://raw.githubusercontent.com/notional-labs/dig/master/networks/mainnets/dig-1/genesis.json"
   },
-  "key_algos": [
-    "secp256k1",
-    "ethsecp256k1"
-],
+  "key_algos": ["secp256k1", "ethsecp256k1"],
   "slip44": 118,
   "fees": {
     "fee_tokens": [
@@ -82,9 +79,6 @@
     "rpc": [
       {
         "address": "https://rpc-1-dig.notional.ventures"
-      },
-      {
-        "address": "https://rpc-2-dig.notional.ventures"
       }
     ],
     "rest": [
@@ -97,10 +91,10 @@
     ]
   },
   "explorers": [
-        {
-            "kind": "ping.pub",
-            "url": "https://ping.pub/dig",
-            "tx_page": "https://ping.pub/dig/tx/${txHash}"
-        }
-    ]
+    {
+      "kind": "ping.pub",
+      "url": "https://ping.pub/dig",
+      "tx_page": "https://ping.pub/dig/tx/${txHash}"
+    }
+  ]
 }

--- a/gravitybridge/chain.json
+++ b/gravitybridge/chain.json
@@ -73,10 +73,6 @@
       {
         "address": "https://gravitychain.io:1317",
         "provider": "althea"
-      },
-      {
-        "address": "http://gravity-rpc.qwoyn.com:1317",
-        "provider": "qwoyn"
       }
     ],
     "grpc": [

--- a/gravitybridge/chain.json
+++ b/gravitybridge/chain.json
@@ -1,115 +1,100 @@
 {
-    "$schema": "../chain.schema.json",
-    "chain_name": "gravitybridge",
-    "status": "live",
-    "network_type": "mainnet",
-    "pretty_name": "Gravity Bridge",
-    "chain_id": "gravity-bridge-3",
-    "bech32_prefix": "gravity",
-    "daemon_name": "gravity",
-    "node_home": "$HOME/.gravity",
-    "genesis": {
-        "genesis_url": "https://raw.githubusercontent.com/Gravity-Bridge/Gravity-Docs/main/genesis.json"
-    },
-    "key_algos": [
-        "secp256k1"
-    ],
-    "slip44": 118,
-    "fees": {
-        "fee_tokens": [
-            {
-                "denom": "ugraviton",
-                "fixed_min_gas_price": 0
-            }
-        ]
-    },
-    "codebase": {
-        "git_repo": "https://github.com/Gravity-Bridge/Gravity-Bridge",
-        "recommended_version": "v1.3.3",
-        "compatible_versions": [
-            "v1.3.0",
-            "v1.3.1",
-            "v1.3.2",
-            "v1.3.3"
-        ],
-        "binaries": {
-            "linux/amd64": "https://github.com/Gravity-Bridge/Gravity-Bridge/releases/download/v1.3.3/gravity-linux-amd64",
-            "linux/arm64": "https://github.com/Gravity-Bridge/Gravity-Bridge/releases/download/v1.3.3/gravity-linux-arm64",
-            "darwin/amd64": "https://github.com/Gravity-Bridge/Gravity-Bridge/releases/download/v1.3.3/gravity-darwin-amd64",
-            "windows/amd64": "https://github.com/Gravity-Bridge/Gravity-Bridge/releases/download/v1.3.3/gravity-windows-amd64.exe"
-        }
-    },
-    "peers": {
-        "seeds": [
-            {
-                "id": "2b089bfb4c7366efb402b48376a7209632380c9c",
-                "address": "65.19.136.133:26656",
-                "provider": "althea"
-            },
-            {
-                "id": "63e662f5e048d4902c7c7126291cf1fc17687e3c",
-                "address": "95.211.103.175:26656",
-                "provider": "amhost"
-            }
-        ],
-        "persistent_peers": [
-            {
-                "id": "21be3f7686c24f8bd9442b325a50f5b5227777a7",
-                "address": "202.61.231.15:26656",
-                "provider": "SkyNet"
-            },
-            {
-                "id": "9aa7e0c250466a2a147f8b7d2b886b0d45d44ca0",
-                "address": "45.138.49.222:26656",
-                "provider": "ps350"
-            }
-        ]
-    },
-    "apis": {
-        "rpc": [
-            {
-                "address": "https://gravitychain.io:26657",
-                "provider": "althea"
-            },
-            {
-                "address": "http://gravity-rpc.qwoyn.com:26657",
-                "provider": "qwoyn"
-            },
-            {
-                "address": "gravity-bridge-1-08.nodes.amhost.net:26657",
-                "provider": "amhost"
-            },
-            {
-                "address": "45.138.49.222:26657",
-                "provider": "ps350"
-            }
-        ],
-        "rest": [
-            {
-                "address": "https://gravitychain.io:1317",
-                "provider": "althea"
-            },
-            {
-                "address": "http://gravity-rpc.qwoyn.com:1317",
-                "provider": "qwoyn"
-            }
-        ],
-        "grpc": [
-            {
-                "address": "https://gravitychain.io:9090",
-                "provider": "althea"
-            },
-            {
-                "address": "gravity-bridge-1-08.nodes.amhost.net:9090",
-                "provider": "amhost"
-            }
-        ]
-    },
-    "explorers": [
-        {
-            "kind": "mintscan",
-            "url": "https://www.mintscan.io/gravity-bridge",
-            "tx_page": "https://www.mintscan.io/gravity-bridge/${txHash}"
-        }
+  "$schema": "../chain.schema.json",
+  "chain_name": "gravitybridge",
+  "status": "live",
+  "network_type": "mainnet",
+  "pretty_name": "Gravity Bridge",
+  "chain_id": "gravity-bridge-3",
+  "bech32_prefix": "gravity",
+  "daemon_name": "gravity",
+  "node_home": "$HOME/.gravity",
+  "genesis": {
+    "genesis_url": "https://raw.githubusercontent.com/Gravity-Bridge/Gravity-Docs/main/genesis.json"
+  },
+  "key_algos": ["secp256k1"],
+  "slip44": 118,
+  "fees": {
+    "fee_tokens": [
+      {
+        "denom": "ugraviton",
+        "fixed_min_gas_price": 0
+      }
     ]
+  },
+  "codebase": {
+    "git_repo": "https://github.com/Gravity-Bridge/Gravity-Bridge",
+    "recommended_version": "v1.3.3",
+    "compatible_versions": ["v1.3.0", "v1.3.1", "v1.3.2", "v1.3.3"],
+    "binaries": {
+      "linux/amd64": "https://github.com/Gravity-Bridge/Gravity-Bridge/releases/download/v1.3.3/gravity-linux-amd64",
+      "linux/arm64": "https://github.com/Gravity-Bridge/Gravity-Bridge/releases/download/v1.3.3/gravity-linux-arm64",
+      "darwin/amd64": "https://github.com/Gravity-Bridge/Gravity-Bridge/releases/download/v1.3.3/gravity-darwin-amd64",
+      "windows/amd64": "https://github.com/Gravity-Bridge/Gravity-Bridge/releases/download/v1.3.3/gravity-windows-amd64.exe"
+    }
+  },
+  "peers": {
+    "seeds": [
+      {
+        "id": "2b089bfb4c7366efb402b48376a7209632380c9c",
+        "address": "65.19.136.133:26656",
+        "provider": "althea"
+      },
+      {
+        "id": "63e662f5e048d4902c7c7126291cf1fc17687e3c",
+        "address": "95.211.103.175:26656",
+        "provider": "amhost"
+      }
+    ],
+    "persistent_peers": [
+      {
+        "id": "21be3f7686c24f8bd9442b325a50f5b5227777a7",
+        "address": "202.61.231.15:26656",
+        "provider": "SkyNet"
+      },
+      {
+        "id": "9aa7e0c250466a2a147f8b7d2b886b0d45d44ca0",
+        "address": "45.138.49.222:26656",
+        "provider": "ps350"
+      }
+    ]
+  },
+  "apis": {
+    "rpc": [
+      {
+        "address": "https://gravitychain.io:26657",
+        "provider": "althea"
+      },
+      {
+        "address": "http://gravity-bridge-1-08.nodes.amhost.net:26657",
+        "provider": "amhost"
+      }
+    ],
+    "rest": [
+      {
+        "address": "https://gravitychain.io:1317",
+        "provider": "althea"
+      },
+      {
+        "address": "http://gravity-rpc.qwoyn.com:1317",
+        "provider": "qwoyn"
+      }
+    ],
+    "grpc": [
+      {
+        "address": "https://gravitychain.io:9090",
+        "provider": "althea"
+      },
+      {
+        "address": "gravity-bridge-1-08.nodes.amhost.net:9090",
+        "provider": "amhost"
+      }
+    ]
+  },
+  "explorers": [
+    {
+      "kind": "mintscan",
+      "url": "https://www.mintscan.io/gravity-bridge",
+      "tx_page": "https://www.mintscan.io/gravity-bridge/${txHash}"
+    }
+  ]
 }

--- a/injective/chain.json
+++ b/injective/chain.json
@@ -64,10 +64,6 @@
     "apis": {
         "rpc": [
             {
-                "address": "https://public.api.injective.network",
-                "provider": "injectiveprotocol"
-            },
-            {
                 "address": "https://injective-rpc.api.chainlayer.network/",
                 "provider": "chainlayer"
             }

--- a/juno/chain.json
+++ b/juno/chain.json
@@ -1,38 +1,34 @@
 {
-    "$schema": "../chain.schema.json",
-    "chain_name": "juno",
-    "status": "live",
-    "network_type": "mainnet",
-    "pretty_name": "Juno",
-    "chain_id": "juno-1",
-    "bech32_prefix": "juno",
-    "slip44": 118,
-    "apis": {
-        "rpc": [
-            {
-                "address": "https://rpc-juno.itastakers.com",
-                "provider": "itastakers"
-            },
-            {
-                "address": "https://juno-1.technofractal.com:443",
-                "provider": "strangelove-ventures"
-            }
-        ],
-        "rest": [
-            {
-                "address": "https://lcd-juno.itastakers.com",
-                "provider": "itastakers"
-            },
-            {
-                "address": "https://lcd.juno-1.technofractal.com/",
-                "provider": "strangelove-ventures"
-            }
-        ],
-        "grpc": [
-            {
-                "address": "35.243.205.230:9090",
-                "provider": "strangelove"
-            }
-        ]
-    }
+  "$schema": "../chain.schema.json",
+  "chain_name": "juno",
+  "status": "live",
+  "network_type": "mainnet",
+  "pretty_name": "Juno",
+  "chain_id": "juno-1",
+  "bech32_prefix": "juno",
+  "slip44": 118,
+  "apis": {
+    "rpc": [
+      {
+        "address": "https://rpc-juno.itastakers.com",
+        "provider": "itastakers"
+      }
+    ],
+    "rest": [
+      {
+        "address": "https://lcd-juno.itastakers.com",
+        "provider": "itastakers"
+      },
+      {
+        "address": "https://lcd.juno-1.technofractal.com/",
+        "provider": "strangelove-ventures"
+      }
+    ],
+    "grpc": [
+      {
+        "address": "35.243.205.230:9090",
+        "provider": "strangelove"
+      }
+    ]
+  }
 }

--- a/juno/chain.json
+++ b/juno/chain.json
@@ -18,10 +18,6 @@
       {
         "address": "https://lcd-juno.itastakers.com",
         "provider": "itastakers"
-      },
-      {
-        "address": "https://lcd.juno-1.technofractal.com/",
-        "provider": "strangelove-ventures"
       }
     ],
     "grpc": [

--- a/osmosis/chain.json
+++ b/osmosis/chain.json
@@ -1,220 +1,211 @@
 {
-    "$schema": "../chain.schema.json",
-    "chain_name": "osmosis",
-    "status": "live",
-    "network_type": "mainnet",
-    "pretty_name": "Osmosis",
-    "chain_id": "osmosis-1",
-    "bech32_prefix": "osmo",
-    "daemon_name": "osmosisd",
-    "node_home": "$HOME/.osmosisd",
-    "genesis": {
-        "genesis_url": "https://github.com/osmosis-labs/networks/raw/main/osmosis-1/genesis.json"
-    },
-    "key_algos": [
-        "secp256k1"
-    ],
-    "slip44": 118,
-    "fees": {
-        "fee_tokens": [
-            {
-                "denom": "uosmo",
-                "fixed_min_gas_price": 0
-            }
-        ]
-    },
-    "codebase": {
-        "git_repo": "https://github.com/osmosis-labs/osmosis",
-        "recommended_version": "v7.0.3",
-        "compatible_versions": [
-            "v7.0.3",
-            "v7.0.2"
-        ]
-    },
-    "peers": {
-        "seeds": [
-            {
-                "id": "83adaa38d1c15450056050fd4c9763fcc7e02e2c",
-                "address": "ec2-44-234-84-104.us-west-2.compute.amazonaws.com:26656",
-                "provider": "notional"
-            },
-            {
-                "id": "23142ab5d94ad7fa3433a889dcd3c6bb6d5f247d",
-                "address": "95.217.193.163:26656",
-                "provider": "notional"
-            },
-            {
-                "id": "f82d1a360dc92d4e74fdc2c8e32f4239e59aebdf",
-                "address": "95.217.121.243:26656",
-                "provider": "notional"
-            },
-            {
-                "id": "e437756a853061cc6f1639c2ac997d9f7e84be67",
-                "address": "144.76.183.180:26656",
-                "provider": "notional"
-            },
-            {
-                "id": "f515a8599b40f0e84dfad935ba414674ab11a668",
-                "address": "osmosis.blockpane.com:26656",
-                "provider": "blockpane"
-            }
-        ],
-        "persistent_peers": [
-            {
-                "id": "8f67a2fcdd7ade970b1983bf1697111d35dfdd6f",
-                "address": "52.79.199.137:26656",
-                "provider": "cosmostation"
-            },
-            {
-                "id": "00c328a33578466c711874ec5ee7ada75951f99a",
-                "address": "35.82.201.64:26656",
-                "provider": "cosmostation"
-            },
-            {
-                "id": "cfb6f2d686014135d4a6034aa6645abd0020cac6",
-                "address": "52.79.88.57:26656",
-                "provider": "cosmostation"
-            },
-            {
-                "id": "8d9967d5f865c68f6fe2630c0f725b0363554e77",
-                "address": "134.255.252.173:26656",
-                "provider": "divecrypto"
-            },
-            {
-                "id": "785bc83577e3980545bac051de8f57a9fd82695f",
-                "address": "194.233.164.146:26656",
-                "provider": "forbole"
-            },
-            {
-                "id": "778fdedf6effe996f039f22901a3360bc838b52e",
-                "address": "161.97.187.189:36657",
-                "provider": "kalpatech"
-            },
-            {
-                "id": "64d36f3a186a113c02db0cf7c588c7c85d946b5b",
-                "address": "209.97.132.170:26656",
-                "provider": "solidstake"
-            },
-            {
-                "id": "4d9ac3510d9f5cfc975a28eb2a7b8da866f7bc47",
-                "address": "37.187.38.191:26656",
-                "provider": "stakelab"
-            },
-            {
-                "id": "2115945f074ddb038de5d835e287fa03e32f0628",
-                "address": "95.217.43.85:26656",
-                "provider": "stakerspace"
-            },
-            {
-                "id": "bf2c480eff178d2647ba1adfeee8ced568fe752c",
-                "address": "91.65.128.44:26656",
-                "provider": "stakerus"
-            },
-            {
-                "id": "2f9c16151400d8516b0f58c030b3595be20b804c",
-                "address": "37.120.245.167:26656",
-                "provider": "syncnode"
-            },
-            {
-                "id": "bada684070727cb3dda430bcc79b329e93399665",
-                "address": "173.212.240.91:26656",
-                "provider": "qf3l3k"
-            },
-            {
-                "id": "3fea02d121cb24503d5fbc53216a527257a9ab55",
-                "address": "143.198.145.208:26656",
-                "provider": "witval"
-            },
-            {
-                "id": "7de029fa5e9c1f39557c0e3523c1ae0b07c58be0",
-                "address": "78.141.219.223:26656",
-                "provider": "artifactstaking"
-            },
-            {
-                "id": "7024d1ca024d5e33e7dc1dcb5ed08349768220b9",
-                "address": "134.122.42.20:26656",
-                "provider": "figment"
-            },
-            {
-                "id": "d326ad6dffa7763853982f334022944259b4e7f4",
-                "address": "143.110.212.33:26656",
-                "provider": "figment"
-            },
-            {
-                "id": "e7916387e05acd53d1b8c0f842c13def365c7bb6",
-                "address": "176.9.64.212:26666",
-                "provider": "medusanode"
-            },
-            {
-                "id": "55eea69c21b46000c1594d8b4a448563b075d9e3",
-                "address": "34.107.19.235:26656",
-                "provider": "binaryholdings"
-            },
-            {
-                "id": "9faf468b90a3b2b85ffd88645a15b3715f68bb0b",
-                "address": "195.201.122.100:26656",
-                "provider": "chainflow"
-            },
-            {
-                "id": "ffc82412c0261a94df122b9cc0ce1de81da5246b",
-                "address": "15.222.240.16:26656",
-                "provider": "cephalopod"
-            },
-            {
-                "id": "5b90a530464885fd28c31f698c81694d0b4a1982",
-                "address": "35.183.238.70:26656",
-                "provider": "cephalopod"
-            },
-            {
-                "id": "7b6689cb18d625bbc069aa99d9d5521293db442c",
-                "address": "51.158.97.192:26656",
-                "provider": "mp20"
-            },
-            {
-                "id": "fda06dcebe2acd17857a6c9e9a7b365da3771ceb",
-                "address": "52.206.252.176:26656",
-                "provider": "stargaze"
-            },
-            {
-                "id": "8d9fd90a009e4b6e9572bf9a84b532a366790a1d",
-                "address": "193.26.156.221:26656",
-                "provider": "validatus"
-            }
-        ]
-    },
-    "apis": {
-        "rpc": [
-            {
-                "address": "https://osmosis.validator.network/",
-                "provider": "validatornetwork"
-            },
-            {
-                "address": "https://osmosis-1.technofractal.com:443",
-                "provider": "strangelove-ventures"
-            },
-            {
-                "address": "https://rpc-osmosis.blockapsis.com",
-                "provider": "chainapsis"
-            }
-        ],
-        "rest": [
-            {
-                "address": "https://lcd-osmosis.blockapsis.com",
-                "provider": "chainapsis"
-            }
-        ],
-        "grpc": [
-            {
-                "address": "osmosis.strange.love:9090",
-                "provider": "strangelove"
-            }
-        ]
-    },
-    "explorers": [
-        {
-            "kind": "mintscan",
-            "url": "https://www.mintscan.io/osmosis",
-            "tx_page": "https://www.mintscan.io/osmosis/txs/${txHash}"
-        }
+  "$schema": "../chain.schema.json",
+  "chain_name": "osmosis",
+  "status": "live",
+  "network_type": "mainnet",
+  "pretty_name": "Osmosis",
+  "chain_id": "osmosis-1",
+  "bech32_prefix": "osmo",
+  "daemon_name": "osmosisd",
+  "node_home": "$HOME/.osmosisd",
+  "genesis": {
+    "genesis_url": "https://github.com/osmosis-labs/networks/raw/main/osmosis-1/genesis.json"
+  },
+  "key_algos": ["secp256k1"],
+  "slip44": 118,
+  "fees": {
+    "fee_tokens": [
+      {
+        "denom": "uosmo",
+        "fixed_min_gas_price": 0
+      }
     ]
+  },
+  "codebase": {
+    "git_repo": "https://github.com/osmosis-labs/osmosis",
+    "recommended_version": "v7.0.3",
+    "compatible_versions": ["v7.0.3", "v7.0.2"]
+  },
+  "peers": {
+    "seeds": [
+      {
+        "id": "83adaa38d1c15450056050fd4c9763fcc7e02e2c",
+        "address": "ec2-44-234-84-104.us-west-2.compute.amazonaws.com:26656",
+        "provider": "notional"
+      },
+      {
+        "id": "23142ab5d94ad7fa3433a889dcd3c6bb6d5f247d",
+        "address": "95.217.193.163:26656",
+        "provider": "notional"
+      },
+      {
+        "id": "f82d1a360dc92d4e74fdc2c8e32f4239e59aebdf",
+        "address": "95.217.121.243:26656",
+        "provider": "notional"
+      },
+      {
+        "id": "e437756a853061cc6f1639c2ac997d9f7e84be67",
+        "address": "144.76.183.180:26656",
+        "provider": "notional"
+      },
+      {
+        "id": "f515a8599b40f0e84dfad935ba414674ab11a668",
+        "address": "osmosis.blockpane.com:26656",
+        "provider": "blockpane"
+      }
+    ],
+    "persistent_peers": [
+      {
+        "id": "8f67a2fcdd7ade970b1983bf1697111d35dfdd6f",
+        "address": "52.79.199.137:26656",
+        "provider": "cosmostation"
+      },
+      {
+        "id": "00c328a33578466c711874ec5ee7ada75951f99a",
+        "address": "35.82.201.64:26656",
+        "provider": "cosmostation"
+      },
+      {
+        "id": "cfb6f2d686014135d4a6034aa6645abd0020cac6",
+        "address": "52.79.88.57:26656",
+        "provider": "cosmostation"
+      },
+      {
+        "id": "8d9967d5f865c68f6fe2630c0f725b0363554e77",
+        "address": "134.255.252.173:26656",
+        "provider": "divecrypto"
+      },
+      {
+        "id": "785bc83577e3980545bac051de8f57a9fd82695f",
+        "address": "194.233.164.146:26656",
+        "provider": "forbole"
+      },
+      {
+        "id": "778fdedf6effe996f039f22901a3360bc838b52e",
+        "address": "161.97.187.189:36657",
+        "provider": "kalpatech"
+      },
+      {
+        "id": "64d36f3a186a113c02db0cf7c588c7c85d946b5b",
+        "address": "209.97.132.170:26656",
+        "provider": "solidstake"
+      },
+      {
+        "id": "4d9ac3510d9f5cfc975a28eb2a7b8da866f7bc47",
+        "address": "37.187.38.191:26656",
+        "provider": "stakelab"
+      },
+      {
+        "id": "2115945f074ddb038de5d835e287fa03e32f0628",
+        "address": "95.217.43.85:26656",
+        "provider": "stakerspace"
+      },
+      {
+        "id": "bf2c480eff178d2647ba1adfeee8ced568fe752c",
+        "address": "91.65.128.44:26656",
+        "provider": "stakerus"
+      },
+      {
+        "id": "2f9c16151400d8516b0f58c030b3595be20b804c",
+        "address": "37.120.245.167:26656",
+        "provider": "syncnode"
+      },
+      {
+        "id": "bada684070727cb3dda430bcc79b329e93399665",
+        "address": "173.212.240.91:26656",
+        "provider": "qf3l3k"
+      },
+      {
+        "id": "3fea02d121cb24503d5fbc53216a527257a9ab55",
+        "address": "143.198.145.208:26656",
+        "provider": "witval"
+      },
+      {
+        "id": "7de029fa5e9c1f39557c0e3523c1ae0b07c58be0",
+        "address": "78.141.219.223:26656",
+        "provider": "artifactstaking"
+      },
+      {
+        "id": "7024d1ca024d5e33e7dc1dcb5ed08349768220b9",
+        "address": "134.122.42.20:26656",
+        "provider": "figment"
+      },
+      {
+        "id": "d326ad6dffa7763853982f334022944259b4e7f4",
+        "address": "143.110.212.33:26656",
+        "provider": "figment"
+      },
+      {
+        "id": "e7916387e05acd53d1b8c0f842c13def365c7bb6",
+        "address": "176.9.64.212:26666",
+        "provider": "medusanode"
+      },
+      {
+        "id": "55eea69c21b46000c1594d8b4a448563b075d9e3",
+        "address": "34.107.19.235:26656",
+        "provider": "binaryholdings"
+      },
+      {
+        "id": "9faf468b90a3b2b85ffd88645a15b3715f68bb0b",
+        "address": "195.201.122.100:26656",
+        "provider": "chainflow"
+      },
+      {
+        "id": "ffc82412c0261a94df122b9cc0ce1de81da5246b",
+        "address": "15.222.240.16:26656",
+        "provider": "cephalopod"
+      },
+      {
+        "id": "5b90a530464885fd28c31f698c81694d0b4a1982",
+        "address": "35.183.238.70:26656",
+        "provider": "cephalopod"
+      },
+      {
+        "id": "7b6689cb18d625bbc069aa99d9d5521293db442c",
+        "address": "51.158.97.192:26656",
+        "provider": "mp20"
+      },
+      {
+        "id": "fda06dcebe2acd17857a6c9e9a7b365da3771ceb",
+        "address": "52.206.252.176:26656",
+        "provider": "stargaze"
+      },
+      {
+        "id": "8d9fd90a009e4b6e9572bf9a84b532a366790a1d",
+        "address": "193.26.156.221:26656",
+        "provider": "validatus"
+      }
+    ]
+  },
+  "apis": {
+    "rpc": [
+      {
+        "address": "https://osmosis.validator.network/",
+        "provider": "validatornetwork"
+      },
+      {
+        "address": "https://rpc-osmosis.blockapsis.com",
+        "provider": "chainapsis"
+      }
+    ],
+    "rest": [
+      {
+        "address": "https://lcd-osmosis.blockapsis.com",
+        "provider": "chainapsis"
+      }
+    ],
+    "grpc": [
+      {
+        "address": "osmosis.strange.love:9090",
+        "provider": "strangelove"
+      }
+    ]
+  },
+  "explorers": [
+    {
+      "kind": "mintscan",
+      "url": "https://www.mintscan.io/osmosis",
+      "tx_page": "https://www.mintscan.io/osmosis/txs/${txHash}"
+    }
+  ]
 }

--- a/secretnetwork/chain.json
+++ b/secretnetwork/chain.json
@@ -56,10 +56,6 @@
     ],
     "rest": [
       {
-        "address": "https://lcd-secret.scrtlabs.com/",
-        "provider": "SCRT Labs"
-      },
-      {
         "address": "https://api.secretapi.io/",
         "provider": "chainofsecrets"
       }

--- a/secretnetwork/chain.json
+++ b/secretnetwork/chain.json
@@ -11,9 +11,7 @@
   "genesis": {
     "genesis_url": "https://github.com/scrtlabs/SecretNetwork/releases/download/v1.2.0/genesis.json"
   },
-  "key_algos": [
-    "secp256k1"
-  ],
+  "key_algos": ["secp256k1"],
   "slip44": 529,
   "fees": {
     "fee_tokens": [
@@ -29,9 +27,7 @@
     "binaries": {
       "linux/amd64": "https://github.com/scrtlabs/SecretNetwork/releases/download/v1.2.0/secretnetwork_1.2.0_amd64.deb"
     },
-    "compatible_versions": [
-      "v1.2.1", "v1.2.2"
-    ]
+    "compatible_versions": ["v1.2.1", "v1.2.2"]
   },
   "peers": {
     "persistent_peers": [
@@ -56,8 +52,8 @@
     ],
     "rest": [
       {
-        "address": "https://api.secretapi.io/",
-        "provider": "chainofsecrets"
+        "address": "https://lcd-secret.scrtlabs.com/",
+        "provider": "SCRT Labs"
       }
     ]
   },

--- a/sentinel/chain.json
+++ b/sentinel/chain.json
@@ -1,109 +1,101 @@
 {
-    "$schema": "../chain.schema.json",
-    "chain_name": "sentinel",
-    "status": "live",
-    "network_type": "mainnet",
-    "pretty_name": "Sentinel",
-    "chain_id": "sentinelhub-2",
-    "bech32_prefix": "sent",
-    "slip44": 750,
-    "genesis": {
-        "genesis_url": "https://raw.githubusercontent.com/sentinel-official/networks/main/sentinelhub-2/genesis.zip"
-    },
-    "codebase": {
-        "git_repo": "https://github.com/sentinel-official/hub",
-        "recommended_version": "v0.6.2",
-        "compatible_versions": [
-            "v0.6.2"
-        ]
-    },
-    "daemon_name": "sentinelhub",
-    "node_home": "$HOME/.sentinelhub",
-    "key_algos": [
-        "secp256k1"
+  "$schema": "../chain.schema.json",
+  "chain_name": "sentinel",
+  "status": "live",
+  "network_type": "mainnet",
+  "pretty_name": "Sentinel",
+  "chain_id": "sentinelhub-2",
+  "bech32_prefix": "sent",
+  "slip44": 750,
+  "genesis": {
+    "genesis_url": "https://raw.githubusercontent.com/sentinel-official/networks/main/sentinelhub-2/genesis.zip"
+  },
+  "codebase": {
+    "git_repo": "https://github.com/sentinel-official/hub",
+    "recommended_version": "v0.6.2",
+    "compatible_versions": ["v0.6.2"]
+  },
+  "daemon_name": "sentinelhub",
+  "node_home": "$HOME/.sentinelhub",
+  "key_algos": ["secp256k1"],
+  "peers": {
+    "seeds": [
+      {
+        "id": "c3aa0ff9b3eb17be1b0a26d7c8a5683e8e528e1a",
+        "address": "159.89.192.105:26656"
+      }
     ],
-    "peers": {
-        "seeds": [
-            {
-                "id": "c3aa0ff9b3eb17be1b0a26d7c8a5683e8e528e1a",
-                "address": "159.89.192.105:26656"
-            }
-        ],
-        "persistent_peers": [
-            {
-                "id": "05fe2a7847fd27345250915fd06752c424f40651",
-                "address": "85.222.234.135:26656"
-            },
-            {
-                "id": "387027e3b1180d3a619cbbf3462704a490785963",
-                "address": "54.176.90.228:26656"
-            },
-            {
-                "id": "63bd9cfce0f0d274aad5b166dd06d829021aec43",
-                "address": "121.78.247.243:56656"
-            },
-            {
-                "id": "855807cc6a919c22ec943050ebb5c80b23724ed0",
-                "address": "3.239.11.246:26656"
-            },
-            {
-                "id": "8caefbf8f4318ecc93f2c901cf11470e4a16c818",
-                "address": "161.97.135.122:26656"
-            },
-            {
-                "id": "9174af5f16f74660cccf49f893d243949af45f7f",
-                "address": "54.177.29.46:26656"
-            },
-            {
-                "id": "9fa528bd2b9e7c80724a1d8a4e1a2a8a83e7d123",
-                "address": "142.93.72.221:26656"
-            },
-            {
-                "id": "a77f6a094578dad899e2f40e0626b4c6d4705311",
-                "address": "3.36.165.232:26656"
-            },
-            {
-                "id": "bd45a11390d16d128a9eeea3935b53d7a1a3c120",
-                "address": "15.236.127.69:26656"
-            },
-            {
-                "id": "cdb8dd7628460a546ce1594ca0bc0c20366514cf",
-                "address": "34.72.64.178:26656"
-            },
-            {
-                "id": "d1efceccb04ded9a604e5235f76da86872157d68",
-                "address": "161.97.149.223:26656"
-            },
-            {
-                "id": "e00b23444cc8dbb353d5faa765ab36cfc0116b57",
-                "address": "83.60.98.134:28685"
-            },
-            {
-                "id": "e5ee89bd4fc371c6a0e66d2b8daefd891b6b87b5",
-                "address": "157.90.117.58:26656"
-            },
-            {
-                "id": "f7ceb735606f90df7eb6cd987641876955b6e325",
-                "address": "46.4.55.150:36656"
-            }
-        ]
-    },
-    "apis": {
-        "rpc": [
-            {
-                "address": "https://rpc-sentinel.keplr.app",
-                "provider": "chainapsis"
-            },
-            {
-                "address": "https://sentinelhub-2.technofractal.com:443",
-                "provider": "strangelove-ventures"
-            }
-        ],
-        "rest": [
-            {
-                "address": "https://lcd-sentinel.keplr.app",
-                "provider": "chainapsis"
-            }
-        ]
-    }
+    "persistent_peers": [
+      {
+        "id": "05fe2a7847fd27345250915fd06752c424f40651",
+        "address": "85.222.234.135:26656"
+      },
+      {
+        "id": "387027e3b1180d3a619cbbf3462704a490785963",
+        "address": "54.176.90.228:26656"
+      },
+      {
+        "id": "63bd9cfce0f0d274aad5b166dd06d829021aec43",
+        "address": "121.78.247.243:56656"
+      },
+      {
+        "id": "855807cc6a919c22ec943050ebb5c80b23724ed0",
+        "address": "3.239.11.246:26656"
+      },
+      {
+        "id": "8caefbf8f4318ecc93f2c901cf11470e4a16c818",
+        "address": "161.97.135.122:26656"
+      },
+      {
+        "id": "9174af5f16f74660cccf49f893d243949af45f7f",
+        "address": "54.177.29.46:26656"
+      },
+      {
+        "id": "9fa528bd2b9e7c80724a1d8a4e1a2a8a83e7d123",
+        "address": "142.93.72.221:26656"
+      },
+      {
+        "id": "a77f6a094578dad899e2f40e0626b4c6d4705311",
+        "address": "3.36.165.232:26656"
+      },
+      {
+        "id": "bd45a11390d16d128a9eeea3935b53d7a1a3c120",
+        "address": "15.236.127.69:26656"
+      },
+      {
+        "id": "cdb8dd7628460a546ce1594ca0bc0c20366514cf",
+        "address": "34.72.64.178:26656"
+      },
+      {
+        "id": "d1efceccb04ded9a604e5235f76da86872157d68",
+        "address": "161.97.149.223:26656"
+      },
+      {
+        "id": "e00b23444cc8dbb353d5faa765ab36cfc0116b57",
+        "address": "83.60.98.134:28685"
+      },
+      {
+        "id": "e5ee89bd4fc371c6a0e66d2b8daefd891b6b87b5",
+        "address": "157.90.117.58:26656"
+      },
+      {
+        "id": "f7ceb735606f90df7eb6cd987641876955b6e325",
+        "address": "46.4.55.150:36656"
+      }
+    ]
+  },
+  "apis": {
+    "rpc": [
+      {
+        "address": "https://rpc-sentinel.keplr.app",
+        "provider": "chainapsis"
+      }
+    ],
+    "rest": [
+      {
+        "address": "https://lcd-sentinel.keplr.app",
+        "provider": "chainapsis"
+      }
+    ]
+  }
 }

--- a/shentu/chain.json
+++ b/shentu/chain.json
@@ -1,154 +1,150 @@
 {
-    "$schema": "../chain.schema.json",
-    "chain_name": "shentu",
-    "status": "live",
-    "network_type": "mainnet",
-    "pretty_name": "Shentu",
-    "chain_id": "shentu-2.2",
-    "bech32_prefix": "certik",
-    "daemon_name": "certik",
-    "node_home": "$HOME/.certik",
-    "genesis": {
-        "genesis_url": "https://raw.githubusercontent.com/ShentuChain/mainnet/main/shentu-2.2/genesis.json"
-    },
-    "key_algos": [
-        "secp256k1"
+  "$schema": "../chain.schema.json",
+  "chain_name": "shentu",
+  "status": "live",
+  "network_type": "mainnet",
+  "pretty_name": "Shentu",
+  "chain_id": "shentu-2.2",
+  "bech32_prefix": "certik",
+  "daemon_name": "certik",
+  "node_home": "$HOME/.certik",
+  "genesis": {
+    "genesis_url": "https://raw.githubusercontent.com/ShentuChain/mainnet/main/shentu-2.2/genesis.json"
+  },
+  "key_algos": ["secp256k1"],
+  "slip44": 118,
+  "codebase": {
+    "git_repo": "https://github.com/ShentuChain/shentu",
+    "recommended_version": "v2.3.0",
+    "compatible_versions": ["v2.3.0"],
+    "binaries": {
+      "linux/amd64": "https://github.com/ShentuChain/shentu/releases/download/v2.3.0/certik_2.3.0.0104_linux_amd64",
+      "darwin/amd64": "https://github.com/ShentuChain/shentu/releases/download/v2.3.0/certik_2.3.0.0104_macos",
+      "windows/amd64": "https://github.com/ShentuChain/shentu/releases/download/v2.3.0/certik_2.3.0.0104_win_x86_64.exe.exe"
+    }
+  },
+  "peers": {
+    "seeds": [
+      {
+        "id": "b3192e1ab0cbb9f439b15c82605379018d96b4f2",
+        "address": "3.209.12.186:26656",
+        "provider": "Shentu"
+      },
+      {
+        "id": "23419a3d9deedabce1a3cbfa0d1a3e55ef2364a7",
+        "address": "34.229.203.57:26656",
+        "provider": "Shentu"
+      },
+      {
+        "id": "6647bdb863cb9b862a00f0ec29337f3d7ed30e57",
+        "address": "34.232.46.41:26656",
+        "provider": "Shentu"
+      },
+      {
+        "id": "78d1ea146833d979517a28a0c50dac5ca443e279",
+        "address": "54.197.5.155:26656",
+        "provider": "Shentu"
+      },
+      {
+        "id": "90e6f3ff63147553604ed6fb3c64425c9ee139f6",
+        "address": "18.206.119.13:26656",
+        "provider": "Shentu"
+      },
+      {
+        "id": "bfd878cfb358f28204ca9009c7dc63b723dc6b98",
+        "address": "52.91.51.227:26656",
+        "provider": "Shentu"
+      },
+      {
+        "id": "a48d2e1def5c705b31d77651cd18df0a1aded9b8",
+        "address": "3.82.105.31:26656",
+        "provider": "Shentu"
+      },
+      {
+        "id": "95c818abe0e7b72e66903835775d5afa884ee1f0",
+        "address": "54.224.14.1:26656",
+        "provider": "Shentu"
+      },
+      {
+        "id": "0d0b19bca0f30fbdaadd20f1a38b2ea35305169e",
+        "address": "100.26.242.20:26656",
+        "provider": "Shentu"
+      },
+      {
+        "id": "ff0f27a5db14928ab12059069702689dff1bc6d7",
+        "address": "3.238.117.221:26656",
+        "provider": "Shentu"
+      },
+      {
+        "id": "41e0c490d87266f7c9e78b0e9b0adafd8d06fca5",
+        "address": "3.236.161.42:26656",
+        "provider": "Shentu"
+      },
+      {
+        "id": "8eb0e830eb7d166a919747c2b9e0d46fe1447802",
+        "address": "54.236.61.32:26656",
+        "provider": "Shentu"
+      },
+      {
+        "id": "e4f9776fdf1b37bba6d0400092952666820991c7",
+        "address": "3.227.241.190:26656",
+        "provider": "Shentu"
+      }
     ],
-    "slip44": 118,
-    "codebase": {
-        "git_repo": "https://github.com/ShentuChain/shentu",
-        "recommended_version": "v2.3.0",
-        "compatible_versions": [
-            "v2.3.0"
-        ],
-        "binaries": {
-            "linux/amd64": "https://github.com/ShentuChain/shentu/releases/download/v2.3.0/certik_2.3.0.0104_linux_amd64",
-            "darwin/amd64": "https://github.com/ShentuChain/shentu/releases/download/v2.3.0/certik_2.3.0.0104_macos",
-            "windows/amd64": "https://github.com/ShentuChain/shentu/releases/download/v2.3.0/certik_2.3.0.0104_win_x86_64.exe.exe"
-        }
-    },
-    "peers": {
-        "seeds": [
-            {
-                "id": "b3192e1ab0cbb9f439b15c82605379018d96b4f2",
-                "address": "3.209.12.186:26656",
-                "provider": "Shentu"
-            },
-            {
-                "id": "23419a3d9deedabce1a3cbfa0d1a3e55ef2364a7",
-                "address": "34.229.203.57:26656",
-                "provider": "Shentu"
-            },
-            {
-                "id": "6647bdb863cb9b862a00f0ec29337f3d7ed30e57",
-                "address": "34.232.46.41:26656",
-                "provider": "Shentu"
-            },
-            {
-                "id": "78d1ea146833d979517a28a0c50dac5ca443e279",
-                "address": "54.197.5.155:26656",
-                "provider": "Shentu"
-            },
-            {
-                "id": "90e6f3ff63147553604ed6fb3c64425c9ee139f6",
-                "address": "18.206.119.13:26656",
-                "provider": "Shentu"
-            },
-            {
-                "id": "bfd878cfb358f28204ca9009c7dc63b723dc6b98",
-                "address": "52.91.51.227:26656",
-                "provider": "Shentu"
-            },
-            {
-                "id": "a48d2e1def5c705b31d77651cd18df0a1aded9b8",
-                "address": "3.82.105.31:26656",
-                "provider": "Shentu"
-            },
-            {
-                "id": "95c818abe0e7b72e66903835775d5afa884ee1f0",
-                "address": "54.224.14.1:26656",
-                "provider": "Shentu"
-            },
-            {
-                "id": "0d0b19bca0f30fbdaadd20f1a38b2ea35305169e",
-                "address": "100.26.242.20:26656",
-                "provider": "Shentu"
-            },
-            {
-                "id": "ff0f27a5db14928ab12059069702689dff1bc6d7",
-                "address": "3.238.117.221:26656",
-                "provider": "Shentu"
-            },
-            {
-                "id": "41e0c490d87266f7c9e78b0e9b0adafd8d06fca5",
-                "address": "3.236.161.42:26656",
-                "provider": "Shentu"
-            },
-            {
-                "id": "8eb0e830eb7d166a919747c2b9e0d46fe1447802",
-                "address": "54.236.61.32:26656",
-                "provider": "Shentu"
-            },
-            {
-                "id": "e4f9776fdf1b37bba6d0400092952666820991c7",
-                "address": "3.227.241.190:26656",
-                "provider": "Shentu"
-            }
-        ],
-        "persistent_peers": [
-            {
-                "id": "2332ea32eb9a640138c65f72b3bb6e48beafa9e8",
-                "address": "54.211.82.176:26656",
-                "provider": "Shentu"
-            },
-            {
-                "id": "a3432f605de8692acd2a22ba99c6a84eae09a0de",
-                "address": "3.89.246.155:26656",
-                "provider": "Shentu"
-            },
-            {
-                "id": "80a86a88a7dfab4d03bad367e3fe27e3d91a9801",
-                "address": "35.172.164.222:26656",
-                "provider": "Shentu"
-            }
-        ]
-    },
-    "apis": {
-        "rpc": [
-            {
-                "address": "https://shenturpc.certikpowered.info/",
-                "provider": "Shentu"
-            },
-            {
-                "address": "3.236.161.42:26657",
-                "provider": "Shentu"
-            },
-            {
-                "address": "54.236.61.32:26657",
-                "provider": "Shentu"
-            },
-            {
-                "address": "3.227.241.190:26657",
-                "provider": "Shentu"
-            }
-        ],
-        "rest": [
-            {
-                "address": "https://azuredragon.noopsbycertik.com/",
-                "provider": "Shentu"
-            }
-        ]
-    },
-    "explorers": [
-        {
-            "kind": "mintscan",
-            "url": "https://www.mintscan.io/certik",
-            "tx_page": "https://www.mintscan.io/certik/txs/${txHash}"
-        },
-        {
-            "kind": "Shentu Explorer",
-            "url": "https://explorer.shentu.foundation/?net=shentu-2.2",
-            "tx_page": "https://explorer.shentu.foundation/transactions/${txHash}?net=shentu-2.2"
-        }
+    "persistent_peers": [
+      {
+        "id": "2332ea32eb9a640138c65f72b3bb6e48beafa9e8",
+        "address": "54.211.82.176:26656",
+        "provider": "Shentu"
+      },
+      {
+        "id": "a3432f605de8692acd2a22ba99c6a84eae09a0de",
+        "address": "3.89.246.155:26656",
+        "provider": "Shentu"
+      },
+      {
+        "id": "80a86a88a7dfab4d03bad367e3fe27e3d91a9801",
+        "address": "35.172.164.222:26656",
+        "provider": "Shentu"
+      }
     ]
+  },
+  "apis": {
+    "rpc": [
+      {
+        "address": "https://shenturpc.certikpowered.info/",
+        "provider": "Shentu"
+      },
+      {
+        "address": "http://3.236.161.42:26657",
+        "provider": "Shentu"
+      },
+      {
+        "address": "http://54.236.61.32:26657",
+        "provider": "Shentu"
+      },
+      {
+        "address": "http://3.227.241.190:26657",
+        "provider": "Shentu"
+      }
+    ],
+    "rest": [
+      {
+        "address": "https://azuredragon.noopsbycertik.com/",
+        "provider": "Shentu"
+      }
+    ]
+  },
+  "explorers": [
+    {
+      "kind": "mintscan",
+      "url": "https://www.mintscan.io/certik",
+      "tx_page": "https://www.mintscan.io/certik/txs/${txHash}"
+    },
+    {
+      "kind": "Shentu Explorer",
+      "url": "https://explorer.shentu.foundation/?net=shentu-2.2",
+      "tx_page": "https://explorer.shentu.foundation/transactions/${txHash}?net=shentu-2.2"
+    }
+  ]
 }

--- a/terra/chain.json
+++ b/terra/chain.json
@@ -53,23 +53,11 @@
                 "provider": "Easy2stake"
             },
             {
-                "address": "http://64.227.72.101:26657",
-                "provider": "cryptocrew"
-            },
-            {
                 "address": "http://public-node.terra.dev:26657",
                 "provider": "Terra"
-            },
-            {
-                "address": "https://terra.technofractal.com:443",
-                "provider": "strangelove-ventures"
             }
         ],
         "rest": [
-            {
-                "address": "http://64.227.72.101:1317",
-                "provider": "cryptocrew"
-            },
             {
                 "address": "https://blockdaemon-terra-lcd.api.bdnodes.net:1317",
                 "provider": "Blockdaemon"


### PR DESCRIPTION
Hi,
While referring to the repository, I came across faulty RPC and REST URLs and removed them. 

p.s. Akash chain was already reviewed #229  so I didn't include it. 

## Remove

### Gravitybridge rpc
45.138.49.222:26657
http://gravity-rpc.qwoyn.com:26657

### Gravitybridge rest
http://gravity-rpc.qwoyn.com:1317

### Bitcanna rpc
http://bitcana.paranorm.pro:26657/

### Bitcanna rest
http://bitcanna.stakelab.fr/

### Terra rpc
https://terra.technofractal.com:443
http://64.227.72.101:26657

### Terra rest
http://64.227.72.101:1317

### Secret Network rest
https://api.secretapi.io/

### Bandchain rpc
https://rpc.laozi3.bandchain.org:80

### Juno rpc
https://juno-1.technofractal.com:443

### Juno rest
https://lcd.juno-1.technofractal.com/

### Osmosis rpc
https://osmosis-1.technofractal.com:443

### Sentinel rpc
https://sentinelhub-2.technofractal.com:443

### Dig rpc
https://rpc-2-dig.notional.ventures

### Dig rest
https://api-2-dig.notional.ventures

## Change

### Gravitybridge rpc
gravity-bridge-1-08.nodes.amhost.net:26657 -> http://gravity-bridge-1-08.nodes.amhost.net:26657/

### Shentu rpc
3.236.161.42:26657 -> http://3.236.161.42:26657
54.236.61.32:26657 -> http://54.236.61.32:26657
3.227.241.190:26657 -> http://3.227.241.190:26657
