### PR TITLE
Add pstake

### DIFF
--- a/persistence/assetlist.json
+++ b/persistence/assetlist.json
@@ -20,7 +20,7 @@
         "symbol": "XPRT",
         "logo_URIs": {
           "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/persistence/images/xprt.png",
-	        "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/persistence/images/xprt.svg"
+          "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/persistence/images/xprt.svg"
         },
         "coingecko_id": "persistence"
       },

--- a/persistence/assetlist.json
+++ b/persistence/assetlist.json
@@ -20,9 +20,40 @@
         "symbol": "XPRT",
         "logo_URIs": {
           "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/persistence/images/xprt.png",
-	  "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/persistence/images/xprt.svg"
+	        "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/persistence/images/xprt.svg"
         },
         "coingecko_id": "persistence"
+      },
+	    {
+        "description": "pSTAKE is a liquid staking protocol unlocking the liquidity of staked assets.",
+        "denom_units": [
+          {
+            "denom": "ibc/A6E3AF63B3C906416A9AF7A556C59EA4BD50E617EFFE6299B99700CCB780E444",
+            "exponent": 0,
+            "aliases": [
+              "gravity0xfB5c6815cA3AC72Ce9F5006869AE67f18bF77006",
+              "0xfB5c6815cA3AC72Ce9F5006869AE67f18bF77006"
+            ]
+          },
+          {
+            "denom": "pstake",
+            "exponent": 18
+          }
+        ],
+        "base": "ibc/A6E3AF63B3C906416A9AF7A556C59EA4BD50E617EFFE6299B99700CCB780E444",
+        "name": "pSTAKE Finance",
+        "display": "pstake",
+        "symbol": "PSTAKE",
+        "ibc": {
+          "source_channel": "channel-24",
+          "dst_channel": "channel-38",
+          "source_denom": "gravity0xfB5c6815cA3AC72Ce9F5006869AE67f18bF77006"
+        },
+        "logo_URIs": {
+          "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/persistence/images/pstake.png",
+          "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/persistence/images/pstake.svg"
+        },
+        "coingecko_id": "pstake-finance"
       }
     ]
   }

--- a/persistence/assetlist.json
+++ b/persistence/assetlist.json
@@ -24,7 +24,7 @@
         },
         "coingecko_id": "persistence"
       },
-	    {
+      {
         "description": "pSTAKE is a liquid staking protocol unlocking the liquidity of staked assets.",
         "denom_units": [
           {


### PR DESCRIPTION
because PSTAKE having been bridged from Ethereum via Gravity Bridge, then transferred to Persistence chain, is considered the canonical form of PSTAKE within the Cosmos, as decided by Persistence team.