### PR TITLE
Remove persistent peers from Theta testnet

### DIFF
--- a/testnets/theta/chain.json
+++ b/testnets/theta/chain.json
@@ -52,26 +52,6 @@
             }
         ],
         "persistent_peers": [
-            {
-                "id": "5c9850dc5ec603b0c97ffd8d67bde3221b877acf",
-                "address": "p2p.sentry-01.theta-testnet.polypore.xyz:26656",
-                "provider": "Hypha"
-            },
-            {
-                "id": "208683ee734ba3cec1cfc0c8bcbc326969641952",
-                "address": "p2p.sentry-02.theta-testnet.polypore.xyz:26656",
-                "provider": "Hypha"
-            },
-            {
-                "id": "58e9d022962a3875fa22d7146949d0dc34e51ba6",
-                "address": "p2p.state-sync-01.theta-testnet.polypore.xyz:26656",
-                "provider": "Hypha"
-            },
-            {
-                "id": "6954e0479cd71fa01aeed15e1a3b87c06433d827",
-                "address": "p2p.state-sync-02.theta-testnet.polypore.xyz:26656",
-                "provider": "Hypha"
-            }
         ]
     },
     "apis": {


### PR DESCRIPTION
Hi! Our seed nodes are operational so I have removed the entries from the `persistent_peers` list.

Both seed and state sync node entries are now aligned with our published [Ansible inventory file](https://github.com/hyphacoop/cosmos-ansible/blob/main/examples/inventory-theta.yml)

Thanks!

Closes #604 
