### PR TITLE
Fix crypto.org logo URI

### DIFF
--- a/cryptoorgchain/assetlist.json
+++ b/cryptoorgchain/assetlist.json
@@ -19,7 +19,7 @@
         "display": "cro",
         "symbol": "CRO",
         "logo_URIs": {
-          "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/cronos/images/cro.png"
+          "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/cronos/images/cronos.png"
         },
         "coingecko_id": "cronos"
       }


### PR DESCRIPTION
Changed in https://github.com/cosmos/chain-registry/pull/399