### PR TITLE
agoric-cosmoshub and agoric-axelar IBC paths

### DIFF
--- a/_IBC/agoric-axelar.json
+++ b/_IBC/agoric-axelar.json
@@ -2,22 +2,22 @@
   "$schema": "../ibc_data.schema.json",
   "chain_1": {
     "chain_name": "agoric",
-    "client_id": "07-tendermint-6",
-    "connection_id": "connection-8"
+    "client_id": "07-tendermint-8",
+    "connection_id": "connection-11"
   },
   "chain_2": {
-    "chain_name": "cosmoshub",
-    "client_id": "07-tendermint-927",
-    "connection_id": "connection-649"
+    "chain_name": "axelar",
+    "client_id": "07-tendermint-68",
+    "connection_id": "connection-50"
   },
   "channels": [
     {
       "chain_1": {
-        "channel_id": "channel-5",
+        "channel_id": "channel-6",
         "port_id": "transfer"
       },
       "chain_2": {
-        "channel_id": "channel-405",
+        "channel_id": "channel-40",
         "port_id": "transfer"
       },
       "ordering": "unordered",


### PR DESCRIPTION
The clients for the agoric-cosmoshub path expired: `07-tendermint-0` and `07-tendermint-898`, respectively. A new path is linked since there are no assets that need to be recovered due to transfers on channels that used those clients.

Additionally, the agoric-axelar path is now linked and added.