### PR TITLE
Bump IRIS Version

### DIFF
--- a/irisnet/chain.json
+++ b/irisnet/chain.json
@@ -3,11 +3,11 @@
     "chain_name": "irisnet",
     "status": "live",
     "network_type": "mainnet",
-    "pretty_name": "Irisnet",
+    "pretty_name": "IRISnet",
     "chain_id": "irishub-1",
-    "bech32_prefix": "iris",
-    "daemon_name": "irisd",
-    "node_home": "$HOME/.irisd",
+    "bech32_prefix": "iaa",
+    "daemon_name": "iris",
+    "node_home": "$HOME/.iris",
     "key_algos": [
         "secp256k1"
     ],
@@ -17,9 +17,9 @@
     },
     "codebase": {
         "git_repo": "https://github.com/irisnet/irishub",
-        "recommended_version": "v1.2.1",
+        "recommended_version": "v1.3.0",
         "compatible_versions": [
-            "v1.2.1"
+            "v1.3.0"
         ]
     },
     "peers": {


### PR DESCRIPTION
Bump IRIS Version to [v1.3.0](https://github.com/irisnet/irishub/releases/tag/v1.3.0)