### PR TITLE
add kujira endpoints & finder

### DIFF
--- a/kujira/chain.json
+++ b/kujira/chain.json
@@ -33,6 +33,10 @@
     "apis": {
         "rpc": [
             {
+                "address": "https://rpc.kaiyo.kujira.setten.io",
+                "provider": "setten.io"
+            },
+            {
                 "address": "https://kujira-rpc.polkachu.com",
                 "provider": "polkachu"
             },
@@ -42,6 +46,10 @@
             }
         ],
         "rest": [
+            {
+                "address": "https://lcd.kaiyo.kujira.setten.io",
+                "provider": "setten.io"
+            },
             {
                 "address": "https://kujira-api.polkachu.com/",
                 "provider": "polkachu"
@@ -53,6 +61,11 @@
         ]
     },
     "explorers": [
+        {
+            "kind": "kujira",
+            "url": "https://finder.kujira.app",
+            "tx_page": "https://finder.kujira.app/tx/${txHash}"
+        },
         {
             "kind": "explorers.guru",
             "url": "https://kujira.explorers.guru",

--- a/kujira/chain.json
+++ b/kujira/chain.json
@@ -64,7 +64,7 @@
         {
             "kind": "kujira",
             "url": "https://finder.kujira.app",
-            "tx_page": "https://finder.kujira.app/tx/${txHash}"
+            "tx_page": "https://finder.kujira.app/kaiyo-1/tx/${txHash}"
         },
         {
             "kind": "explorers.guru",


### PR DESCRIPTION
This adds LCD and RPC endpoints managed via setten.io (https://twitter.com/TeamKujira/status/1543548547122995201)

It also adds a link to our own finder app https://finder.kujira.app