### PR TITLE
Nomic version update

### DIFF
--- a/nomic/chain.json
+++ b/nomic/chain.json
@@ -13,9 +13,10 @@
     },
     "codebase": {
         "git_repo": "https://github.com/nomic-io/nomic",
-        "recommended_version": "v0.5.0",
+        "recommended_version": "develop",
         "compatible_versions": [
-            "v0.5.0"
+            "develop",
+            "v3"
         ]
     },
     "peers": {


### PR DESCRIPTION
- Updated Nomic chain recommended version to "develop". (The branch in git.)
- Updated Nomic chain compatible versions to "develop" (branch) and "v3" (tag).

Nomic had a network upgrade a few weeks ago from their v3 version to whatever was on the develop branch at the time to fix a security/continuity bug. The two versions should be compatible. It's been weeks since this was released but no version was tagged from develop. We must assume that the develop branch is the latest up-to-date source code for the chain.