### PR TITLE
Add chain logo to chain schema

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,7 +137,11 @@ A sample `chain.json` includes the following information.
             "url": "https://www.mintscan.io/osmosis",
             "tx_page": "https://www.mintscan.io/osmosis/txs/${txHash}"
         }
-    ]
+    ],
+    "logo_URIs": {
+        "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/osmosis/images/osmosis-chain-logo.png",
+        "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/osmosis/images/osmosis-chain-logo.svg"
+    }
 }
 ```
 

--- a/chain.schema.json
+++ b/chain.schema.json
@@ -228,6 +228,6 @@
                     "format": "uri-reference"
                 }
             }
-        },
+        }
     }
 }

--- a/chain.schema.json
+++ b/chain.schema.json
@@ -215,6 +215,19 @@
                     "type": "number"
                 }
             }
-        }
+        },
+         "logo_URIs": {
+            "type": "object",
+            "properties": {
+                "png": {
+                    "type": "string",
+                    "format": "uri-reference"
+                },
+                "svg": {
+                    "type": "string",
+                    "format": "uri-reference"
+                }
+            }
+        },
     }
 }


### PR DESCRIPTION
Add chain logo to chain.schema.json, same as is used in assetlist.schema.json.
Also added to README
resolves #265 