### PR TITLE
Add API endoints to 34 chains

### DIFF
--- a/akash/chain.json
+++ b/akash/chain.json
@@ -100,6 +100,10 @@
             {
                 "address": "https://akash-rpc.polkachu.com",
                 "provider": "Polkachu"
+            },
+            {
+                "address": "https://rpc-akash-ia.notional.ventures/",
+                "provider": "Notional"
             }
         ],
         "rest": [
@@ -112,6 +116,16 @@
             {
                 "address": "https://rest-akash.ecostake.com",
                 "provider": "ecostake"
+            },
+            {
+                "address": "https://api-akash-ia.notional.ventures/",
+                "provider": "Notional"
+            }
+        ],
+        "grpc": [
+            {
+                "address": "grpc-akash-ia.notional.ventures:443",
+                "provider": "Notional"
             }
         ]
     },

--- a/assetmantle/chain.json
+++ b/assetmantle/chain.json
@@ -329,6 +329,10 @@
             {
                 "address": "https://rpc.asset-mantle.ezstaking.io",
                 "provider": "EZStaking.io"
+            },
+            {
+                "address": "https://rpc-assetmantle-ia.notional.ventures/",
+                "provider": "Notional"
             }
         ],
         "rest": [
@@ -343,6 +347,16 @@
             {
                 "address": "https://lcd.asset-mantle.ezstaking.io",
                 "provider": "EZStaking.io"
+            },
+            {
+                "address": "https://api-assetmantle-ia.notional.ventures/",
+                "provider": "Notional"
+            }
+        ],
+        "grpc": [
+            {
+                "address": "grpc-assetmantle-ia.notional.ventures:443",
+                "provider": "Notional"
             }
         ]
     },

--- a/bandchain/chain.json
+++ b/bandchain/chain.json
@@ -44,12 +44,26 @@
       {
         "address": "http://rpc.laozi1.bandchain.org:80",
         "provider": "bandprotocol"
+      },
+      {
+        "address": "https://rpc-bandchain-ia.notional.ventures/",
+        "provider": "Notional"
       }
     ],
     "rest": [
       {
         "address": "https://laozi1.bandchain.org/api",
         "provider": "bandprotocol"
+      },
+      {
+        "address": "https://api-bandchain-ia.notional.ventures/",
+        "provider": "Notional"
+      }
+    ],
+    "grpc": [
+      {
+        "address": "grpc-bandchain-ia.notional.ventures:443",
+        "provider": "Notional"
       }
     ]
   },

--- a/bitcanna/chain.json
+++ b/bitcanna/chain.json
@@ -125,12 +125,20 @@
              {
                 "address": "https://bitcanna-rpc.polkachu.com",
                 "provider": "Polkachu"
+             },
+             {
+                "address": "https://rpc-bitcanna-ia.notional.ventures/",
+                "provider": "Notional"
              }
         ],
         "grpc": [
             {
                 "address": "https://grpc.bitcanna.io",
                 "provider": "bitcanna"
+            },
+            {
+                "address": "grpc-bitcanna-ia.notional.ventures:443",
+                "provider": "Notional"
             }
         ],
         "rest": [
@@ -145,6 +153,10 @@
             {
                 "address": "https://lcd-bitcanna.itastakers.com/",
                 "provider": "itastaker"
+            },
+            {
+                "address": "https://api-bitcanna-ia.notional.ventures/",
+                "provider": "Notional"
             }
         ]
     },

--- a/bitsong/chain.json
+++ b/bitsong/chain.json
@@ -80,6 +80,10 @@
       {
         "address": "https://rpc.bitsong.interbloc.org",
         "provider": "interbloc"
+      },
+      {
+        "address": "https://rpc-bitsong-ia.notional.ventures/",
+        "provider": "Notional"
       }
     ],
     "rest": [
@@ -90,7 +94,17 @@
       {  
         "address": "https://api.bitsong.interbloc.org",
         "provider": "interbloc"
-      }    
+      },
+      {
+        "address": "https://api-bitsong-ia.notional.ventures/",
+        "provider": "Notional"
+      }
+    ],
+    "grpc": [
+      {
+        "address": "grpc-bitsong-ia.notional.ventures:443",
+        "provider": "Notional"
+      }
     ]
   },
   "explorers": [ 

--- a/bostrom/chain.json
+++ b/bostrom/chain.json
@@ -79,6 +79,10 @@
             {
                 "address": "https://rpc.cyber.posthuman.digital",
                 "provider": "posthuman"
+            },
+            {
+                "address": "https://rpc-cyber-ia.notional.ventures/",
+                "provider": "Notional"
             }
         ],
         "rest": [
@@ -89,6 +93,16 @@
             {
                 "address": "https://lcd.cyber.posthuman.digital",
                 "provider": "posthuman"
+            },
+            {
+                "address": "https://api-cyber-ia.notional.ventures/",
+                "provider": "Notional"
+            }
+        ],
+        "grpc": [
+            {
+                "address": "grpc-cyber-ia.notional.ventures:443",
+                "provider": "Notional"
             }
         ]
     },

--- a/cerberus/chain.json
+++ b/cerberus/chain.json
@@ -103,6 +103,10 @@
             {
                 "address": "https://cerberus-rpc.polkachu.com",
                 "provider": "Polkachu"
+            },
+            {
+                "address": "https://rpc-cerberus-ia.notional.ventures/",
+                "provider": "Notional"
             }
         ],
         "rest": [
@@ -113,6 +117,16 @@
             {
                 "address": "https://rest-cerberus.ecostake.com",
                 "provider": "ecostake"
+            },
+            {
+                "address": "https://api-cerberus-ia.notional.ventures/",
+                "provider": "Notional"
+            }
+        ],
+        "grpc": [
+            {
+                "address": "grpc-cerberus-ia.notional.ventures:443",
+                "provider": "Notional"
             }
         ]
     },

--- a/cheqd/chain.json
+++ b/cheqd/chain.json
@@ -80,6 +80,10 @@
             {
                 "address": "https://rpc.cheqd.ezstaking.io",
                 "provider": "EZStaking.io"
+            },
+            {
+                "address": "https://rpc-cheqd-ia.notional.ventures/",
+                "provider": "Notional"
             }
         ],
         "rest": [
@@ -90,6 +94,16 @@
             {
                 "address": "https://lcd.cheqd.ezstaking.io",
                 "provider": "EZStaking.io"
+            },
+            {
+                "address": "https://api-cheqd-ia.notional.ventures/",
+                "provider": "Notional"
+            }
+        ],
+        "rest": [
+            {
+                "address": "grpc-cheqd-ia.notional.ventures:443",
+                "provider": "Notional"
             }
         ]
     },

--- a/chihuahua/chain.json
+++ b/chihuahua/chain.json
@@ -86,6 +86,10 @@
             {
                 "address": "https://chihuahua-rpc.polkachu.com",
                 "provider": "Polkachu"
+            },
+            {
+                "address": "https://rpc-chihuahua-ia.notional.ventures/",
+                "provider": "Notional"
             }
         ],
         "rest": [
@@ -96,6 +100,16 @@
             {
                 "address": "https://rest-chihuahua.ecostake.com",
                 "provider": "ecostake"
+            },
+            {
+                "address": "https://api-chihuahua-ia.notional.ventures/",
+                "provider": "Notional"
+            }
+        ],
+        "grpc": [
+            {
+                "address": "grpc-chihuahua-ia.notional.ventures:443",
+                "provider": "Notional"
             }
         ]
     },

--- a/comdex/chain.json
+++ b/comdex/chain.json
@@ -97,6 +97,10 @@
             {
                 "address": "https://rpc.comdex.ezstaking.io",
                 "provider": "EZStaking.io"
+            },
+            {
+                "address": "https://rpc-comdex-ia.notional.ventures/",
+                "provider": "Notional"
             }
         ],
         "rest": [
@@ -119,6 +123,16 @@
             {
                 "address": "https://lcd.comdex.ezstaking.io",
                 "provider": "EZStaking.io"
+            },
+            {
+                "address": "https://api-comdex-ia.notional.ventures/",
+                "provider": "Notional"
+            }
+        ],
+        "grpc": [
+            {
+                "address": "grpc-comdex-ia.notional.ventures:443",
+                "provider": "Notional"
             }
         ]
     },

--- a/cosmoshub/chain.json
+++ b/cosmoshub/chain.json
@@ -195,6 +195,10 @@
             {
                 "address": "https://rpc.cosmos.ezstaking.io",
                 "provider": "EZStaking.io"
+            },
+            {
+                "address": "https://rpc-cosmoshub-ia.notional.ventures/",
+                "provider": "Notional"
             }
         ],
         "rest": [
@@ -213,6 +217,10 @@
             {
                 "address": "https://lcd.cosmos.ezstaking.io",
                 "provider": "EZStaking.io"
+            },
+            {
+                "address": "https://api-cosmoshub-ia.notional.ventures/",
+                "provider": "Notional"
             }
         ],
         "grpc": [
@@ -223,6 +231,10 @@
             {
                 "address": "cosmoshub.strange.love:9090",
                 "provider": "strangelove"
+            },
+            {
+                "address": "grpc-cosmoshub-ia.notional.ventures:443",
+                "provider": "Notional"
             }
         ]
     },

--- a/cryptoorgchain/chain.json
+++ b/cryptoorgchain/chain.json
@@ -120,6 +120,10 @@
       {
         "address": "https://rpc-crypto-org.keplr.app/",
         "provider": "chainapsis"
+      },
+      {
+        "address": "https://rpc-cryptoorgchain-ia.notional.ventures/",
+        "provider": "Notional"
       }
     ],
     "rest": [
@@ -130,6 +134,16 @@
       {
         "address": "https://lcd-crypto-org.keplr.app/",
         "provider": "chainapsis"
+      },
+      {
+        "address": "https://api-cryptoorgchain-ia.notional.ventures/",
+        "provider": "Notional"
+      }
+    ],
+    "grpc": [
+      {
+        "address": "grpc-cryptoorgchain-ia.notional.ventures:443",
+        "provider": "Notional"
       }
     ]
   },

--- a/dig/chain.json
+++ b/dig/chain.json
@@ -79,11 +79,25 @@
     "rpc": [
       {
         "address": "https://rpc-1-dig.notional.ventures"
+      },
+      {
+        "address": "https://rpc-dig-ia.notional.ventures/",
+        "provider": "Notional"
       }
     ],
     "rest": [
       {
         "address": "https://api-1-dig.notional.ventures"
+      },
+      {
+        "address": "https://api-dig-ia.notional.ventures/",
+        "provider": "Notional"
+      }
+    ],
+    "grpc": [
+      {
+        "address": "grpc-dig-ia.notional.ventures:443",
+        "provider": "Notional"
       }
     ]
   },

--- a/emoney/chain.json
+++ b/emoney/chain.json
@@ -126,6 +126,10 @@
             {
                 "address": "https://rpc.emoney.ezstaking.io",
                 "provider": "EZStaking.io"
+            },
+            {
+                "address": "https://rpc-emoney-ia.notional.ventures/",
+                "provider": "Notional"
             }
         ],
         "rest": [
@@ -140,6 +144,16 @@
             {
                 "address": "https://lcd.emoney.ezstaking.io",
                 "provider": "EZStaking.io"
+            },
+            {
+                "address": "https://api-emoney-ia.notional.ventures/",
+                "provider": "Notional"
+            }
+        ],
+        "grpc": [
+            {
+                "address": "grpc-emoney-ia.notional.ventures:443",
+                "provider": "Notional"
             }
         ]
     },

--- a/evmos/chain.json
+++ b/evmos/chain.json
@@ -97,6 +97,10 @@
       {
         "address": "https://rpc.evmos.ezstaking.io",
         "provider": "EZStaking.io"
+      },
+      {
+        "address": "https://rpc-evmos-ia.notional.ventures/",
+        "provider": "Notional"
       }
     ],
     "rest": [
@@ -107,12 +111,20 @@
       {
         "address": "https://lcd.evmos.ezstaking.io",
         "provider": "EZStaking.io"
+      },
+      {
+        "address": "https://api-evmos-ia.notional.ventures/",
+        "provider": "Notional"
       }
     ],
     "grpc": [
       {
         "address": "https://grpc.bd.evmos.org:9090",
         "provider": "evmos.org"
+      },
+      {
+        "address": "grpc-evmos-ia.notional.ventures:443",
+        "provider": "Notional"
       }
     ],
     "evm-http-jsonrpc": [

--- a/fetchhub/chain.json
+++ b/fetchhub/chain.json
@@ -63,18 +63,30 @@
             {
                 "address": "https://rpc-fetchhub.fetch.ai:443",
                 "provider": "fetch.ai"
+            },
+            {
+                "address": "https://rpc-fetchhub-ia.notional.ventures/",
+                "provider": "Notional"
             }
         ],
         "rest": [
             {
                 "address": "https://rest-fetchhub.fetch.ai",
                 "provider": "fetch.ai"
+            },
+            {
+                "address": "https://api-fetchhub-ia.notional.ventures/",
+                "provider": "Notional"
             }
         ],
         "grpc": [
             {
                 "address": "https://grpc-fetchhub.fetch.ai:443",
                 "provider": "fetch.ai"
+            },
+            {
+                "address": "grpc-fetchhub-ia.notional.ventures:443",
+                "provider": "Notional"
             }
         ]
     },

--- a/gravitybridge/chain.json
+++ b/gravitybridge/chain.json
@@ -75,6 +75,10 @@
       {
         "address": "https://rpc.gravity-bridge.ezstaking.io",
         "provider": "EZStaking.io"
+      },
+      {
+        "address": "https://rpc-gravitybridge-ia.notional.ventures/",
+        "provider": "Notional"
       }
     ],
     "rest": [
@@ -85,6 +89,10 @@
       {
         "address": "https://lcd.gravity-bridge.ezstaking.io",
         "provider": "EZStaking.io"
+      },
+      {
+        "address": "https://api-gravitybridge-ia.notional.ventures/",
+        "provider": "Notional"
       }
     ],
     "grpc": [
@@ -95,6 +103,10 @@
       {
         "address": "gravity-bridge-1-08.nodes.amhost.net:9090",
         "provider": "amhost"
+      },
+      {
+        "address": "grpc-gravitybridge-ia.notional.ventures:443",
+        "provider": "Notional"
       }
     ]
   },

--- a/impacthub/chain.json
+++ b/impacthub/chain.json
@@ -84,6 +84,10 @@
             {
                 "address": "https://rpc.ixo.ezstaking.io",
                 "provider": "EZStaking.io"
+            },
+            {
+                "address": "https://rpc-ixo-ia.notional.ventures/",
+                "provider": "Notional"
             }
         ],
         "rest": [
@@ -106,6 +110,16 @@
             {
                 "address": "https://lcd.ixo.ezstaking.io",
                 "provider": "EZStaking.io"
+            },
+            {
+                "address": "https://api-ixo-ia.notional.ventures/",
+                "provider": "Notional"
+            }
+        ],
+        "grpc": [
+            {
+                "address": "grpc-ixo-ia.notional.ventures:443",
+                "provider": "Notional"
             }
         ]
     },

--- a/irisnet/chain.json
+++ b/irisnet/chain.json
@@ -91,12 +91,26 @@
             {
                 "address": "https://rpc-iris.keplr.app",
                 "provider": "chainapsis"
+            },
+            {
+                "address": "https://rpc-irisnet-ia.notional.ventures/",
+                "provider": "Notional"
             }
         ],
         "rest": [
             {
                 "address": "https://lcd-iris.keplr.app",
                 "provider": "chainapsis"
+            },
+            {
+                "address": "https://api-irisnet-ia.notional.ventures/",
+                "provider": "Notional"
+            }
+        ],
+        "grpc": [
+            {
+                "address": "grpc-irisnet-ia.notional.ventures:443",
+                "provider": "Notional"
             }
         ]
     },

--- a/juno/chain.json
+++ b/juno/chain.json
@@ -28,6 +28,10 @@
       {
         "address": "https://rpc.junomint.com",
         "provider": "EZStaking.io"
+      },
+      {
+        "address": "https://rpc-juno-ia.notional.ventures/",
+        "provider": "Notional"
       }
     ],
     "rest": [
@@ -46,12 +50,20 @@
       {
         "address": "https://lcd.junomint.com",
         "provider": "EZStaking.io"
+      },
+      {
+        "address": "https://api-juno-ia.notional.ventures/",
+        "provider": "Notional"
       }
     ],
     "grpc": [
       {
         "address": "35.243.205.230:9090",
         "provider": "strangelove"
+      },
+      {
+        "address": "grpc-juno-ia.notional.ventures:443",
+        "provider": "Notional"
       }
     ]
   },

--- a/kava/chain.json
+++ b/kava/chain.json
@@ -89,18 +89,30 @@
             {
                 "address": "https://kava-rpc.polkachu.com",
                 "provider": "Polkachu"
+            },
+            {
+                "address": "https://rpc-kava-ia.notional.ventures/",
+                "provider": "Notional"
             }
         ],
         "rest": [
             {
                 "address": "https://api.data.kava.io/",
                 "provider": "kava"
+            },
+            {
+                "address": "https://api-kava-ia.notional.ventures/",
+                "provider": "Notional"
             }
         ],
         "grpc": [
             {
                 "address": "https://grpc.data.kava.io/",
                 "provider": "kava"
+            },
+            {
+                "address": "grpc-kava-ia.notional.ventures:443",
+                "provider": "Notional"
             }
         ]
     },

--- a/kichain/chain.json
+++ b/kichain/chain.json
@@ -84,6 +84,10 @@
             {
                 "address": "https://rpc.kichain.ezstaking.io",
                 "provider": "EZStaking.io"
+            },
+            {
+                "address": "https://rpc-kichain-ia.notional.ventures/",
+                "provider": "Notional"
             }
         ],
         "rest": [
@@ -94,6 +98,16 @@
             {
                 "address": "https://lcd.kichain.ezstaking.io",
                 "provider": "EZStaking.io"
+            },
+            {
+                "address": "https://api-kichain-ia.notional.ventures/",
+                "provider": "Notional"
+            }
+        ],
+        "grpc": [
+            {
+                "address": "grpc-kichain-ia.notional.ventures:443",
+                "provider": "Notional"
             }
         ]
     },

--- a/konstellation/chain.json
+++ b/konstellation/chain.json
@@ -113,12 +113,26 @@
             {
                 "address": "https://konstellation-rpc.polkachu.com",
                 "provider": "Polkachu"
+            },
+            {
+                "address": "https://rpc-konstellation-ia.notional.ventures/",
+                "provider": "Notional"
             }
         ],
         "rest": [
             {
                 "address": "https://node1.konstellation.tech:1318",
                 "provider": "konstellation"
+            },
+            {
+                "address": "https://api-konstellation-ia.notional.ventures/",
+                "provider": "Notional"
+            }
+        ],
+        "grpc": [
+            {
+                "address": "grpc-konstellation-ia.notional.ventures:443/",
+                "provider": "Notional"
             }
         ]
     },

--- a/likecoin/chain.json
+++ b/likecoin/chain.json
@@ -78,12 +78,26 @@
             {
                 "address": "https://mainnet-node.like.co/rpc/",
                 "provider": "like.co"
+            },
+            {
+                "address": "https://rpc-likecoin-ia.notional.ventures/",
+                "provider": "Notional"
             }
         ],
         "rest": [
             {
                 "address": "https://mainnet-node.like.co",
                 "provider": "like.co"
+            },
+            {
+                "address": "https://api-likecoin-ia.notional.ventures/",
+                "provider": "Notional"
+            }
+        ],
+        "grpc": [
+            {
+                "address": "grpc-likecoin-ia.notional.ventures:443",
+                "provider": "Notional"
             }
         ]
     },

--- a/osmosis/chain.json
+++ b/osmosis/chain.json
@@ -202,6 +202,10 @@
       {
         "address": "https://osmosis-rpc.polkachu.com",
         "provider": "Polkachu"
+      },
+      {
+        "address": "https://rpc-osmosis-ia.notional.ventures/",
+        "provider": "Notional"
       }
     ],
     "rest": [
@@ -212,12 +216,20 @@
       {
         "address": "https://rest-osmosis.ecostake.com",
         "provider": "ecostake"
+      },
+      {
+        "address": "https://api-osmosis-ia.notional.ventures/",
+        "provider": "Notional"
       }
     ],
     "grpc": [
       {
         "address": "osmosis.strange.love:9090",
         "provider": "strangelove"
+      },
+      {
+        "address": "grpc-osmosis-ia.notional.ventures:443",
+        "provider": "Notional"
       }
     ]
   },

--- a/persistence/chain.json
+++ b/persistence/chain.json
@@ -106,12 +106,26 @@
       {
         "address" : "https://rpc.core.persistence.one",
         "provider" : "persistence"
+      },
+      {
+        "address" : "https://rpc-persistent-ia.notional.ventures/",
+        "provider" : "Notional"
       }
     ],
     "rest" : [
       {
         "address" : "https://rest.core.persistence.one",
         "provider" : "persistence"
+      },
+      {
+        "address" : "https://api-persistent-ia.notional.ventures/",
+        "provider" : "Notional"
+      }
+    ],
+    "grpc" : [
+      {
+        "address" : "grpc-persistent-ia.notional.ventures:443",
+        "provider" : "Notional"
       }
     ]
   },

--- a/provenance/chain.json
+++ b/provenance/chain.json
@@ -57,12 +57,26 @@
             {
                 "address": "https://rpc.provenance.io/",
                 "provider": "figure"
+            },
+            {
+                "address": "https://api-provenance-ia.notional.ventures/",
+                "provider": "Notional"
             }
         ],
         "rest": [
             {
                 "address": "https://api.provenance.io",
                 "provider": "figure"
+            },
+           {
+                "address": "https://api-provenance-ia.notional.ventures/",
+                "provider": "Notional"
+            }
+        ],
+        "grpc": [
+           {
+                "address": "grpc-provenance-ia.notional.ventures:443",
+                "provider": "Notional"
             }
         ]
     },

--- a/regen/chain.json
+++ b/regen/chain.json
@@ -58,12 +58,20 @@
             {
                 "address": "http://rpc.regen.forbole.com:80",
                 "provider": "forbole"
+            },
+            {
+                "address": "https://rpc-regen-ia.notional.ventures/",
+                "provider": "Notional"
             }
         ],
         "grpc": [
             {
                 "address": "regen.stakesystems.io:2083",
                 "provider": "stakesystems"
+            },
+            {
+                "address": "grpc-regen-ia.notional.ventures:443",
+                "provider": "Notional"
             }
         ],
         "rest": [
@@ -74,6 +82,10 @@
             {
                 "address": "https://regen.stakesystems.io",
                 "provider": "stakesystems"
+            },
+            {
+                "address": "https://api-regen-ia.notional.ventures/",
+                "provider": "Notional"
             }
         ]
     },

--- a/sentinel/chain.json
+++ b/sentinel/chain.json
@@ -89,12 +89,26 @@
       {
         "address": "https://rpc-sentinel.keplr.app",
         "provider": "chainapsis"
+      },
+      {
+        "address": "https://rpc-sentinel-ia.notional.ventures/",
+        "provider": "Notional"
       }
     ],
     "rest": [
       {
         "address": "https://lcd-sentinel.keplr.app",
         "provider": "chainapsis"
+      },
+      {
+        "address": "https://api-sentinel-ia.notional.ventures/",
+        "provider": "Notional"
+      }
+    ],
+    "grpc": [
+      {
+        "address": "grpc-sentinel-ia.notional.ventures:443",
+        "provider": "Notional"
       }
     ]
   }

--- a/sifchain/chain.json
+++ b/sifchain/chain.json
@@ -68,16 +68,28 @@
             {
                 "address": "https://sifchain-rpc.polkachu.com",
                 "provider": "Polkachu"
+            },
+            {
+                "address": "https://rpc-sifchain-ia.notional.ventures/",
+                "provider": "Notional"
             }
         ],
         "grpc": [
             {
                 "address": "https://grpc.sifchain.finance:443"
+            },
+            {
+                "address": "grpc-sifchain-ia.notional.ventures:443",
+                "provider": "Notional"
             }
         ],
         "rest": [
             {
                 "address": "https://api.sifchain.finance:443"
+            },
+            {
+                "address": "https://api-sifchain-ia.notional.ventures/",
+                "provider": "Notional"
             }
         ]
     },

--- a/stargaze/chain.json
+++ b/stargaze/chain.json
@@ -156,6 +156,10 @@
       {
         "address": "https://stargaze-rpc.polkachu.com",
         "provider": "Polkachu"
+      },
+      {
+        "address": "https://rpc-stargaze-ia.notional.ventures/",
+        "provider": "Notional"
       }
     ],
     "rest": [
@@ -170,6 +174,16 @@
       {
         "address": "https://api.stars.kingnodes.com/",
         "provider": "kingnodes"
+      },
+      {
+        "address": "https://api-stargaze-ia.notional.ventures/",
+        "provider": "Notional"
+      }
+    ],
+    "grpc": [
+      {
+        "address": "grpc-stargaze-ia.notional.ventures:443",
+        "provider": "Notional"
       }
     ]
   },

--- a/starname/chain.json
+++ b/starname/chain.json
@@ -62,12 +62,26 @@
             {
                 "address": "https://rpc-iov.keplr.app",
                 "provider": "chainapsis"
+            },
+            {
+                "address": "https://rpc-starname-ia.notional.ventures/",
+                "provider": "Notional"
             }
         ],
         "rest": [
             {
                 "address": "https://lcd-iov.keplr.app",
                 "provider": "chainapsis"
+            },
+            {
+                "address": "https://api-starname-ia.notional.ventures/",
+                "provider": "Notional"
+            }
+        ],
+        "grpc": [
+            {
+                "address": "grpc-starname-ia.notional.ventures:443",
+                "provider": "starname"
             }
         ]
     },

--- a/terra/chain.json
+++ b/terra/chain.json
@@ -55,6 +55,10 @@
             {
                 "address": "http://public-node.terra.dev:26657",
                 "provider": "Terra"
+            },
+            {
+                "address": "https://rpc-terra-ia.notional.ventures/",
+                "provider": "Notional"
             }
         ],
         "rest": [
@@ -65,6 +69,16 @@
             {
                 "address": "https://terra.mainnet.lcd.blockngine.io:443",
                 "provider": "BlockNgine Validators"
+            },
+            {
+                "address": "https://api-terra-ia.notional.ventures/",
+                "provider": "Notional"
+            }
+        ],
+        "grpc": [
+            {
+                "address": "grpc-terra-ia.notional.ventures:443",
+                "provider": "Notional"
             }
         ]
     },

--- a/vidulum/chain.json
+++ b/vidulum/chain.json
@@ -73,12 +73,26 @@
       {
         "address": "https://mainnet-rpc.vidulum.app/",
         "provider": "vidulum"
+      },
+      {
+        "address": "https://rpc-vidulum-ia.notional.ventures/",
+        "provider": "Notional"
       }
     ],
     "rest": [
       {
         "address": "https://mainnet-lcd.vidulum.app",
         "provider": "vidulum"
+      },
+      {
+        "address": "https://api-vidulum-ia.notional.ventures/",
+        "provider": "Notional"
+      }
+    ],
+    "grpc": [
+      {
+        "address": "grpc-vidulum-ia.notional.ventures:443",
+        "provider": "Notional"
       }
     ]
   },


### PR DESCRIPTION
Add endoints to:

Osmosis (osmosis)
Starname (starname)
Regen (regen)
Akash (akash)
Gaia (cosmoshub)
Sentinel (sentinel)
E-Money (emoney)
Ixo (impacthub)
Juno (juno)
Sifchain (sifchain)
Likecoin (likecoin)
Ki (kichain)
Cyber (cyber)
Cheqd (cheqd)
Stargaze (stargaze)
Band (bandchain)
Chihuahua (chihuahua)
Kava (kava)
BitCanna (bitcanna)
Konstellation (konstellation)
Terra (terra)
Vidulum (vidulum)
Provenance (provenance)
Dig (dig)
Gravity-Bridge (gravitybridge)
Comdex (comdex)
Cerberus (cerberus)
BitSong (bitsong)
AssetMantle (assetmantle)
FetchAI (fetchhub)
Evmos (evmos)
Persistence (persistent)
Crypto.org (cryptoorgchain)
IRISnet (irisnet)