### PR TITLE
Add Wallets property to chain jsons

### DIFF
--- a/README.md
+++ b/README.md
@@ -217,6 +217,9 @@ A sample `chain.json` includes the following information.
   },
   "keywords" [
     "dex"
+  ],
+  "wallets": [
+    "keplr"
   ]
 }
 ```

--- a/chain.schema.json
+++ b/chain.schema.json
@@ -252,7 +252,92 @@
       "items": {
         "$ref": "#/$defs/explorer"
       }
+    },
+    "wallets": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
     }
+  },
+  "if": {
+    "properties": {
+      "wallets": {
+        "type": "array",
+        "contains": {
+          "type": "string",
+          "enum": [
+            "keplr"
+          ]
+        },
+        "minContains": 1
+      }
+    },
+    "required": [
+      "wallets"
+    ]
+  },
+  "then": {
+    "properties": {
+      "fees": {
+        "type": "object",
+        "properties": {
+          "fee_tokens": {
+            "type": "array",
+            "contains": {
+              "type": "object",
+              "required": [
+                "denom",
+                "low_gas_price",
+                "average_gas_price",
+                "high_gas_price"
+              ]
+            },
+            "minContains": 1
+          }
+        },
+        "required": [
+          "fee_tokens" 
+        ]
+      },
+      "staking": {
+        "type": "object",
+        "properties": {
+          "staking_tokens": {
+            "minContains": 1,
+            "maxContains": 1
+          }
+        },
+        "required": [
+          "staking_tokens" 
+        ]
+      },
+      "apis": {
+        "type": "object",
+        "properties": {
+          "rpc": {
+            "minContains": 1
+          },
+          "rest": {
+            "minContains": 1
+          }
+        }
+      },
+      "codebase": {
+        "required": [
+          "cosmos_sdk_version"
+        ]
+      }
+    },
+    "required": [
+      "chain_id",
+      "bech32_prefix",
+      "slip44",
+      "fees",
+      "staking",
+      "apis",
+      "codebase"
+    ]
   },
   "$defs": {
     "peer": {

--- a/osmosis/chain.json
+++ b/osmosis/chain.json
@@ -425,5 +425,8 @@
   },
   "keywords": [
     "dex"
+  ],
+  "wallets": [
+    "keplr"
   ]
 }


### PR DESCRIPTION
added 
"wallets": [
  "keplr"
],
with some json schema validation in the case that "keplr" is specified--must be able to work with [Keplr's suggest chain feature](https://docs.keplr.app/api/suggest-chain.html).

sample:
    "required": [
      "chain_id",
      "bech32_prefix",
      "slip44",
      "fees",
      "staking",
      "apis",
      "codebase"
    ]
but the requirements go more in-depth, e.g., requiring low, avg, and high gas fee rates, and more.
