### PR TITLE
Update osmosis versions

### DIFF
--- a/osmosis/chain.json
+++ b/osmosis/chain.json
@@ -68,32 +68,32 @@
         "next_version_name": "v5"
       },
       {
-        "name": "v5",
+        "name": "v6",
         "tag": "v6.4.1",
         "height": 2383300,
         "next_version_name": "v7"
       },
       {
-        "name": "v7",
+        "name": "v8",
         "tag": "v8.0.0",
         "height": 3401000,
         "next_version_name": "v9"
       },
       {
-        "name": "v9",
-        "tag": "v10.0.1",
+        "name": "v10",
+        "tag": "v10.1.1",
         "height": 4707300,
         "next_version_name": "v11"
       },
       {
         "name": "v11",
-        "tag": "v11.0.0",
+        "tag": "v11.0.1",
         "height": 5432450,
         "next_version_name": "v12"
       },
       {
         "name": "v12",
-        "tag": "v12.1.0",
+        "tag": "v12.2.0",
         "height": 6246000
       }
     ]

--- a/osmosis/chain.json
+++ b/osmosis/chain.json
@@ -65,19 +65,19 @@
         "name": "v4",
         "tag": "v4.2.0",
         "height": 1314500,
-        "next_version_name": "v5"
+        "next_version_name": "v6"
       },
       {
         "name": "v6",
         "tag": "v6.4.1",
         "height": 2383300,
-        "next_version_name": "v7"
+        "next_version_name": "v8"
       },
       {
         "name": "v8",
         "tag": "v8.0.0",
         "height": 3401000,
-        "next_version_name": "v9"
+        "next_version_name": "v10"
       },
       {
         "name": "v10",


### PR DESCRIPTION
This PR:
- fixes some inconsistencies in the osmosis versions:

```yaml
    "name": "v5",        # wrong
    "name": "v6",        # correct
    "tag": "v6.4.1",
```
 - bumps all major version to the latest patch release

```yaml
    "tag": "v10.0.1",  # wrong
    "tag": "v10.1.1"
```