### PR TITLE
Update Kleomedes domains

### DIFF
--- a/cerberus/chain.json
+++ b/cerberus/chain.json
@@ -137,7 +137,7 @@
         "provider": "Lavender.Five Nodes 🐝"
       },
       {
-        "address": "https://cerberus-rpc.kleomed.es",
+        "address": "https://cerberus-rpc.kleomedes.network",
         "provider": "Kleomedes"
       },
       {
@@ -167,7 +167,7 @@
         "provider": "Lavender.Five Nodes 🐝"
       },
       {
-        "address": "https://cerberus-api.kleomed.es",
+        "address": "https://cerberus-api.kleomedes.network",
         "provider": "Kleomedes"
       },
       {

--- a/chihuahua/chain.json
+++ b/chihuahua/chain.json
@@ -133,7 +133,7 @@
         "provider": "BlockHunters \uD83C\uDFAF"
       },
       {
-        "address": "https://chihuahua-rpc.kleomed.es",
+        "address": "https://chihuahua-rpc.kleomedes.network",
         "provider": "Kleomedes"
       }
     ],
@@ -163,7 +163,7 @@
         "provider": "BlockHunters \uD83C\uDFAF"
       },
       {
-        "address": "https://chihuahua-api.kleomed.es",
+        "address": "https://chihuahua-api.kleomedes.network",
         "provider": "Kleomedes"
       }
     ],

--- a/cosmoshub/chain.json
+++ b/cosmoshub/chain.json
@@ -255,13 +255,13 @@
         "provider": "Silk Nodes"
       },
       {
-        "address": "https://atom-rpc.kleomed.es",
+        "address": "https://atom-rpc.kleomedes.network",
         "provider": "Kleomedes"
       },
       {
         "address": "https://rpc-cosmoshub.architectnodes.com",
         "provider": "Architect Nodes"
-      },      
+      },
       {
         "address": "https://rpc.cosmos.dragonstake.io",
         "provider": "DragonStake"
@@ -329,7 +329,7 @@
         "provider": "Silk Nodes"
       },
       {
-        "address": "https://atom-api.kleomed.es",
+        "address": "https://atom-api.kleomedes.network",
         "provider": "Kleomedes"
       },
       {

--- a/fetchhub/chain.json
+++ b/fetchhub/chain.json
@@ -96,7 +96,7 @@
         "provider": "Polkachu"
       },
       {
-        "address": "https://fetchai-rpc.kleomed.es",
+        "address": "https://fetchai-rpc.kleomedes.network",
         "provider": "Kleomedes"
       }
     ],
@@ -114,7 +114,7 @@
         "provider": "Polkachu"
       },
       {
-        "address": "https://fetchai-api.kleomed.es",
+        "address": "https://fetchai-api.kleomedes.network",
         "provider": "Kleomedes"
       }
     ],

--- a/jackal/chain.json
+++ b/jackal/chain.json
@@ -110,7 +110,7 @@
         "provider": "AgoraNodes"
       },
       {
-        "address": "https://jackal-rpc.kleomed.es",
+        "address": "https://jackal-rpc.kleomedes.network",
         "provider": "Kleomedes"
       }
     ],
@@ -144,7 +144,7 @@
         "provider": "AgoraNodes"
       },
       {
-        "address": "https://jackal-api.kleomed.es",
+        "address": "https://jackal-api.kleomedes.network",
         "provider": "Kleomedes"
       }
     ],

--- a/juno/chain.json
+++ b/juno/chain.json
@@ -162,7 +162,7 @@
         "provider": "Silk Nodes"
       },
       {
-        "address": "https://juno-rpc.kleomed.es",
+        "address": "https://juno-rpc.kleomedes.network",
         "provider": "Kleomedes"
       },
       {
@@ -232,7 +232,7 @@
         "provider": "Silk Nodes"
       },
       {
-        "address": "https://juno-api.kleomed.es",
+        "address": "https://juno-api.kleomedes.network",
         "provider": "Kleomedes"
       },
       {

--- a/kujira/chain.json
+++ b/kujira/chain.json
@@ -118,7 +118,7 @@
         "provider": "kjnodes"
       },
       {
-        "address": "https://kuji-rpc.kleomed.es",
+        "address": "https://kuji-rpc.kleomedes.network",
         "provider": "Kleomedes"
       }
     ],
@@ -194,7 +194,7 @@
         "provider": "kjnodes"
       },
       {
-        "address": "https://kuji-api.kleomed.es",
+        "address": "https://kuji-api.kleomedes.network",
         "provider": "Kleomedes"
       }
     ]

--- a/meme/chain.json
+++ b/meme/chain.json
@@ -101,7 +101,7 @@
         "provider": "PUPMØS"
       },
       {
-        "address": "https://meme-rpc.kleomed.es",
+        "address": "https://meme-rpc.kleomedes.network",
         "provider": "Kleomedes"
       },
       {
@@ -131,7 +131,7 @@
         "provider": "PUPMØS"
       },
       {
-        "address": "https://meme-api.kleomed.es",
+        "address": "https://meme-api.kleomedes.network",
         "provider": "Kleomedes"
       }
     ],

--- a/persistence/chain.json
+++ b/persistence/chain.json
@@ -146,7 +146,7 @@
         "provider": "Polkachu"
       },
       {
-        "address": "https://persistence-rpc.kleomed.es",
+        "address": "https://persistence-rpc.kleomedes.network",
         "provider": "Kleomedes"
       }
     ],
@@ -168,7 +168,7 @@
         "provider": "Polkachu"
       },
       {
-        "address": "https://persistence-api.kleomed.es",
+        "address": "https://persistence-api.kleomedes.network",
         "provider": "Kleomedes"
       }
     ],

--- a/rebus/chain.json
+++ b/rebus/chain.json
@@ -137,7 +137,7 @@
         "provider": "BlockHunters \uD83C\uDFAF"
       },
       {
-        "address": "https://rebus-rpc.kleomed.es",
+        "address": "https://rebus-rpc.kleomedes.network",
         "provider": "Kleomedes"
       }
     ],
@@ -187,7 +187,7 @@
         "provider": "BlockHunters \uD83C\uDFAF"
       },
       {
-        "address": "https://rebus-api.kleomed.es",
+        "address": "https://rebus-api.kleomedes.network",
         "provider": "Kleomedes"
       }
     ],

--- a/sifchain/chain.json
+++ b/sifchain/chain.json
@@ -104,7 +104,7 @@
         "provider": "ChainTools"
       },
       {
-        "address": "https://sif-rpc.kleomed.es",
+        "address": "https://sif-rpc.kleomedes.network",
         "provider": "Kleomedes"
       },
       {
@@ -166,7 +166,7 @@
         "provider": "Polkachu"
       },
       {
-        "address": "https://sif-api.kleomed.es",
+        "address": "https://sif-api.kleomedes.network",
         "provider": "Kleomedes"
       },
       {

--- a/teritori/chain.json
+++ b/teritori/chain.json
@@ -123,7 +123,7 @@
         "provider": "BlockHunters \uD83C\uDFAF"
       },
       {
-        "address": "https://teritori-rpc.kleomed.es",
+        "address": "https://teritori-rpc.kleomedes.network",
         "provider": "Kleomedes"
       }
     ],
@@ -177,7 +177,7 @@
         "provider": "BlockHunters \uD83C\uDFAF"
       },
       {
-        "address": "https://teritori-api.kleomed.es",
+        "address": "https://teritori-api.kleomedes.network",
         "provider": "Kleomedes"
       }
     ],


### PR DESCRIPTION
Update Kleomedes servers to use new `kleomedes.network` domains, rather than `kleomed.es`.