### PR TITLE
Add Kleomedes REST/RPC nodes

### DIFF
--- a/cerberus/chain.json
+++ b/cerberus/chain.json
@@ -116,6 +116,10 @@
       {
         "address": "https://cerberus-rpc.lavenderfive.com/",
         "provider": "Lavender.Five Nodes 🐝"
+      },
+      {
+          "address": "https://cerberus-rpc.kleomed.es",
+          "provider": "Kleomedes"
       }
     ],
     "rest": [
@@ -142,6 +146,10 @@
       {
         "address": "https://cerberus-api.lavenderfive.com/",
         "provider": "Lavender.Five Nodes 🐝"
+      },
+      {
+          "address": "https://cerberus-api.kleomed.es",
+          "provider": "Kleomedes"
       }
     ],
     "grpc": [

--- a/cosmoshub/chain.json
+++ b/cosmoshub/chain.json
@@ -237,6 +237,10 @@
       {
         "address": "https://rpc.cosmos.interbloc.org",
         "provider": "Interbloc"
+      },
+      {
+        "address": "https://atom-rpc.kleomed.es",
+        "provider": "Kleomedes"
       }
     ],
     "rest": [
@@ -283,6 +287,10 @@
       {
         "address": "https://api.cosmos.interbloc.org",
         "provider": "Interbloc"
+      },
+      {
+        "address": "https://atom-api.kleomed.es",
+        "provider": "Kleomedes"
       }
     ],
     "grpc": [

--- a/juno/chain.json
+++ b/juno/chain.json
@@ -145,6 +145,10 @@
       {
         "address": "https://rpc.juno.chaintools.tech/",
         "provider": "ChainTools"
+      },
+      {
+        "address": "https://juno-rpc.kleomed.es",
+        "provider": "Kleomedes"
       }
     ],
     "rest": [
@@ -183,6 +187,10 @@
       {
         "address": "https://juno-api.polkachu.com",
         "provider": "Polkachu"
+      },
+      {
+        "address": "https://juno-api.kleomed.es",
+        "provider": "Kleomedes"
       }
     ],
     "grpc": [

--- a/meme/chain.json
+++ b/meme/chain.json
@@ -103,6 +103,10 @@
       {
         "address": "https://rpc.meme.pupmos.network/",
         "provider": "PUPMØS"
+      },
+      {
+        "address": "https://meme-rpc.kleomed.es",
+        "provider": "Kleomedes"
       }
     ],
     "rest": [
@@ -121,6 +125,10 @@
       {
         "address": "https://api.meme.pupmos.network/",
         "provider": "PUPMØS"
+      },
+      {
+        "address": "https://meme-api.kleomed.es",
+        "provider": "Kleomedes"
       }
     ],
     "grpc": [

--- a/sifchain/chain.json
+++ b/sifchain/chain.json
@@ -85,6 +85,10 @@
       {
         "address": "https://rpc.sifchain.chaintools.tech/",
         "provider": "ChainTools"
+      },
+      {
+        "address": "https://sif-rpc.kleomed.es",
+        "provider": "Kleomedes"
       }
     ],
     "grpc": [
@@ -123,6 +127,10 @@
       {
         "address": "https://sifchain-api.polkachu.com",
         "provider": "Polkachu"
+      },
+      {
+        "address": "https://sif-api.kleomed.es",
+        "provider": "Kleomedes"
       }
     ]
   },


### PR DESCRIPTION
Node definitions added for Cerberus, Cosmos, Juno, Meme, and Sifchain.

This is to fix https://github.com/cosmos/chain-registry/pull/766