### PR TITLE
Adding coingecko to Jackal

### DIFF
--- a/jackal/assetlist.json
+++ b/jackal/assetlist.json
@@ -22,7 +22,7 @@
           "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/jackal/images/jkl.png",
           "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/jackal/images/jkl.svg"
         },
-        "coingecko_id": ""
+        "coingecko_id": "jackal-protocol"
       }
     ]
   }


### PR DESCRIPTION
Jackal is now listed on coingecko.

https://www.coingecko.com/en/coins/jackal-protocol

