### PR TITLE
Add juno testnet gRPC endpoint

### DIFF
--- a/testnets/junotestnet/chain.json
+++ b/testnets/junotestnet/chain.json
@@ -44,9 +44,7 @@
     "cosmwasm_enabled": true
   },
   "peers": {
-    "seeds": [
-      
-    ],
+    "seeds": [],
     "persistent_peers": [
       {
         "id": "ed90921d43ede634043d152d7a87e8881fb85e90",
@@ -77,7 +75,10 @@
       }
     ],
     "grpc": [
-      
+      {
+        "address": "juno-testnet-grpc.polkachu.com:12690",
+        "provider": "Polkachu"
+      }
     ]
   },
   "explorers": [


### PR DESCRIPTION
Adds the polkachu juno testnet gRPC endpoint to config.

I tested that the gRPC url works, and it also follows the same format as the other Polkachu gRPC urls.