### PR TITLE
Updated `recommended_version`

### DIFF
--- a/bostrom/chain.json
+++ b/bostrom/chain.json
@@ -14,9 +14,9 @@
     "slip44": 118,
     "codebase": {
         "git_repo": "https://github.com/cybercongress/go-cyber",
-        "recommended_version": "v0.2.0",
+        "recommended_version": "v0.3.0",
         "compatible_versions": [
-            "v0.2.0"
+            "v0.3.0"
         ],
         "binaries": {
             "linux/amd64": "https://github.com/cybercongress/go-cyber/releases/download/v0.2.0/cyber_v0.2.0_linux-amd64.tar.gz",


### PR DESCRIPTION
According to [Cyberfrey](https://github.com/cybercongress/go-cyber/releases/tag/v0.3.0) release