### PR TITLE
Add Staking Metadata to Chain Schema

### DIFF
--- a/chain.schema.json
+++ b/chain.schema.json
@@ -264,6 +264,10 @@
                 {
                     "const": "whitelisted-liquid",
                     "description": "Utilizes a protocol-permissioned whitelist to issue liquid staking derivatives. As seen on Crescent Network."
+                },
+                {
+                    "const": "iqlusion-liquid",
+                    "description": "Enables this network to permissionlessly issue validator-specific liquid staking derivatives without unbonding. Coming soon to Cosmos Hub."
                 }
             ]
         },

--- a/chain.schema.json
+++ b/chain.schema.json
@@ -76,6 +76,23 @@
                 }
             }
         },
+        "staking": {
+            "type": "object",
+            "properties": {
+                "staking_tokens": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/$defs/staking_token"
+                    }
+                },
+                "staking_systems": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/$defs/staking_system"
+                    }
+                }
+            }
+        },
         "codebase": {
             "type": "object",
             "required": [
@@ -219,7 +236,27 @@
                 }
             }
         },
-         "logo_URIs": {
+        "staking_token": {
+            "type": "object",
+            "required": [
+                "denom"
+            ],
+            "properties": {
+                "denom": {
+                    "type": "string"
+                }
+            }
+        },
+        "staking_system": {
+            "type": "string",
+            "enum": [
+                "interfluid",
+                "interchain",
+                "epoched",
+                "permissioned-liquid"
+            ]
+        },
+        "logo_URIs": {
             "type": "object",
             "properties": {
                 "png": {

--- a/chain.schema.json
+++ b/chain.schema.json
@@ -255,14 +255,14 @@
                 },
                 {
                     "const": "interfluid",
-                    "description": "Enables liquidity providers on a foreign network to utilize AMM-pooled staking tokens for governance and delegation. Coming soon to Osmosis."
+                    "description": "Enables liquidity providers on a foreign network to utilize AMM-pooled staking tokens for governance and delegation. Soon provided by Osmosis."
                 },
                 {
                     "const": "interchain",
-                    "description": "Enables this network to be secured by the validator set of another network. As seen on Gravity Bridge."
+                    "description": "Enables this network to be secured by the validator set of another network. As to be seen on Neutron."
                 },
                 {
-                    "const": "permissioned-liquid",
+                    "const": "whitelisted-liquid",
                     "description": "Utilizes a protocol-permissioned whitelist to issue liquid staking derivatives. As seen on Crescent Network."
                 }
             ]

--- a/chain.schema.json
+++ b/chain.schema.json
@@ -262,10 +262,6 @@
                     "description": "Enables this network to be secured by the validator set of another network. As seen on Gravity Bridge."
                 },
                 {
-                    "const": "epoched",
-                    "description": "Implements staking and distribution functionality more efficiently by applying updates at timed intervals rather than exhausting compute at every block. As used for Osmosis Liquidity Mining Rewards."
-                },
-                {
                     "const": "permissioned-liquid",
                     "description": "Utilizes a protocol-permissioned whitelist to issue liquid staking derivatives. As seen on Crescent Network."
                 }

--- a/chain.schema.json
+++ b/chain.schema.json
@@ -248,12 +248,23 @@
             }
         },
         "staking_system": {
-            "type": "string",
-            "enum": [
-                "interfluid",
-                "interchain",
-                "epoched",
-                "permissioned-liquid"
+            "oneOf": [
+                {
+                    "const": "interfluid",
+                    "description": "Enables liquidity providers on this network to utilize AMM-pooled staking tokens for governance and delegation. As seen on Osmosis."
+                },
+                {
+                    "const": "interchain",
+                    "description": "Enables this network to be secured by the validator set of another network. As seen on Gravity Bridge."
+                },
+                {
+                    "const": "epoched",
+                    "description": "Implements staking and distribution functionality more efficiently by applying updates at timed intervals rather than exhausting compute at every block. As seen on Osmosis."
+                },
+                {
+                    "const": "permissioned-liquid",
+                    "description": "Utilizes a protocol-permissioned whitelist to issue liquid staking derivatives. As seen on Crescent Network."
+                }
             ]
         },
         "logo_URIs": {

--- a/chain.schema.json
+++ b/chain.schema.json
@@ -250,8 +250,12 @@
         "staking_system": {
             "oneOf": [
                 {
-                    "const": "interfluid",
+                    "const": "superfluid",
                     "description": "Enables liquidity providers on this network to utilize AMM-pooled staking tokens for governance and delegation. As seen on Osmosis."
+                },
+                {
+                    "const": "interfluid",
+                    "description": "Enables liquidity providers on a foreign network to utilize AMM-pooled staking tokens for governance and delegation. Coming soon to Osmosis."
                 },
                 {
                     "const": "interchain",
@@ -259,7 +263,7 @@
                 },
                 {
                     "const": "epoched",
-                    "description": "Implements staking and distribution functionality more efficiently by applying updates at timed intervals rather than exhausting compute at every block. As seen on Osmosis."
+                    "description": "Implements staking and distribution functionality more efficiently by applying updates at timed intervals rather than exhausting compute at every block. As used for Osmosis Liquidity Mining Rewards."
                 },
                 {
                     "const": "permissioned-liquid",


### PR DESCRIPTION
Closes https://github.com/cosmos/chain-registry/issues/126. 
## Summary
Adds staking metadata for seamless usage in applications like REStake, Omniflix InSync, Ping.pub, and others.

## Changes 
* Adds `staking_token` object definition to denote staking tokens
* Adds `staking_system` enum definition to describe staking implementation types
  * Initial values:  `"interfluid", "interchain", "epoched", "permissioned-liquid"`
* Adds `staking` property definition containing the definitions described above.

## Example Chain.json
```
{
  ...

  "staking": {
    "staking_systems": ["interfluid"],
    "staking_tokens": [
      {
        "denom": "uosmo"
      }
    ]
  }

  ...
}
```