### PR TITLE
fix client id typo for agroic<>osmosis

### DIFF
--- a/_IBC/agoric-osmosis.json
+++ b/_IBC/agoric-osmosis.json
@@ -7,7 +7,7 @@
   },
   "chain_2": {
     "chain_name": "osmosis",
-    "client_id": "07-tendermint-2019",
+    "client_id": "07-tendermint-2109",
     "connection_id": "connection-1649"
   },
   "channels": [


### PR DESCRIPTION
When the path details were initially shared in the Agoric Discord there was a typo for the client-id on Osmosis