### PR TITLE
Add check logo uri pattern

### DIFF
--- a/assetlist.schema.json
+++ b/assetlist.schema.json
@@ -92,12 +92,12 @@
                         "png": {
                             "type": "string",
                             "format": "uri-reference",
-                            "pattern": "^https://raw\\.githubusercontent\\.com/cosmos/chain-registry/master(/testnets/|/)([a-z]|[0-9]){1,}/images/([a-z]|[0-9]){1,}\\.png$"
+                            "pattern": "^https://raw\\.githubusercontent\\.com/cosmos/chain-registry/master(/|/testnets/|/_non-cosmos/)([a-z]|[0-9]){1,}/images/([a-z]|[0-9]){1,}\\.png$"
                         },
                         "svg": {
                             "type": "string",
                             "format": "uri-reference",
-                            "pattern": "^https://raw\\.githubusercontent\\.com/cosmos/chain-registry/master(/testnets/|/)([a-z]|[0-9]){1,}/images/([a-z]|[0-9]){1,}\\.svg$"
+                            "pattern": "^https://raw\\.githubusercontent\\.com/cosmos/chain-registry/master(/|/testnets/|/_non-cosmos/)([a-z]|[0-9]){1,}/images/([a-z]|[0-9]){1,}\\.svg$"
                         }
                     }
                 },

--- a/assetlist.schema.json
+++ b/assetlist.schema.json
@@ -91,11 +91,13 @@
                     "properties": {
                         "png": {
                             "type": "string",
-                            "format": "uri-reference"
+                            "format": "uri-reference",
+                            "pattern": "^https://raw\\.githubusercontent\\.com/cosmos/chain-registry/master(/testnets/|/)([a-z]|[0-9]){1,}/images/([a-z]|[0-9]){1,}\\.png$"
                         },
                         "svg": {
                             "type": "string",
-                            "format": "uri-reference"
+                            "format": "uri-reference",
+                            "pattern": "^https://raw\\.githubusercontent\\.com/cosmos/chain-registry/master(/testnets/|/)([a-z]|[0-9]){1,}/images/([a-z]|[0-9]){1,}\\.svg$"
                         }
                     }
                 },

--- a/chain.schema.json
+++ b/chain.schema.json
@@ -239,12 +239,12 @@
                 "png": {
                     "type": "string",
                     "format": "uri-reference",
-                    "pattern": "^https://raw\\.githubusercontent\\.com/cosmos/chain-registry/master(/testnets/|/)([a-z]|[0-9]){1,}/images/([a-z]|[0-9]){1,}\\.png$"
+                    "pattern": "^https://raw\\.githubusercontent\\.com/cosmos/chain-registry/master(/|/testnets/|/_non-cosmos/)([a-z]|[0-9]){1,}/images/([a-z]|[0-9]){1,}\\.png$"
                 },
                 "svg": {
                     "type": "string",
                     "format": "uri-reference",
-                    "pattern": "^https://raw\\.githubusercontent\\.com/cosmos/chain-registry/master(/testnets/|/)([a-z]|[0-9]){1,}/images/([a-z]|[0-9]){1,}\\.svg$"
+                    "pattern": "^https://raw\\.githubusercontent\\.com/cosmos/chain-registry/master/(|/testnets/|/_non-cosmos/)([a-z]|[0-9]){1,}/images/([a-z]|[0-9]){1,}\\.svg$"
                 }
             }
         }

--- a/chain.schema.json
+++ b/chain.schema.json
@@ -238,11 +238,13 @@
             "properties": {
                 "png": {
                     "type": "string",
-                    "format": "uri-reference"
+                    "format": "uri-reference",
+                    "pattern": "^https://raw\\.githubusercontent\\.com/cosmos/chain-registry/master(/testnets/|/)([a-z]|[0-9]){1,}/images/([a-z]|[0-9]){1,}\\.png$"
                 },
                 "svg": {
                     "type": "string",
-                    "format": "uri-reference"
+                    "format": "uri-reference",
+                    "pattern": "^https://raw\\.githubusercontent\\.com/cosmos/chain-registry/master(/testnets/|/)([a-z]|[0-9]){1,}/images/([a-z]|[0-9]){1,}\\.svg$"
                 }
             }
         }


### PR DESCRIPTION
Now all image URIs will be in the proper format and pointing to the chain registry, and not any other repo 