### PR TITLE
Add Agoric IBC path metadata

### DIFF
--- a/_IBC/agoric-cosmoshub.json
+++ b/_IBC/agoric-cosmoshub.json
@@ -1,31 +1,31 @@
 {
-    "$schema": "../ibc_data.schema.json",
-    "chain-1": {
-      "chain-name": "agoric",
-      "client-id": "07-tendermint-0",
-      "connection-id": "connection-0"
-    },
-    "chain-2": {
-      "chain-name": "cosmoshub",
-      "client-id": "07-tendermint-898",
-      "connection-id": "connection-622"
-    },
-    "channels": [
-      {
-        "chain-1": {
-          "channel-id": "channel-0",
-          "port-id": "transfer"
-        },
-        "chain-2": {
-          "channel-id": "channel-374",
-          "port-id": "transfer"
-        },
-        "ordering": "unordered",
-        "version": "ics20-1",
-        "tags": {
-          "status": "live",
-          "preferred": true,
-        }
+  "$schema": "../ibc_data.schema.json",
+  "chain-1": {
+    "chain-name": "agoric",
+    "client-id": "07-tendermint-0",
+    "connection-id": "connection-0"
+  },
+  "chain-2": {
+    "chain-name": "cosmoshub",
+    "client-id": "07-tendermint-898",
+    "connection-id": "connection-622"
+  },
+  "channels": [
+    {
+      "chain-1": {
+        "channel-id": "channel-0",
+        "port-id": "transfer"
+      },
+      "chain-2": {
+        "channel-id": "channel-374",
+        "port-id": "transfer"
+      },
+      "ordering": "unordered",
+      "version": "ics20-1",
+      "tags": {
+        "status": "live",
+        "preferred": true
       }
-    ]
-  }
+    }
+  ]
+}

--- a/_IBC/agoric-cosmoshub.json
+++ b/_IBC/agoric-cosmoshub.json
@@ -1,0 +1,31 @@
+{
+    "$schema": "../ibc_data.schema.json",
+    "chain-1": {
+      "chain-name": "agoric",
+      "client-id": "07-tendermint-0",
+      "connection-id": "connection-0"
+    },
+    "chain-2": {
+      "chain-name": "cosmoshub",
+      "client-id": "07-tendermint-898",
+      "connection-id": "connection-622"
+    },
+    "channels": [
+      {
+        "chain-1": {
+          "channel-id": "channel-0",
+          "port-id": "transfer"
+        },
+        "chain-2": {
+          "channel-id": "channel-374",
+          "port-id": "transfer"
+        },
+        "ordering": "unordered",
+        "version": "ics20-1",
+        "tags": {
+          "status": "live",
+          "preferred": true,
+        }
+      }
+    ]
+  }

--- a/_IBC/agoric-crescent.json
+++ b/_IBC/agoric-crescent.json
@@ -1,0 +1,31 @@
+{
+    "$schema": "../ibc_data.schema.json",
+    "chain-1": {
+      "chain-name": "agoric",
+      "client-id": "07-tendermint-2",
+      "connection-id": "connection-2"
+    },
+    "chain-2": {
+      "chain-name": "crescent",
+      "client-id": "07-tendermint-19",
+      "connection-id": "connection-14"
+    },
+    "channels": [
+      {
+        "chain-1": {
+          "channel-id": "channel-2",
+          "port-id": "transfer"
+        },
+        "chain-2": {
+          "channel-id": "channel-11",
+          "port-id": "transfer"
+        },
+        "ordering": "unordered",
+        "version": "ics20-1",
+        "tags": {
+          "status": "live",
+          "preferred": true,
+        }
+      }
+    ]
+  }

--- a/_IBC/agoric-crescent.json
+++ b/_IBC/agoric-crescent.json
@@ -1,31 +1,31 @@
 {
-    "$schema": "../ibc_data.schema.json",
-    "chain-1": {
-      "chain-name": "agoric",
-      "client-id": "07-tendermint-2",
-      "connection-id": "connection-2"
-    },
-    "chain-2": {
-      "chain-name": "crescent",
-      "client-id": "07-tendermint-19",
-      "connection-id": "connection-14"
-    },
-    "channels": [
-      {
-        "chain-1": {
-          "channel-id": "channel-2",
-          "port-id": "transfer"
-        },
-        "chain-2": {
-          "channel-id": "channel-11",
-          "port-id": "transfer"
-        },
-        "ordering": "unordered",
-        "version": "ics20-1",
-        "tags": {
-          "status": "live",
-          "preferred": true,
-        }
+  "$schema": "../ibc_data.schema.json",
+  "chain-1": {
+    "chain-name": "agoric",
+    "client-id": "07-tendermint-2",
+    "connection-id": "connection-2"
+  },
+  "chain-2": {
+    "chain-name": "crescent",
+    "client-id": "07-tendermint-19",
+    "connection-id": "connection-14"
+  },
+  "channels": [
+    {
+      "chain-1": {
+        "channel-id": "channel-2",
+        "port-id": "transfer"
+      },
+      "chain-2": {
+        "channel-id": "channel-11",
+        "port-id": "transfer"
+      },
+      "ordering": "unordered",
+      "version": "ics20-1",
+      "tags": {
+        "status": "live",
+        "preferred": true
       }
-    ]
-  }
+    }
+  ]
+}

--- a/_IBC/agoric-osmosis.json
+++ b/_IBC/agoric-osmosis.json
@@ -1,0 +1,31 @@
+{
+    "$schema": "../ibc_data.schema.json",
+    "chain-1": {
+      "chain-name": "agoric",
+      "client-id": "07-tendermint-1",
+      "connection-id": "connection-1"
+    },
+    "chain-2": {
+      "chain-name": "osmosis",
+      "client-id": "07-tendermint-2019",
+      "connection-id": "connection-1649"
+    },
+    "channels": [
+      {
+        "chain-1": {
+          "channel-id": "channel-1",
+          "port-id": "transfer"
+        },
+        "chain-2": {
+          "channel-id": "channel-320",
+          "port-id": "transfer"
+        },
+        "ordering": "unordered",
+        "version": "ics20-1",
+        "tags": {
+          "status": "live",
+          "preferred": true,
+        }
+      }
+    ]
+  }

--- a/_IBC/agoric-osmosis.json
+++ b/_IBC/agoric-osmosis.json
@@ -1,31 +1,31 @@
 {
-    "$schema": "../ibc_data.schema.json",
-    "chain-1": {
-      "chain-name": "agoric",
-      "client-id": "07-tendermint-1",
-      "connection-id": "connection-1"
-    },
-    "chain-2": {
-      "chain-name": "osmosis",
-      "client-id": "07-tendermint-2019",
-      "connection-id": "connection-1649"
-    },
-    "channels": [
-      {
-        "chain-1": {
-          "channel-id": "channel-1",
-          "port-id": "transfer"
-        },
-        "chain-2": {
-          "channel-id": "channel-320",
-          "port-id": "transfer"
-        },
-        "ordering": "unordered",
-        "version": "ics20-1",
-        "tags": {
-          "status": "live",
-          "preferred": true,
-        }
+  "$schema": "../ibc_data.schema.json",
+  "chain-1": {
+    "chain-name": "agoric",
+    "client-id": "07-tendermint-1",
+    "connection-id": "connection-1"
+  },
+  "chain-2": {
+    "chain-name": "osmosis",
+    "client-id": "07-tendermint-2019",
+    "connection-id": "connection-1649"
+  },
+  "channels": [
+    {
+      "chain-1": {
+        "channel-id": "channel-1",
+        "port-id": "transfer"
+      },
+      "chain-2": {
+        "channel-id": "channel-320",
+        "port-id": "transfer"
+      },
+      "ordering": "unordered",
+      "version": "ics20-1",
+      "tags": {
+        "status": "live",
+        "preferred": true
       }
-    ]
-  }
+    }
+  ]
+}


### PR DESCRIPTION
Agoric recently enabled IBC and today their community coordinated around channel initialization for `Crescent`, `Osmosis`, and `Cosmos Hub`. These are the json files containing the path metadata for each of those new IBC paths.