### PR TITLE
make EVMOS symbol uppercase

### DIFF
--- a/evmos/assetlist.json
+++ b/evmos/assetlist.json
@@ -17,7 +17,7 @@
       "base": "aevmos",
       "name": "Evmos",
       "display": "evmos",
-      "symbol": "evmos",
+      "symbol": "EVMOS",
       "logo_URIs": {
         "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/evmos/images/evmos.svg",
 	"png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/evmos/images/evmos.png"


### PR DESCRIPTION
..because all other symbols are also uppercase? (consistency) -suggestion only