### PR TITLE
Update outdated genesis URL for FetchHub

### DIFF
--- a/fetchhub/chain.json
+++ b/fetchhub/chain.json
@@ -33,7 +33,7 @@
       "v0.10.5"
     ],
     "genesis": {
-      "genesis_url": "https://storage.googleapis.com/fetch-ai-mainnet-v2-genesis/genesis-fetchhub4.json"
+      "genesis_url": "https://raw.githubusercontent.com/fetchai/genesis-fetchhub/fetchhub-4/fetchhub-4/data/genesis_migrated_5300200.json"
     }
   },
   "peers": {


### PR DESCRIPTION
Correct the genesis URL in the configuration for Fetchhub to match the version in the official Fetch.ai docs:

https://docs.fetch.ai/ledger_v2/live-networks/#mainnet

