### PR TITLE
Update Osmo to v7.3.0

### DIFF
--- a/osmosis/chain.json
+++ b/osmosis/chain.json
@@ -23,8 +23,8 @@
   },
   "codebase": {
     "git_repo": "https://github.com/osmosis-labs/osmosis",
-    "recommended_version": "v7.2.0",
-    "compatible_versions": ["v7.2.0", "v7.1.0", "v7.0.3", "v7.0.2"],
+    "recommended_version": "v7.3.0",
+    "compatible_versions": ["v7.3.0", "v7.2.0", "v7.1.0", "v7.0.3", "v7.0.2"],
     "binaries": {
       "linux/amd64": "https://github.com/osmosis-labs/osmosis/releases/download/v7.2.0/osmosisd-7.2.0-linux-amd64"
     }

--- a/osmosis/chain.json
+++ b/osmosis/chain.json
@@ -26,7 +26,7 @@
     "recommended_version": "v7.3.0",
     "compatible_versions": ["v7.3.0", "v7.2.0", "v7.1.0", "v7.0.3", "v7.0.2"],
     "binaries": {
-      "linux/amd64": "https://github.com/osmosis-labs/osmosis/releases/download/v7.2.0/osmosisd-7.2.0-linux-amd64"
+      "linux/amd64": "https://github.com/osmosis-labs/osmosis/releases/download/v7.3.0/osmosisd-7.3.0-linux-amd64"
     }
   },
   "peers": {


### PR DESCRIPTION
Update Osmosis version from v7.2.0 to v7.3.0, and kept the same compatible versions (now including v7.3.0)