### PR TITLE
add SLIP-44 number for kava

### DIFF
--- a/kava/chain.json
+++ b/kava/chain.json
@@ -11,6 +11,7 @@
     "genesis": {
         "genesis_url": "https://kava-genesis-files.s3.us-east-1.amazonaws.com/kava_2222-10/genesis.json"
     },
+    "slip44": 459,
     "codebase": {
         "git_repo": "https://github.com/kava-Labs/kava/",
         "recommended_version": "v0.17.3",


### PR DESCRIPTION
Kava is HD root 459, per [SLIP-44](https://github.com/satoshilabs/slips/blob/master/slip-0044.md)