### PR TITLE
further validation for _IBC data files

### DIFF
--- a/.github/workflows/utility/test_ibcdata.py
+++ b/.github/workflows/utility/test_ibcdata.py
@@ -1,0 +1,38 @@
+import re
+import json
+from os import getcwd, listdir
+from os.path import isfile, join
+
+import pytest
+
+mypath = join(getcwd(),"_IBC")
+fileList = [f for f in listdir(mypath) if isfile(join(mypath, f))]
+
+@pytest.mark.parametrize("input", fileList)
+def test_fileName(input):
+    # validates that the json file name has two "strings" separated by a hyphen (-) and ends with ".json"
+    pattern = re.compile(r'.*-.*.json$')
+    result = re.match(pattern, input)
+    assert result
+
+@pytest.mark.parametrize("input", fileList)
+def test_alphabeticalOrder(input):
+    # validates that chain_1 and chain_2 in file name are in alphabetical order
+    pattern = re.compile(r'(.*)-(.*).json$')
+    m = pattern.match(input)
+    toSort = [(m.group(1)), (m.group(2))]
+    toSort.sort(key=str.lower)
+    assert (m.group(1) == toSort[0]) and (m.group(2) == toSort[1])
+
+@pytest.mark.parametrize("input", fileList)
+def test_chainNameMatchFileName(input):
+    # validates that the chain-name for chain-1 and chain-2 inside the json file match the order used in the file name.
+    pattern = re.compile(r'(.*)-(.*).json$')
+    m = pattern.match(input)
+    fileName_chain1 = m.group(1).lower()
+    fileName_chain2 = m.group(2).lower()
+    with open(join(mypath,input), "r") as read_file:
+        json_file = json.load(read_file)
+        chain_1 = str(json_file["chain-1"]["chain-name"]).lower()
+        chain_2 = str(json_file["chain-2"]["chain-name"]).lower()
+    assert fileName_chain1 == chain_1 and fileName_chain2 == chain_2

--- a/.github/workflows/utility/test_ibcdata.py
+++ b/.github/workflows/utility/test_ibcdata.py
@@ -1,21 +1,21 @@
 import re
 import json
 from os import getcwd, listdir
-from os.path import isfile, join
+from os.path import isfile, isdir, join
 
 import pytest
 
 mypath = join(getcwd(),"_IBC")
-fileList = [f for f in listdir(mypath) if isfile(join(mypath, f))]
+ibcData_files = [f for f in listdir(mypath) if isfile(join(mypath, f))]
 
-@pytest.mark.parametrize("input", fileList)
+@pytest.mark.parametrize("input", ibcData_files)
 def test_fileName(input):
     # validates that the json file name has two "strings" separated by a hyphen (-) and ends with ".json"
     pattern = re.compile(r'.*-.*.json$')
     result = re.match(pattern, input)
     assert result
 
-@pytest.mark.parametrize("input", fileList)
+@pytest.mark.parametrize("input", ibcData_files)
 def test_alphabeticalOrder(input):
     # validates that chain_1 and chain_2 in file name are in alphabetical order
     pattern = re.compile(r'(.*)-(.*).json$')
@@ -24,7 +24,7 @@ def test_alphabeticalOrder(input):
     toSort.sort(key=str.lower)
     assert (m.group(1) == toSort[0]) and (m.group(2) == toSort[1])
 
-@pytest.mark.parametrize("input", fileList)
+@pytest.mark.parametrize("input", ibcData_files)
 def test_chainNameMatchFileName(input):
     # validates that the chain-name for chain-1 and chain-2 inside the json file match the order used in the file name.
     pattern = re.compile(r'(.*)-(.*).json$')
@@ -36,3 +36,12 @@ def test_chainNameMatchFileName(input):
         chain_1 = str(json_file["chain-1"]["chain-name"]).lower()
         chain_2 = str(json_file["chain-2"]["chain-name"]).lower()
     assert fileName_chain1 == chain_1 and fileName_chain2 == chain_2
+
+@pytest.mark.parametrize("input", ibcData_files)
+    # validates that the chain-name's used exist as root folders on the chain-registry
+def test_existstsOnChainReg(input):
+    pattern = re.compile(r'(.*)-(.*).json$')
+    m = pattern.match(input)
+    chain1 = m.group(1).lower()
+    chain2 = m.group(2).lower()
+    assert isdir(join(getcwd(),chain1)) and isdir(join(getcwd(),chain2))

--- a/.github/workflows/validate_ibcdatajson.yml
+++ b/.github/workflows/validate_ibcdatajson.yml
@@ -1,14 +1,31 @@
 on: [pull_request, workflow_dispatch]
 name: PR workflow
 jobs:
-  validate_pathsjson:
+  validate_ibcdatajson:
     name: Validate ibc data schemas
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - name: checkout registry
+        uses: actions/checkout@v2
+
       - name: Validate IBC data schemas
         uses: snapcart/json-schema-validator@v1.0.0
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           json_schema: ./ibc_data.schema.json
           json_path_pattern: ^_IBC\/.*\.json$
+
+      - name: Set up Python
+        uses: actions/setup-python@v2
+        with:
+          python-version: 3.9
+
+      - name: Install Python dependencies
+        run:  |
+          python -m pip install --upgrade pip
+          cd .github/workflows/utility
+          pip install pytest==7.1.2
+
+      - name: Validate chain_1 and chain_2 are alphabetical
+        run:   |
+          python -m pytest --import-mode=append .github/workflows/utility

--- a/.github/workflows/validate_ibcdatajson.yml
+++ b/.github/workflows/validate_ibcdatajson.yml
@@ -26,6 +26,6 @@ jobs:
           cd .github/workflows/utility
           pip install pytest==7.1.2
 
-      - name: Validate chain_1 and chain_2 are alphabetical
+      - name: Chain Name Validation
         run:   |
           python -m pytest --import-mode=append .github/workflows/utility


### PR DESCRIPTION
This PR adds further validation for json files in the _IBC folder.

Workflow has been tested on a fork.

It performs three validations:

- validates that the json file name has two "strings" separated by a hyphen (-) and ends with ".json"
- validates that chain_1 and chain_2 used in the file name are in alphabetical order
- validates that the chain-name for chain-1 and chain-2 inside the json file match the order used in the file name

Consider merging before https://github.com/cosmos/chain-registry/pull/369 ?