### PR TITLE
Update agoric-axelar metadata

### DIFF
--- a/_IBC/agoric-axelar.json
+++ b/_IBC/agoric-axelar.json
@@ -2,22 +2,22 @@
   "$schema": "../ibc_data.schema.json",
   "chain_1": {
     "chain_name": "agoric",
-    "client_id": "07-tendermint-8",
-    "connection_id": "connection-11"
+    "client_id": "07-tendermint-11",
+    "connection_id": "connection-14"
   },
   "chain_2": {
     "chain_name": "axelar",
-    "client_id": "07-tendermint-68",
-    "connection_id": "connection-50"
+    "client_id": "07-tendermint-69",
+    "connection_id": "connection-51"
   },
   "channels": [
     {
       "chain_1": {
-        "channel_id": "channel-6",
+        "channel_id": "channel-9",
         "port_id": "transfer"
       },
       "chain_2": {
-        "channel_id": "channel-40",
+        "channel_id": "channel-41",
         "port_id": "transfer"
       },
       "ordering": "unordered",


### PR DESCRIPTION
The existing light clients between Agoric and Axelar were misconfigured so the channels ended up being closed.

This is the updated information.