### PR TITLE
fix osmosisd version format

### DIFF
--- a/osmosis/chain.json
+++ b/osmosis/chain.json
@@ -37,9 +37,9 @@
   },
   "codebase": {
     "git_repo": "https://github.com/osmosis-labs/osmosis",
-    "recommended_version": "12.1.0",
+    "recommended_version": "v12.1.0",
     "compatible_versions": [
-      "12.1.0"
+      "v12.1.0"
     ],
     "binaries": {
       "linux/amd64": "https://github.com/osmosis-labs/osmosis/releases/download/v12.1.0/osmosisd-12.1.0-linux-amd64?checksum=sha256:44433f93946338b8cb167d9030ebbcfe924294d95d745026ada5dbe8f50d5010",


### PR DESCRIPTION
otther chain.jsons are using the "v" format for version number, see https://github.com/cosmos/chain-registry/blob/master/cosmoshub/chain.json#L29