### PR TITLE
Re-add ECO Stake Akash APIs

### DIFF
--- a/akash/chain.json
+++ b/akash/chain.json
@@ -92,6 +92,10 @@
             },
             {
                 "address": "http://akash.c29r3.xyz:80/rpc"
+            },
+            {
+                "address": "https://rpc-akash.ecostake.com",
+                "provider": "ecostake"
             }
         ],
         "rest": [
@@ -100,6 +104,10 @@
             },
             {
                 "address": "https://api.akash.smartnodes.one"
+            },
+            {
+                "address": "https://rest-akash.ecostake.com",
+                "provider": "ecostake"
             }
         ]
     }


### PR DESCRIPTION
I think these were removed accidentally in https://github.com/cosmos/chain-registry/pull/229