### PR TITLE
feat: adding asset and chain info for saage-testnet-5

### DIFF
--- a/testnets/saagetestnet/assetlist.json
+++ b/testnets/saagetestnet/assetlist.json
@@ -1,6 +1,7 @@
 {
     "$schema": "../../assetlist.schema.json",
     "chain_id": "sit-5",
+    "chain_name": "saagetestnet5",
     "assets": [
       {
         "description": "The SGE token is primarily a governance token for the Saage chain.",

--- a/testnets/saagetestnet/assetlist.json
+++ b/testnets/saagetestnet/assetlist.json
@@ -1,24 +1,24 @@
 {
     "$schema": "../../assetlist.schema.json",
-    "chain_id": "saage-internal-testnet-1.3",
+    "chain_id": "sit-5",
     "assets": [
       {
         "description": "The SGE token is primarily a governance token for the Saage chain.",
         "denom_units": [
           {
-            "denom": "usaage",
+            "denom": "usge",
             "exponent": 0,
             "aliases": []
           },
           {
-            "denom": "saage",
+            "denom": "sge",
             "exponent": 6,
             "aliases": []
           }
         ],
-        "base": "usaage",
+        "base": "usge",
         "name": "Saage",
-        "display": "saage",
+        "display": "sge",
         "symbol": "SGE",
         "logo_URIs": {
           "png": "https://defitech-logo.s3.amazonaws.com/Final+Logo+Saage.png",
@@ -29,25 +29,25 @@
         "description": "The SGE token is primarily a governance token for the Saage chain.",
         "denom_units": [
           {
-            "denom": "ibc/8B670F5ACD4887208C8FAD58396D39114A8F2C9B57E72EE02F51438069A72AEA",
+            "denom": "ibc/67C5D5653FB5EA135A008DB9374E4BDF1B70C81EAE1641F7CE0DC07135BE5023",
             "exponent": 0,
             "aliases": [
-              "usaage"
+              "usge"
             ]
           },
           {
-            "denom": "saage",
+            "denom": "sge",
             "exponent": 6
           }
         ],
-        "base": "ibc/8B670F5ACD4887208C8FAD58396D39114A8F2C9B57E72EE02F51438069A72AEA",
+        "base": "ibc/67C5D5653FB5EA135A008DB9374E4BDF1B70C81EAE1641F7CE0DC07135BE5023",
         "name": "Saage",
-        "display": "saage",
+        "display": "sge",
         "symbol": "SGE",
         "ibc": {
           "source_channel": "channel-0",
-          "dst_channel": "channel-207",
-          "source_denom": "usaage"
+          "dst_channel": "channel-278",
+          "source_denom": "usge"
         },
         "logo_URIs": {
           "png": "https://defitech-logo.s3.amazonaws.com/Final+Logo+Saage.png",

--- a/testnets/saagetestnet/assetlist.json
+++ b/testnets/saagetestnet/assetlist.json
@@ -1,7 +1,6 @@
 {
     "$schema": "../../assetlist.schema.json",
-    "chain_id": "sit-5",
-    "chain_name": "saagetestnet5",
+    "chain_name": "saagetestnet",
     "assets": [
       {
         "description": "The SGE token is primarily a governance token for the Saage chain.",

--- a/testnets/saagetestnet/chain.json
+++ b/testnets/saagetestnet/chain.json
@@ -1,6 +1,6 @@
 {
   "$schema": "../../chain.schema.json",
-  "chain_name": "saagetestnet5",
+  "chain_name": "saagetestnet",
   "status": "live",
   "network_type": "testnet",
   "pretty_name": "Saage-Testnet-5",

--- a/testnets/saagetestnet/chain.json
+++ b/testnets/saagetestnet/chain.json
@@ -1,52 +1,62 @@
 {
   "$schema": "../../chain.schema.json",
-  "chain_name": "saagetestnet",
+  "chain_name": "saagetestnet5",
   "status": "live",
   "network_type": "testnet",
-  "pretty_name": "Saage-Testnet",
-  "chain_id": "saage-internal-testnet-1.3",
-  "bech32_prefix": "saage",
+  "pretty_name": "Saage-Testnet-5",
+  "chain_id": "sit-5",
+  "bech32_prefix": "sge",
   "daemon_name": "saaged",
   "node_home": "$HOME/.saage",
   "genesis": {
-    "genesis_url": "https://github.com/saage-tech/network-testnet-1/blob/master/networks/saage-testnet-3/genesis.json"
+    "genesis_url": "https://github.com/saage-tech/network-testnet-1/blob/master/networks/saage-testnet-5/genesis.json"
   },
   "key_algos": ["secp256k1"],
   "slip44": 909,
   "fees": {
     "fee_tokens": [
       {
-        "denom": "usaage",
+        "denom": "usge",
         "fixed_min_gas_price": 0
       }
     ]
   },
   "codebase": {
     "git_repo": "https://github.com/saage-tech/saage-testnet-1",
-    "recommended_version": "v0.4.1",
-    "compatible_versions":["v0.4.1"]
+    "recommended_version": "v0.6.0",
+    "compatible_versions":["v0.6.0"]
   },
   "peers": {
     "persistent_peers": [
       {
-        "id": "e1fc6bc72db2c38e55751d350a72eba699a58f2d",
-        "address": "44.203.79.229:26656",
-        "provider": "saage"
+        "id": "c1e005ef1d63a3e543d2542dffaabdd65a381bb3",
+        "address": "3.82.54.192:26656",
+        "provider": "devopsNexus"
       },
       {
-        "id": "7ab5678c46266bdb294426de40e2b984e0af2917",
+        "id": "8313705fa5c5b1e4a8c45e99df8ed216604b9310",
+        "address": "3.235.109.126:26656",
+        "provider": "darkRealm"
+      },
+      {
+        "id": "0a43064d5706673220a8a49f6fe144b8a1c53f7c",
+        "address": "44.201.51.199:26656",
+        "provider": "scorpionKing"
+      },
+      {
+        "id": "80ccda3f9a1fb765036fa1b97b504a697189ec4f",
         "address": "3.235.167.226:26656",
-        "provider": "saage"
+        "provider": "nitka"
       },
       {
-        "id": "ff661f7eacf9962bcd8a8aeb63bd8b9a3eee40bd",
-        "address": "52.202.79.213:26656",
-        "provider": "saage"
+        "id": "8f5670953c3af833746d4d62fdda380e6500480d",
+        "address": "54.187.111.220:26656",
+        "provider": "nitka"
       },
       {
-        "id": "e0e5c42ce3d3c10359c566ffa217e2743048e8df",
+        "id": "f8d5f23f741ccbe7da0f7112e3e55bf0fde1e7b5",
         "address": "54.226.144.104:26656",
-        "provider": "saage"
+        "provider": "validictator"
       }
     ]
   },
@@ -73,8 +83,8 @@
   "explorers": [
     {
       "kind": "bigdipper",
-      "url": "http://blockexplorer-1.testnet.saage.io/",
-      "tx_page": "http://blockexplorer-1.testnet.saage.io/transactions/{txHash}"
+      "url": "https://blockexplorer-1.testnet.saage.io/",
+      "tx_page": "https://blockexplorer-1.testnet.saage.io/transactions/{txHash}"
     }
   ]
 }


### PR DESCRIPTION
This PR aims to register the tokens and chain parameters for `sit-5`, the 5th testnet of Saage.

## Changes

1. change in name of the token
2. change in BECH32 prefix
3. change in IBC denomination