### PR TITLE
Update binary version for crescent

### DIFF
--- a/crescent/chain.json
+++ b/crescent/chain.json
@@ -25,13 +25,13 @@
   },
   "codebase": {
     "git_repo": "https://github.com/crescent-network/crescent",
-    "recommended_version": "v1.1.0",
+    "recommended_version": "v2.1.0",
     "compatible_versions": [
-      "v1.1.0"
+      "v2.1.0"
     ],
     "binaries": {
-      "linux/amd64": "https://github.com/crescent-network/crescent/releases/download/v1.1.0/crescentd-v1.1.0-linux-amd64",
-      "darwin/amd64": "https://github.com/crescent-network/crescent/releases/download/v1.1.0/crescentd-v1.1.0-darwin-amd64"
+      "linux/amd64": "https://github.com/crescent-network/crescent/releases/download/v2.1.0/crescentd-v2.1.0-linux-amd64",
+      "darwin/amd64": "https://github.com/crescent-network/crescent/releases/download/v2.1.0/crescentd-v2.1.0-darwin-amd64"
         }
   },
   "peers": {


### PR DESCRIPTION
Update binary version for crescent 
- from [v1.1.0](https://github.com/crescent-network/crescent/releases/tag/v1.1.0) to [v2.1.0](https://github.com/crescent-network/crescent/releases/tag/v2.1.0)