### PR TITLE
Impacthub version updates

### DIFF
--- a/impacthub/chain.json
+++ b/impacthub/chain.json
@@ -26,15 +26,16 @@
     },
     "codebase": {
         "git_repo": "https://github.com/ixofoundation/ixo-blockchain",
-        "recommended_version": "v1.6.0",
+        "recommended_version": "v0.18.1",
         "compatible_versions": [
-            "v1.6.0"
+            "v0.18.1",
+            "v0.18.0"
         ],
         "binaries": {
-            "linux/amd64": "https://github.com/ixofoundation/ixo-blockchain/releases/download/v1.6.0/ixod-1.6.0-linux-amd64",
-            "linux/arm64": "https://github.com/ixofoundation/ixo-blockchain/releases/download/v1.6.0/ixod-1.6.0-linux-arm64",
-            "darwin/amd64": "https://github.com/ixofoundation/ixo-blockchain/releases/download/v1.6.0/ixod-1.6.0-darwin-amd64",
-            "windows/arm64": "https://github.com/ixofoundation/ixo-blockchain/releases/download/v1.6.0/ixod-1.6.0-windows-amd64.exe"
+            "linux/amd64": "",
+            "linux/arm64": "",
+            "darwin/amd64": "",
+            "windows/arm64": ""
         }
     },
     "peers": {
@@ -72,10 +73,6 @@
             {
                 "address": "https://proxies.sifchain.finance/api/impacthub-3/rpc",
                 "provider": "sifchain"
-            },
-            {
-                "address": "http://18.220.101.192:26657/",
-                "provider": "regen"
             },
             {
                 "address": "https://impacthub.ixo.world/rpc/",

--- a/impacthub/chain.json
+++ b/impacthub/chain.json
@@ -30,13 +30,7 @@
         "compatible_versions": [
             "v0.18.1",
             "v0.18.0"
-        ],
-        "binaries": {
-            "linux/amd64": "",
-            "linux/arm64": "",
-            "darwin/amd64": "",
-            "windows/arm64": ""
-        }
+        ]
     },
     "peers": {
         "seeds": [


### PR DESCRIPTION
- Changed recommended version to 0.18.1
- Changed compatible versions to 0.18.0 and 0.18.1
- Removed one RPC node IP address that does not respond
- Removed invalid links to binaries (kept the keys and made them empty string, so we don't break any automations. Maybe we get binaries at a later date.)
