### PR TITLE
Update LikeCoin to v3.0.0 starferry

### DIFF
--- a/likecoin/chain.json
+++ b/likecoin/chain.json
@@ -24,16 +24,16 @@
     },
     "codebase": {
         "git_repo": "https://github.com/likecoin/likecoin-chain",
-        "recommended_version": "v2.0.2",
+        "recommended_version": "v3.0.0",
         "compatible_versions": [
-            "v2.0.2"
+            "v3.0.0"
         ],
         "binaries": {
-            "linux/amd64": "https://github.com/likecoin/likecoin-chain/releases/download/v2.0.2/likecoin-chain_2.0.2_Linux_x86_64.tar.gz",
-            "linux/arm64": "https://github.com/likecoin/likecoin-chain/releases/download/v2.0.2/likecoin-chain_2.0.2_Linux_arm64.tar.gz",
-            "darwin/amd64": "https://github.com/likecoin/likecoin-chain/releases/download/v2.0.2/likecoin-chain_2.0.2_Darwin_x86_64.tar.gz",
-            "darwin/arm64": "https://github.com/likecoin/likecoin-chain/releases/download/v2.0.2/likecoin-chain_2.0.2_Darwin_arm64.tar.gz",
-            "windows/amd64": "https://github.com/likecoin/likecoin-chain/releases/download/v2.0.2/likecoin-chain_2.0.2_Windows_x86_64.zip"
+            "linux/amd64": "https://github.com/likecoin/likecoin-chain/releases/download/v3.0.0/likecoin-chain_3.0.0_Linux_x86_64.tar.gz",
+            "linux/arm64": "https://github.com/likecoin/likecoin-chain/releases/download/v3.0.0/likecoin-chain_3.0.0_Linux_arm64.tar.gz",
+            "darwin/amd64": "https://github.com/likecoin/likecoin-chain/releases/download/v3.0.0/likecoin-chain_3.0.0_Darwin_x86_64.tar.gz",
+            "darwin/arm64": "https://github.com/likecoin/likecoin-chain/releases/download/v3.0.0/likecoin-chain_3.0.0_Darwin_arm64.tar.gz",
+            "windows/amd64": "https://github.com/likecoin/likecoin-chain/releases/download/v3.0.0/likecoin-chain_3.0.0_Windows_x86_64.zip"
         }
     },
     "peers": {


### PR DESCRIPTION
We have just upgraded our chain with x/nft support
https://blog.like.co/en/likecoin-chain-upgrade-starferry-overview/