### PR TITLE
Add name & symbol required

### DIFF
--- a/assetlist.schema.json
+++ b/assetlist.schema.json
@@ -25,7 +25,9 @@
             "required": [
                 "denom_units",
                 "base",
-                "display"
+                "display",
+                "name",
+                "symbol"
             ],
             "properties": {
                 "kind": {


### PR DESCRIPTION
I think that these 2 fields are necessary mandatory:

- The "symbol" is used everywhere and can be different from "display" (ex : Graviton)
- The "name" is the representation of the token in front, that can be used on all the sites, and used in particular on info
- Improve the verification process and make them mandatory, some people will not fill them or even forget to fill