### PR TITLE
Update assetlist.json to reflect IST denom

### DIFF
--- a/agoric/assetlist.json
+++ b/agoric/assetlist.json
@@ -3,7 +3,7 @@
   "chain_name": "agoric",
   "assets": [
     {
-      "description": "BLD is the token used to secure the Agoric chain through staking and to backstop the RUN Protocol.",
+      "description": "BLD is the token used to secure the Agoric chain through staking and to backstop Inter Protocol.",
       "denom_units": [
         {
           "denom": "ubld",
@@ -23,21 +23,21 @@
       }
     },
     {
-      "description": "RUN is the stable token used by the Agoric chain for execution fees and commerce.",
+      "description": "IST is the stable token used by the Agoric chain for execution fees and commerce.",
       "denom_units": [
         {
-          "denom": "urun",
+          "denom": "uist",
           "exponent": 0
         },
         {
-          "denom": "run",
+          "denom": "ist",
           "exponent": 6
         }
       ],
-      "base": "urun",
+      "base": "uist",
       "name": "Agoric Stable Token",
-      "display": "run",
-      "symbol": "RUN",
+      "display": "ist",
+      "symbol": "IST",
       "logo_URIs": {
         "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/agoric/images/run.png"
       }


### PR DESCRIPTION
Recently, Agoric renamed RUN Protocol to Inter Protocol. As a result, the denom previously referred to as RUN is now IST, short for the Inter Stable Token. This update changes the denom name and descriptions in the asset list to match the new naming conventions. 

A follow up proposal to update the logos is on the way.