### PR TITLE
Adds ATOMScan to most chains that are supported

### DIFF
--- a/akash/chain.json
+++ b/akash/chain.json
@@ -211,6 +211,11 @@
           "kind": "bigdipper",
           "url": "https://akash.bigdipper.live/",
           "tx_page": "https://akash.bigdipper.live/transactions/${txHash}"
+        },
+        {
+          "kind": "atomscan",
+          "url": "https://atomscan.com/akash",
+          "tx_page": "https://atomscan.com/akash/transactions/${txHash}"
         }
       ]
 }

--- a/assetmantle/chain.json
+++ b/assetmantle/chain.json
@@ -380,6 +380,11 @@
             "kind": "explorers.guru",
             "url": "https://assetmantle.explorers.guru",
             "tx_page": "https://assetmantle.explorers.guru/transaction/${txHash}"
+        },
+        {
+          "kind": "atomscan",
+          "url": "https://atomscan.com/assetmantle",
+          "tx_page": "https://atomscan.com/assetmantle/transactions/${txHash}"
         }
     ]
 }

--- a/axelar/chain.json
+++ b/axelar/chain.json
@@ -118,6 +118,11 @@
             "kind": "explorers.guru",
             "url": "https://axelar.explorers.guru",
             "tx_page": "https://axelar.explorers.guru/transaction/${txHash}"
+        },
+        {
+          "kind": "atomscan",
+          "url": "https://atomscan.com/axelar",
+          "tx_page": "https://atomscan.com/axelar/transactions/${txHash}"
         }
     ]
 }

--- a/bandchain/chain.json
+++ b/bandchain/chain.json
@@ -82,6 +82,11 @@
       "kind": "ping.pub",
       "url": "https://ping.pub/band-protocol",
       "tx_page": "https://ping.pub/band-protocol/tx/{txHash}"
+    },
+    {
+      "kind": "atomscan",
+      "url": "https://atomscan.com/band-protocol",
+      "tx_page": "https://atomscan.com/band-protocol/transactions/${txHash}"
     }
   ]
 }

--- a/bitcanna/chain.json
+++ b/bitcanna/chain.json
@@ -178,6 +178,11 @@
                 "kind": "mintscan",
                 "url": "https://www.mintscan.io/bitcanna/",
                 "tx_page": "https://www.mintscan.io/bitcanna/txs/${txHash}"
+            },
+            {
+              "kind": "atomscan",
+              "url": "https://atomscan.com/bitcanna",
+              "tx_page": "https://atomscan.com/bitcanna/transactions/${txHash}"
             }
     ]
 }

--- a/bitsong/chain.json
+++ b/bitsong/chain.json
@@ -134,6 +134,11 @@
         "kind": "big-dipper",
         "url": "https://explorebitsong.com",
         "tx_page": "https://explorebitsong.com/transactions/${txHash}"
+    },
+    {
+      "kind": "atomscan",
+      "url": "https://atomscan.com/bitsong",
+      "tx_page": "https://atomscan.com/bitsong/transactions/${txHash}"
     }
   ]
 }

--- a/cerberus/chain.json
+++ b/cerberus/chain.json
@@ -153,6 +153,11 @@
             "kind": "mintscan",
             "url": "https://www.mintscan.io/cerberus",
             "tx_page": "https://www.mintscan.io/cerberus/txs/{txHash}"
+        },
+        {
+          "kind": "atomscan",
+          "url": "https://atomscan.com/cerberus",
+          "tx_page": "https://atomscan.com/cerberus/transactions/${txHash}"
         }
     ]
 }

--- a/cheqd/chain.json
+++ b/cheqd/chain.json
@@ -130,6 +130,6 @@
             "url": "https://atomscan.com/cheqd",
             "tx_page": "https://atomscan.com/cheqd/transactions/${txHash}",
             "account_page": "https://atomscan.com/cheqd/accounts/${accountAddress}"
-          }
+        }
     ]
 }

--- a/chihuahua/chain.json
+++ b/chihuahua/chain.json
@@ -123,6 +123,11 @@
             "kind": "mintscan",
             "url": "https://mintscan.io/chihuahua",
             "tx_page": "https://mintscan.io/chihuahua/txs/${txHash}"
+        },
+        {
+          "kind": "atomscan",
+          "url": "https://atomscan.com/chihuahua",
+          "tx_page": "https://atomscan.com/chihuahua/transactions/${txHash}"
         }
     ]
 }

--- a/comdex/chain.json
+++ b/comdex/chain.json
@@ -151,6 +151,11 @@
             "kind": "ping-pub",
             "url": "https://ping.pub/comdex",
             "tx_page": "https://ping.pub/comdex/tx/${txHash}"
+        },
+        {
+          "kind": "atomscan",
+          "url": "https://atomscan.com/comdex",
+          "tx_page": "https://atomscan.com/comdex/transactions/${txHash}"
         }
     ]
 }

--- a/cosmoshub/chain.json
+++ b/cosmoshub/chain.json
@@ -271,6 +271,11 @@
             "kind": "bigdipper",
             "url": "https://cosmos.bigdipper.live/",
             "tx_page": "https://cosmos.bigdipper.live/transactions/${txHash}"
+        },
+        {
+          "kind": "atomscan",
+          "url": "https://atomscan.com",
+          "tx_page": "https://atomscan.com/transactions/${txHash}"
         }
     ]
 }

--- a/crescent/chain.json
+++ b/crescent/chain.json
@@ -158,6 +158,11 @@
       "kind": "explorers.guru",
       "url": "https://crescent.explorers.guru",
       "tx_page": "https://crescent.explorers.guru/transaction/${txHash}"
+    },
+    {
+      "kind": "atomscan",
+      "url": "https://atomscan.com/crescent",
+      "tx_page": "https://atomscan.com/crescent/transactions/${txHash}"
     }
   ]
 }

--- a/cudos/chain.json
+++ b/cudos/chain.json
@@ -100,6 +100,11 @@
       "url": "https://www.mintscan.io/cudos",
       "tx_page": "https://www.mintscan.io/cudos/txs/${txHash}",
       "account_page": "https://www.mintscan.io/cudos/account/${accountAddress}"
+    },
+    {
+      "kind": "atomscan",
+      "url": "https://atomscan.com/cudos",
+      "tx_page": "https://atomscan.com/cudos/transactions/${txHash}"
     }
   ]
 }

--- a/decentr/chain.json
+++ b/decentr/chain.json
@@ -133,6 +133,11 @@
             "kind": "ping.pub",
             "url": "https://ping.pub/decentr/",
             "tx_page": "https://ping.pub/decentr/tx/${txHash}"
+        },
+        {
+          "kind": "atomscan",
+          "url": "https://atomscan.com/decentr",
+          "tx_page": "https://atomscan.com/decentr/transactions/${txHash}"
         }
     ]
 }

--- a/desmos/chain.json
+++ b/desmos/chain.json
@@ -100,6 +100,11 @@
             "kind": "ping-pub",
             "url": "https://ping.pub/desmos",
             "tx_page": "https://ping.pub/desmos/tx/${txHash}"
+        },
+        {
+          "kind": "atomscan",
+          "url": "https://atomscan.com/desmos",
+          "tx_page": "https://atomscan.com/desmos/transactions/${txHash}"
         }
     ]
 }

--- a/dig/chain.json
+++ b/dig/chain.json
@@ -106,6 +106,11 @@
       "kind": "ping.pub",
       "url": "https://ping.pub/dig",
       "tx_page": "https://ping.pub/dig/tx/${txHash}"
+    },
+    {
+      "kind": "atomscan",
+      "url": "https://atomscan.com/dig",
+      "tx_page": "https://atomscan.com/dig/transactions/${txHash}"
     }
   ]
 }

--- a/echelon/chain.json
+++ b/echelon/chain.json
@@ -175,6 +175,11 @@
         "kind": "atomscan",
         "url": "https://atomscan.com/echelon",
         "tx_page": "https://atomscan.com/echelon/tx/${txHash}"
+    },
+    {
+      "kind": "atomscan",
+      "url": "https://atomscan.com/echelon",
+      "tx_page": "https://atomscan.com/echelon/transactions/${txHash}"
     }
   ]
 }

--- a/evmos/chain.json
+++ b/evmos/chain.json
@@ -228,6 +228,11 @@
         "kind": "explorers.guru",
 		    "url": "https://evmos.explorers.guru",
 		    "tx_page": "https://evmos.explorers.guru/transaction/${txHash}"
+    },
+    {
+      "kind": "atomscan",
+      "url": "https://atomscan.com/evmos",
+      "tx_page": "https://atomscan.com/evmos/transactions/${txHash}"
     }
   ]
 }

--- a/fetchhub/chain.json
+++ b/fetchhub/chain.json
@@ -109,6 +109,11 @@
             "kind": "ping.pub",
             "url": "https://ping.pub/fetchhub",
             "tx_page": "https://ping.pub/fetchhub/tx/${txHash}"
+        },
+        {
+          "kind": "atomscan",
+          "url": "https://atomscan.com/fetchhub",
+          "tx_page": "https://atomscan.com/fetchhub/transactions/${txHash}"
         }
     ]
 }

--- a/gravitybridge/chain.json
+++ b/gravitybridge/chain.json
@@ -137,6 +137,11 @@
       "kind": "explorers.guru",
       "url": "https://gravity.explorers.guru",
       "tx_page": "https://gravity.explorers.guru/transaction/${txHash}"
+    },
+    {
+      "kind": "atomscan",
+      "url": "https://atomscan.com/gravity-bridge",
+      "tx_page": "https://atomscan.com/gravity-bridge/transactions/${txHash}"
     }
   ]
 }

--- a/idep/chain.json
+++ b/idep/chain.json
@@ -88,6 +88,11 @@
       "kind": "chadscan",
       "url": "https://chadscan.com",
       "tx_page": "https://chadscan.com/transactions/${txHash}"
+    },
+    {
+      "kind": "atomscan",
+      "url": "https://atomscan.com/idep",
+      "tx_page": "https://atomscan.com/idep/transactions/${txHash}"
     }
   ]
 }

--- a/impacthub/chain.json
+++ b/impacthub/chain.json
@@ -133,6 +133,11 @@
             "kind": "ping.pub",
             "url": "https://ping.pub/ixo",
             "tx_page": "https://ping.pub/ixo/tx/${txHash}"
+        },
+        {
+          "kind": "atomscan",
+          "url": "https://atomscan.com/ixo",
+          "tx_page": "https://atomscan.com/ixo/transactions/${txHash}"
         }
     ]
 }

--- a/injective/chain.json
+++ b/injective/chain.json
@@ -94,6 +94,11 @@
             "kind": "ping-pub",
             "url": "https://ping.pub/injective",
             "tx_page": "https://ping.pub/injective/tx/${txHash}"
+        },
+        {
+          "kind": "atomscan",
+          "url": "https://atomscan.com/injective",
+          "tx_page": "https://atomscan.com/injective/transactions/${txHash}"
         }
     ]
 }

--- a/irisnet/chain.json
+++ b/irisnet/chain.json
@@ -124,6 +124,11 @@
             "kind": "ping-pub",
             "url": "https://ping.pub/iris-network",
             "tx_page": "https://ping.pub/iris-network/tx/${txHash}"
+        },
+        {
+          "kind": "atomscan",
+          "url": "https://atomscan.com/iris-network",
+          "tx_page": "https://atomscan.com/iris-network/transactions/${txHash}"
         }
     ]
 }

--- a/juno/chain.json
+++ b/juno/chain.json
@@ -164,6 +164,11 @@
         "kind": "mintscan",
         "url": "https://www.mintscan.io/juno",
         "tx_page": "https://www.mintscan.io/juno/txs/{txHash}"
+      },
+      {
+        "kind": "atomscan",
+        "url": "https://atomscan.com/juno",
+        "tx_page": "https://atomscan.com/juno/transactions/${txHash}"
       }
     ]
   }

--- a/kava/chain.json
+++ b/kava/chain.json
@@ -133,6 +133,11 @@
             "kind": "ping-pub",
             "url": "https://ping.pub/kava",
             "tx_page": "https://ping.pub/kava/tx/${txHash}"
+        },
+        {
+          "kind": "atomscan",
+          "url": "https://atomscan.com/kava",
+          "tx_page": "https://atomscan.com/kava/transactions/${txHash}"
         }
     ]
 }

--- a/kichain/chain.json
+++ b/kichain/chain.json
@@ -121,6 +121,11 @@
             "kind": "ping-pub",
             "url": "https://ping.pub/kichain",
             "tx_page": "https://ping.pub/kichain/tx/${txHash}"
+        },
+        {
+          "kind": "atomscan",
+          "url": "https://atomscan.com/ki-chain",
+          "tx_page": "https://atomscan.com/ki-chain/transactions/${txHash}"
         }
     ]
 }

--- a/kujira/chain.json
+++ b/kujira/chain.json
@@ -78,6 +78,11 @@
             "kind": "explorers.guru",
             "url": "https://kujira.explorers.guru",
             "tx_page": "https://kujira.explorers.guru/transaction/${txHash}"
+        },
+        {
+          "kind": "atomscan",
+          "url": "https://atomscan.com/kujira",
+          "tx_page": "https://atomscan.com/kujira/transactions/${txHash}"
         }
     ],
     "logo_URIs": {

--- a/likecoin/chain.json
+++ b/likecoin/chain.json
@@ -119,6 +119,11 @@
             "kind": "ping-pub",
             "url": "https://ping.pub/likecoin",
             "tx_page": "https://ping.pub/likecoin/tx/${txHash}"
+        },
+        {
+          "kind": "atomscan",
+          "url": "https://atomscan.com/likecoin",
+          "tx_page": "https://atomscan.com/likecoin/transactions/${txHash}"
         }
     ]
 }

--- a/lumnetwork/chain.json
+++ b/lumnetwork/chain.json
@@ -106,6 +106,11 @@
             "kind": "ping-pub",
             "url": "https://ping.pub/lum-network",
             "tx_page": "https://ping.pub/lum-network/tx/${txHash}"
+        },
+        {
+          "kind": "atomscan",
+          "url": "https://atomscan.com/lum-network",
+          "tx_page": "https://atomscan.com/lum-network/transactions/${txHash}"
         }
     ]
 }

--- a/meme/chain.json
+++ b/meme/chain.json
@@ -125,6 +125,11 @@
       "kind": "MEME Explorer",
       "url": "https://explorer.meme.sx/meme",
       "tx_page": "https://explorer.meme.sx/meme/tx/${txHash}"
+    },
+    {
+      "kind": "atomscan",
+      "url": "https://atomscan.com/meme",
+      "tx_page": "https://atomscan.com/meme/transactions/${txHash}"
     }
   ]
 }

--- a/omniflixhub/chain.json
+++ b/omniflixhub/chain.json
@@ -83,6 +83,11 @@
             "url": "https://www.mintscan.io/omniflix",
             "tx_page": "https://www.mintscan.io/omniflix/txs/${txHash}",
             "account_page": "https://www.mintscan.io/omniflix/account/${accountAddress}"
+        },
+        {
+          "kind": "atomscan",
+          "url": "https://atomscan.com/omniflixhub",
+          "tx_page": "https://atomscan.com/omniflixhub/transactions/${txHash}"
         }
     ]
 }

--- a/osmosis/chain.json
+++ b/osmosis/chain.json
@@ -298,6 +298,11 @@
             "url": "https://osmosis.explorers.guru",
             "tx_page": "https://osmosis.explorers.guru/transaction/${txHash}",
             "account_page": "https://osmosis.explorers.guru/transaction/${accountAddress}"
+        },
+        {
+          "kind": "atomscan",
+          "url": "https://atomscan.com/osmosis",
+          "tx_page": "https://atomscan.com/osmosis/transactions/${txHash}"
         }
     ],
     "logo_URIs": {

--- a/persistence/chain.json
+++ b/persistence/chain.json
@@ -144,6 +144,11 @@
       "kind": "ping-pub",
       "url": "https://ping.pub/persistence",
       "tx_page": "https://ping.pub/persistence/tx/${txHash}"
+    },
+    {
+      "kind": "atomscan",
+      "url": "https://atomscan.com/persistence",
+      "tx_page": "https://atomscan.com/persistence/transactions/${txHash}"
     }
   ]
 }

--- a/provenance/chain.json
+++ b/provenance/chain.json
@@ -105,6 +105,11 @@
             "kind": "mintscan",
             "url": "https://www.mintscan.io/provenance",
             "tx_page": "https://www.mintscan.io/provenance/txs/${txHash}"
-        }      
+        }    ,
+        {
+          "kind": "atomscan",
+          "url": "https://atomscan.com/provenance",
+          "tx_page": "https://atomscan.com/provenance/transactions/${txHash}"
+        }  
     ]
 }

--- a/regen/chain.json
+++ b/regen/chain.json
@@ -102,6 +102,11 @@
             "kind": "ping-pub",
             "url": "https://ping.pub/regen",
             "tx_page": "https://ping.pub/regen/tx/${txHash}"
+        },
+        {
+          "kind": "atomscan",
+          "url": "https://atomscan.com/regen-network",
+          "tx_page": "https://atomscan.com/regen-network/transactions/${txHash}"
         }
     ]
 }

--- a/rizon/chain.json
+++ b/rizon/chain.json
@@ -70,6 +70,11 @@
             "kind": "ping-pub",
             "url": "https://ping.pub/rizon",
             "tx_page": "https://ping.pub/rizon/tx/${txHash}"
+        },
+        {
+          "kind": "atomscan",
+          "url": "https://atomscan.com/rizon",
+          "tx_page": "https://atomscan.com/rizon/transactions/${txHash}"
         }
     ]
 }

--- a/secretnetwork/chain.json
+++ b/secretnetwork/chain.json
@@ -127,6 +127,11 @@
         "kind": "mintscan",
         "url": "https://www.mintscan.io/secret",
         "tx_page": "https://www.mintscan.io/secret/txs/${txHash}"
+    },
+    {
+      "kind": "atomscan",
+      "url": "https://atomscan.com/secret-network",
+      "tx_page": "https://atomscan.com/secret-network/transactions/${txHash}"
     }
   ]
 }

--- a/sifchain/chain.json
+++ b/sifchain/chain.json
@@ -108,6 +108,11 @@
             "kind": "mintscan",
             "url": "https://www.mintscan.io/sifchain",
             "tx_page": "https://www.mintscan.io/sifchain/txs/{txHash}"
+        },
+        {
+          "kind": "atomscan",
+          "url": "https://atomscan.com/sifchain",
+          "tx_page": "https://atomscan.com/sifchain/transactions/${txHash}"
         }
     ]
 }

--- a/stargaze/chain.json
+++ b/stargaze/chain.json
@@ -210,6 +210,11 @@
         "kind": "ping-pub",
         "url": "https://ping.pub/stargaze",
         "tx_page": "https://ping.pub/stargaze/tx/${txHash}"
+    },
+    {
+      "kind": "atomscan",
+      "url": "https://atomscan.com/stargaze",
+      "tx_page": "https://atomscan.com/stargaze/transactions/${txHash}"
     }
   ]
 }

--- a/starname/chain.json
+++ b/starname/chain.json
@@ -95,6 +95,11 @@
             "kind": "ping-pub",
             "url": "https://ping.pub/starname",
             "tx_page": "https://ping.pub/starname/tx/${txHash}"
+        },
+        {
+          "kind": "atomscan",
+          "url": "https://atomscan.com/starname",
+          "tx_page": "https://atomscan.com/starname/transactions/${txHash}"
         }
     ]
 }

--- a/terra/chain.json
+++ b/terra/chain.json
@@ -87,6 +87,11 @@
             "kind": "ping-pub",
             "url": "https://ping.pub/terra-luna",
             "tx_page": "https://ping.pub/terra-luna/tx/${txHash}"
+        },
+        {
+          "kind": "atomscan",
+          "url": "https://atomscan.com/terra",
+          "tx_page": "https://atomscan.com/terra/transactions/${txHash}"
         }
     ]
 }

--- a/umee/chain.json
+++ b/umee/chain.json
@@ -171,6 +171,11 @@
 		    "kind": "explorers.guru",
 		    "url": "https://umee.explorers.guru",
 		    "tx_page": "https://umee.explorers.guru/transaction/${txHash}"
-		}
+		},
+        {
+          "kind": "atomscan",
+          "url": "https://atomscan.com/umee",
+          "tx_page": "https://atomscan.com/umee/transactions/${txHash}"
+        }
 	]
 }

--- a/vidulum/chain.json
+++ b/vidulum/chain.json
@@ -106,6 +106,11 @@
       "kind": "Ping",
       "url": "https://ping.pub/vidulum",
       "tx_page": "https://ping.pub/vidulum/tx/${txHash}"
+    },
+    {
+      "kind": "atomscan",
+      "url": "https://atomscan.com/vidulum",
+      "tx_page": "https://atomscan.com/vidulum/transactions/${txHash}"
     }
   ]
 }


### PR DESCRIPTION
Hi team,

We'd love to get ATOMScan's explorer which we've been running for a long time added to the registry for all of the chains we support.

Please let me know if there's anything else you'd like from us.

Thanks.