### PR TITLE
Update likecoin v2.0.0

### DIFF
--- a/likecoin/chain.json
+++ b/likecoin/chain.json
@@ -5,7 +5,7 @@
     "network_type": "mainnet",
     "pretty_name": "LikeCoin",
     "chain_id": "likecoin-mainnet-2",
-    "bech32_prefix": "cosmos",
+    "bech32_prefix": "like",
     "daemon_name": "liked",
     "node_home": "$HOME/.liked",
     "genesis": {
@@ -24,17 +24,20 @@
     },
     "codebase": {
         "git_repo": "https://github.com/likecoin/likecoin-chain",
-        "recommended_version": "fotan-1",
+        "recommended_version": "v2.0.0",
         "compatible_versions": [
-            "fotan-1"
-        ]
+            "v2.0.0"
+        ],
+        "binaries": {
+            "linux/amd64": "https://github.com/likecoin/likecoin-chain/releases/download/v2.0.0/likecoin-chain_2.0.0_Linux_x86_64.tar.gz"
+        }
     },
     "peers": {
         "seeds": [
             {
                 "id": "913bd0f4bea4ef512ffba39ab90eae84c1420862",
                 "address": "34.82.131.35:26656",
-                "provider": "likecoin"
+                "provider": "like.co"
             },
             {
                 "id": "e44a2165ac573f84151671b092aa4936ac305e2a",
@@ -44,9 +47,29 @@
         ],
         "persistent_peers": [
             {
+                "id": "f087d600cf3d34d3bac04a9723a53180619e8445",
+                "address": "35.247.83.138:26656",
+                "provider": "like.co"
+            },
+            {
                 "id": "75822abfbcc23dcefd025e245b46e2dec5357f75",
                 "address": "207.246.101.4:26656",
                 "provider": "forbole"
+            },
+            {
+                "id": "9f62898076c35d78df21c1d2280be922221c23af",
+                "address": "139.59.8.62:2180",
+                "provider": "Notional"
+            },
+            {
+                "id": "20afcd5637b2278efc78c54fd523bd331d1820f2",
+                "address": "78.47.110.110:26656",
+                "provider": "moonbeam"
+            },
+            {
+                "id": "5940f55e0e7e2f1a2c9507bf62fbfd7c6d2f3874",
+                "address": "likechain.oursky.com:26656",
+                "provider": "Oursky"
             }
         ]
     },
@@ -54,13 +77,13 @@
         "rpc": [
             {
                 "address": "https://mainnet-node.like.co/rpc/",
-                "provider": "likecoin"
+                "provider": "like.co"
             }
         ],
         "rest": [
             {
                 "address": "https://mainnet-node.like.co",
-                "provider": "likecoin"
+                "provider": "like.co"
             }
         ]
     },


### PR DESCRIPTION
Update verison, binary, and new `like` prefix (old `cosmo` prefix is still supported for tx)