### PR TITLE
change coingecko_id for cryptoorgchain

### DIFF
--- a/cryptoorgchain/assetlist.json
+++ b/cryptoorgchain/assetlist.json
@@ -21,7 +21,7 @@
         "logo_URIs": {
           "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/cronos/images/cronos.png"
         },
-        "coingecko_id": "cronos"
+        "coingecko_id": "crypto-com-chain"
       }
     ]
   }


### PR DESCRIPTION
"cronos" is not the correct id

https://www.coingecko.com/en/coins/cronos