### PR TITLE
Update Sentinel CoinType to 118

### DIFF
--- a/sentinel/chain.json
+++ b/sentinel/chain.json
@@ -6,7 +6,7 @@
   "pretty_name": "Sentinel",
   "chain_id": "sentinelhub-2",
   "bech32_prefix": "sent",
-  "slip44": 750,
+  "slip44": 118,
   "genesis": {
     "genesis_url": "https://raw.githubusercontent.com/sentinel-official/networks/main/sentinelhub-2/genesis.zip"
   },


### PR DESCRIPTION
Update Sentinel CoinType to 118 (was 750). As confirmed by Sentinel Team (Tony Stark)
Resolved #313 