### PR TITLE
[osmosis] after few versions, binary for Linux is back

### DIFF
--- a/osmosis/chain.json
+++ b/osmosis/chain.json
@@ -24,7 +24,10 @@
   "codebase": {
     "git_repo": "https://github.com/osmosis-labs/osmosis",
     "recommended_version": "v7.2.0",
-    "compatible_versions": ["v7.2.0", "v7.1.0", "v7.0.3", "v7.0.2"]
+    "compatible_versions": ["v7.2.0", "v7.1.0", "v7.0.3", "v7.0.2"],
+    "binaries": {
+      "linux/amd64": "https://github.com/osmosis-labs/osmosis/releases/download/v7.2.0/osmosisd-7.2.0-linux-amd64"
+    }
   },
   "peers": {
     "seeds": [


### PR DESCRIPTION
have added the binary section and link to linux/amd64 binary
https://github.com/osmosis-labs/osmosis/releases/tag/v7.2.0