### PR TITLE
Fix: gravity bridge assetlist.json pstake exponent

### DIFF
--- a/gravitybridge/assetlist.json
+++ b/gravitybridge/assetlist.json
@@ -36,7 +36,7 @@
           },
           {
             "denom": "pstake",
-            "exponent": 6
+            "exponent": 18
           }
         ],
         "base": "gravity0xfB5c6815cA3AC72Ce9F5006869AE67f18bF77006",


### PR DESCRIPTION
pstake exponent is 18.. 