### PR TITLE
Update binary version of Crescent Network

### DIFF
--- a/crescent/chain.json
+++ b/crescent/chain.json
@@ -25,9 +25,10 @@
   },
   "codebase": {
     "git_repo": "https://github.com/crescent-network/crescent",
-    "recommended_version": "v2.1.0",
+    "recommended_version": "v2.1.1",
     "compatible_versions": [
-      "v2.1.0"
+      "v2.1.0",
+      "v2.1.1"
     ],
     "binaries": {
       "linux/amd64": "https://github.com/crescent-network/crescent/releases/download/v2.1.0/crescentd-v2.1.0-linux-amd64",


### PR DESCRIPTION
- recommended_version to [`v2.1.1`](https://github.com/crescent-network/crescent/releases/tag/v2.1.1)
- add `v2.1.1` on compatible_versions