### PR TITLE
chore(names): cleans up explorer names

### DIFF
--- a/arkh/chain.json
+++ b/arkh/chain.json
@@ -59,7 +59,7 @@
   },
   "explorers": [
     {
-      "kind": "Ping",
+      "kind": "ping.pub",
       "url": "https://testnet.ping.pub/arkh",
       "tx_page": "https://testnet.ping.pub/arkh/tx/${txHash}"
     }

--- a/beezee/chain.json
+++ b/beezee/chain.json
@@ -106,12 +106,12 @@
   },
   "explorers": [
     {
-      "kind": "Ping",
+      "kind": "ping.pub",
       "url": "https://explorers.vidulum.app/beezee",
       "tx_page": "https://explorers.vidulum.app/beezee/tx/${txHash}"
     },
     {
-      "kind": "Ping",
+      "kind": "ping.pub",
       "url": "https://explorer.erialos.me/beezee",
       "tx_page": "https://explorer.erialos.me/beezee/tx/${txHash}"
     }

--- a/bitcanna/chain.json
+++ b/bitcanna/chain.json
@@ -195,7 +195,7 @@
       "tx_page": "https://cosmos-explorer.bitcanna.io/transactions/${txHash}"
     },
     {
-      "kind": "ping-pub",
+      "kind": "ping.pub",
       "url": "https://ping.pub/bitcanna",
       "tx_page": "https://ping.pub/bitcanna/tx/${txHash}"
     },

--- a/bitsong/chain.json
+++ b/bitsong/chain.json
@@ -222,7 +222,7 @@
       "tx_page": "https://ezstaking.tools/bitsong/txs/${txHash}"
     },
     {
-      "kind": "ping-pub",
+      "kind": "ping.pub",
       "url": "https://ping.pub/bitsong",
       "tx_page": "https://ping.pub/bitsong/tx/${txHash}"
     },

--- a/bitsong/chain.json
+++ b/bitsong/chain.json
@@ -232,7 +232,7 @@
       "tx_page": "https://www.mintscan.io/bitsong/txs/${txHash}"
     },
     {
-      "kind": "big-dipper",
+      "kind": "bigdipper",
       "url": "https://explorebitsong.com",
       "tx_page": "https://explorebitsong.com/transactions/${txHash}"
     },

--- a/bostrom/chain.json
+++ b/bostrom/chain.json
@@ -113,7 +113,7 @@
       "tx_page": "https://cyb.ai/network/bostrom/tx/${txHash}"
     },
     {
-      "kind": "ping-pub",
+      "kind": "ping.pub",
       "url": "https://ping.pub/bostrom",
       "tx_page": "https://ping.pub/bostrom/tx/${txHash}"
     },

--- a/cerberus/chain.json
+++ b/cerberus/chain.json
@@ -192,7 +192,7 @@
   },
   "explorers": [
     {
-      "kind": "SkyNet",
+      "kind": "skynetexplorers",
       "url": "https://skynetexplorers.com/cerberus",
       "tx_page": "https://skynetexplorers.com/cerberus/tx/${txHash}"
     },

--- a/cheqd/chain.json
+++ b/cheqd/chain.json
@@ -162,12 +162,12 @@
       "tx_page": "https://explorer.cheqd.io/transactions/${txHash}"
     },
     {
-      "kind": "ping-pub",
+      "kind": "ping.pub",
       "url": "https://ping.pub/cheqd",
       "tx_page": "https://ping.pub/cheqd/tx/${txHash}"
     },
     {
-      "kind": "atomscan.com",
+      "kind": "atomscan",
       "url": "https://atomscan.com/cheqd",
       "tx_page": "https://atomscan.com/cheqd/transactions/${txHash}",
       "account_page": "https://atomscan.com/cheqd/accounts/${accountAddress}"

--- a/comdex/chain.json
+++ b/comdex/chain.json
@@ -215,7 +215,7 @@
       "tx_page": "https://comdex.aneka.io/txs/${txHash}"
     },
     {
-      "kind": "ping-pub",
+      "kind": "ping.pub",
       "url": "https://ping.pub/comdex",
       "tx_page": "https://ping.pub/comdex/tx/${txHash}"
     },

--- a/cosmoshub/chain.json
+++ b/cosmoshub/chain.json
@@ -412,7 +412,7 @@
       "tx_page": "https://www.mintscan.io/cosmos/txs/${txHash}"
     },
     {
-      "kind": "ping-pub",
+      "kind": "ping.pub",
       "url": "https://ping.pub/cosmos",
       "tx_page": "https://ping.pub/cosmos/tx/${txHash}"
     },

--- a/cronos/chain.json
+++ b/cronos/chain.json
@@ -116,7 +116,7 @@
       "tx_page": "https://cronoscan.com/tx/${txHash}"
     },
     {
-      "kind": "crypto-org",
+      "kind": "crypto.org",
       "url": "https://cronos.org/explorer",
       "tx_page": "https://cronos.org/explorer/tx/${txHash}"
     }

--- a/cryptoorgchain/chain.json
+++ b/cryptoorgchain/chain.json
@@ -169,7 +169,7 @@
       "tx_page": "https://crypto.org/explorer/tx/${txHash}"
     },
     {
-      "kind": "ping-pub",
+      "kind": "ping.pub",
       "url": "https://ping.pub/crypto-com-chain",
       "tx_page": "https://ping.pub/crypto-com-chain/tx/${txHash}"
     },

--- a/cudos/chain.json
+++ b/cudos/chain.json
@@ -100,7 +100,7 @@
   },
   "explorers": [
     {
-      "kind": "big-dipper-v2",
+      "kind": "bigdipper",
       "url": "https://explorer.cudos.org/",
       "tx_page": "https://explorer.cudos.org/transactions/${txHash}",
       "account_page": "https://explorer.cudos.org/accounts/${accountAddress}"

--- a/desmos/chain.json
+++ b/desmos/chain.json
@@ -146,7 +146,7 @@
       "tx_page": "https://ezstaking.tools/desmos/txs/${txHash}"
     },
     {
-      "kind": "big-dipper",
+      "kind": "bigdipper",
       "url": "https://explorer.desmos.network",
       "tx_page": "https://explorer.desmos.network/transactions/${txHash}"
     },

--- a/desmos/chain.json
+++ b/desmos/chain.json
@@ -157,7 +157,7 @@
       "account_page": "https://www.mintscan.io/desmos/account/${accountAddress}"
     },
     {
-      "kind": "ping-pub",
+      "kind": "ping.pub",
       "url": "https://ping.pub/desmos",
       "tx_page": "https://ping.pub/desmos/tx/${txHash}"
     },

--- a/echelon/chain.json
+++ b/echelon/chain.json
@@ -203,7 +203,7 @@
       "tx_page": "https://scout.ech.network/tx/${txHash}"
     },
     {
-      "kind": "ping-pub",
+      "kind": "ping.pub",
       "url": "https://ping.pub/echelon",
       "tx_page": "https://ping.pub/echelon/tx/${txHash}"
     },

--- a/emoney/chain.json
+++ b/emoney/chain.json
@@ -207,7 +207,7 @@
       "tx_page": "https://www.mintscan.io/emoney/txs/${txHash}"
     },
     {
-      "kind": "ping-pub",
+      "kind": "ping.pub",
       "url": "https://ping.pub/e-money",
       "tx_page": "https://ping.pub/e-money/tx/${txHash}"
     },

--- a/evmos/chain.json
+++ b/evmos/chain.json
@@ -436,7 +436,7 @@
       "tx_page": "https://evm.evmos.org/tx/${txHash}"
     },
     {
-      "kind": "ping-pub",
+      "kind": "ping.pub",
       "url": "https://ping.pub/evmos",
       "tx_page": "https://ping.pub/evmos/tx/${txHash}"
     },

--- a/firmachain/chain.json
+++ b/firmachain/chain.json
@@ -98,7 +98,7 @@
       "tx_page": "https://ezstaking.tools/firmachain/txs/${txHash}"
     },
     {
-      "kind": "big-dipper",
+      "kind": "bigdipper",
       "url": "https://explorer.firmachain.dev",
       "tx_page": "https://explorer.firmachain.dev/transactions/${txHash}"
     },

--- a/galaxy/chain.json
+++ b/galaxy/chain.json
@@ -196,7 +196,7 @@
   },
   "explorers": [
     {
-      "kind": "ping-pub",
+      "kind": "ping.pub",
       "url": "https://explorer.postcapitalist.io/Galaxy",
       "tx_page": "https://explorer.postcapitalist.io/Galaxy/tx/${txHash}"
     }

--- a/genesisl1/chain.json
+++ b/genesisl1/chain.json
@@ -77,7 +77,7 @@
   },
   "explorers": [
     {
-      "kind": "ping-pub",
+      "kind": "ping.pub",
       "url": "https://ping.pub/genesisL1",
       "tx_page": "https://ping.pub/genesisL1/tx/${txHash}"
     },

--- a/injective/chain.json
+++ b/injective/chain.json
@@ -143,7 +143,7 @@
       "tx_page": "https://explorer.injective.network/transaction/${txHash}"
     },
     {
-      "kind": "ping-pub",
+      "kind": "ping.pub",
       "url": "https://ping.pub/injective",
       "tx_page": "https://ping.pub/injective/tx/${txHash}"
     },

--- a/irisnet/chain.json
+++ b/irisnet/chain.json
@@ -140,7 +140,7 @@
       "tx_page": "https://www.mintscan.io/iris/txs/${txHash}"
     },
     {
-      "kind": "ping-pub",
+      "kind": "ping.pub",
       "url": "https://ping.pub/iris-network",
       "tx_page": "https://ping.pub/iris-network/tx/${txHash}"
     },

--- a/jackal/chain.json
+++ b/jackal/chain.json
@@ -189,7 +189,7 @@
   },
   "explorers": [
     {
-      "kind": "ping-pub",
+      "kind": "ping.pub",
       "url": "https://ping.pub/jackal",
       "tx_page": "https://ping.pub/jackal/tx/${txHash}"
     },

--- a/kava/chain.json
+++ b/kava/chain.json
@@ -154,7 +154,7 @@
       "tx_page": "https://www.mintscan.io/kava/txs/${txHash}"
     },
     {
-      "kind": "ping-pub",
+      "kind": "ping.pub",
       "url": "https://ping.pub/kava",
       "tx_page": "https://ping.pub/kava/tx/${txHash}"
     },

--- a/kichain/chain.json
+++ b/kichain/chain.json
@@ -186,7 +186,7 @@
       "tx_page": "https://www.mintscan.io/ki-chain/txs/${txHash}"
     },
     {
-      "kind": "ping-pub",
+      "kind": "ping.pub",
       "url": "https://ping.pub/kichain",
       "tx_page": "https://ping.pub/kichain/tx/${txHash}"
     },

--- a/likecoin/chain.json
+++ b/likecoin/chain.json
@@ -135,7 +135,7 @@
       "url": "https://stake.like.co/"
     },
     {
-      "kind": "ping-pub",
+      "kind": "ping.pub",
       "url": "https://ping.pub/likecoin",
       "tx_page": "https://ping.pub/likecoin/tx/${txHash}"
     },

--- a/lumenx/chain.json
+++ b/lumenx/chain.json
@@ -84,7 +84,7 @@
   },
   "explorers": [
     {
-      "kind": "ping-pub",
+      "kind": "ping.pub",
       "url": "https://scope.helios-1.lumenex.io/lumenx",
       "tx_page": "https://scope.helios-1.lumenex.io/lumenx/tx/${txHash}"
     }

--- a/lumnetwork/chain.json
+++ b/lumnetwork/chain.json
@@ -175,7 +175,7 @@
       "tx_page": "https://explorer.lum.network/txs/${txHash}"
     },
     {
-      "kind": "ping-pub",
+      "kind": "ping.pub",
       "url": "https://ping.pub/lum-network",
       "tx_page": "https://ping.pub/lum-network/tx/${txHash}"
     },

--- a/meme/chain.json
+++ b/meme/chain.json
@@ -165,7 +165,7 @@
       "tx_page": "https://atomscan.com/meme/transactions/${txHash}"
     },
     {
-      "kind": "Brochain Explorer",
+      "kind": "Brochain",
       "url": "https://explorer.brocha.in/meme",
       "tx_page": "https://explorer.brocha.in/meme/tx/${txHash}"
     }

--- a/meme/chain.json
+++ b/meme/chain.json
@@ -149,7 +149,7 @@
       "tx_page": "https://ping.pub/meme/tx/${txHash}"
     },
     {
-      "kind": "atomscan.com",
+      "kind": "atomscan",
       "url": "https://atomscan.com/meme",
       "tx_page": "https://atomscan.com/meme/transactions/${txHash}",
       "account_page": "https://atomscan.com/meme/accounts/${accountAddress}"

--- a/microtick/chain.json
+++ b/microtick/chain.json
@@ -19,7 +19,7 @@
   },
   "explorers": [
     {
-      "kind": "ping-pub",
+      "kind": "ping.pub",
       "url": "https://ping.pub/microtick",
       "tx_page": "https://ping.pub/microtick/tx/${txHash}"
     }

--- a/persistence/chain.json
+++ b/persistence/chain.json
@@ -199,7 +199,7 @@
       "tx_page": "https://www.mintscan.io/persistence/txs/${txHash}"
     },
     {
-      "kind": "ping-pub",
+      "kind": "ping.pub",
       "url": "https://ping.pub/persistence",
       "tx_page": "https://ping.pub/persistence/tx/${txHash}"
     },

--- a/point/chain.json
+++ b/point/chain.json
@@ -108,7 +108,7 @@
       "tx_page": "https://explorer.pointnetwork.io/tx/${txHash}"
     },
     {
-      "kind": "ping-pub",
+      "kind": "ping.pub",
       "url": "https://cosmos.pointnetwork.io/",
       "tx_page": "https://cosmos.pointnetwork.io/point/tx/${txHash}"
     }

--- a/provenance/chain.json
+++ b/provenance/chain.json
@@ -107,7 +107,7 @@
       "tx_page": "https://hubble.figment.io/provenance/chains/pio-mainnet-1/${block}/transactions/${txHash}"
     },
     {
-      "kind": "ping-pub",
+      "kind": "ping.pub",
       "url": "https://ping.pub/provenance",
       "tx_page": "https://ping.pub/provenance/tx/${txHash}"
     },

--- a/rebus/chain.json
+++ b/rebus/chain.json
@@ -229,7 +229,7 @@
       "tx_page": "https://rebus.explorers.guru/transaction/${txHash}"
     },
     {
-      "kind": "nodestake",
+      "kind": "NodeStake",
       "url": "https://explorer.nodestake.top/rebus",
       "tx_page": "https://explorer.nodestake.top/rebus/tx/${txHash}"
     },
@@ -239,7 +239,7 @@
       "tx_page": "https://exp.nodeist.net/M-Rebus/tx/${txHash}"
     },
     {
-      "kind": "Brochain Explorer",
+      "kind": "Brochain",
       "url": "https://explorer.brocha.in/rebus",
       "tx_page": "https://explorer.brocha.in/rebus/tx/${txHash}"
     },

--- a/regen/chain.json
+++ b/regen/chain.json
@@ -132,7 +132,7 @@
       "tx_page": "https://www.mintscan.io/regen/txs/${txHash}"
     },
     {
-      "kind": "ping-pub",
+      "kind": "ping.pub",
       "url": "https://ping.pub/regen",
       "tx_page": "https://ping.pub/regen/tx/${txHash}"
     },

--- a/rizon/chain.json
+++ b/rizon/chain.json
@@ -120,7 +120,7 @@
       "tx_page": "https://www.mintscan.io/rizon/txs/${txHash}"
     },
     {
-      "kind": "ping-pub",
+      "kind": "ping.pub",
       "url": "https://ping.pub/rizon",
       "tx_page": "https://ping.pub/rizon/tx/${txHash}"
     },

--- a/secretnetwork/chain.json
+++ b/secretnetwork/chain.json
@@ -160,7 +160,7 @@
       "tx_page": "https://secretnodes.com/secret/chains/secret-4/transactions/${txHash}"
     },
     {
-      "kind": "ping-pub",
+      "kind": "ping.pub",
       "url": "https://ping.pub/secret",
       "tx_page": "https://ping.pub/secret/tx/${txHash}"
     },

--- a/sifchain/chain.json
+++ b/sifchain/chain.json
@@ -190,7 +190,7 @@
       "tx_page": "https://ezstaking.tools/sifchain/txs/${txHash}"
     },
     {
-      "kind": "ping-pub",
+      "kind": "ping.pub",
       "url": "https://ping.pub/sifchain",
       "tx_page": "https://ping.pub/sifchain/tx/${txHash}"
     },

--- a/stargaze/chain.json
+++ b/stargaze/chain.json
@@ -280,7 +280,7 @@
       "tx_page": "https://www.mintscan.io/stargaze/txs/${txHash}"
     },
     {
-      "kind": "ping-pub",
+      "kind": "ping.pub",
       "url": "https://ping.pub/stargaze",
       "tx_page": "https://ping.pub/stargaze/tx/${txHash}"
     },

--- a/starname/chain.json
+++ b/starname/chain.json
@@ -106,7 +106,7 @@
       "tx_page": "https://www.mintscan.io/starname/txs/${txHash}"
     },
     {
-      "kind": "ping-pub",
+      "kind": "ping.pub",
       "url": "https://ping.pub/starname",
       "tx_page": "https://ping.pub/starname/tx/${txHash}"
     },

--- a/terra/chain.json
+++ b/terra/chain.json
@@ -107,7 +107,7 @@
   },
   "explorers": [
     {
-      "kind": "ping-pub",
+      "kind": "ping.pub",
       "url": "https://ping.pub/terra-luna",
       "tx_page": "https://ping.pub/terra-luna/tx/${txHash}"
     },

--- a/testnets/cudostestnet/chain.json
+++ b/testnets/cudostestnet/chain.json
@@ -128,7 +128,7 @@
   },
   "explorers": [
     {
-      "kind": "big-dipper-testnet",
+      "kind": "bigdipper-testnet",
       "url": "https://explorer.testnet.cudos.org/",
       "tx_page": "https://explorer.testnet.cudos.org/transactions/${txHash}",
       "account_page": "https://explorer.testnet.cudos.org/accounts/${accountAddress}"

--- a/testnets/jackaltestnet/chain.json
+++ b/testnets/jackaltestnet/chain.json
@@ -153,7 +153,7 @@
   },
   "explorers": [
     {
-      "kind": "ping-pub",
+      "kind": "ping.pub",
       "url": "https://ping.pub/jackal",
       "tx_page": "https://ping.pub/jackal/tx/${txHash}"
     }

--- a/testnets/pulsar/chain.json
+++ b/testnets/pulsar/chain.json
@@ -96,7 +96,7 @@
       "tx_page": "https://secretnodes.com/secret/chains/pulsar-2/transactions/${txHash}"
     },
     {
-      "kind": "ping-pub",
+      "kind": "ping.pub",
       "url": "https://testnet.ping.pub/secret",
       "tx_page": "https://testnet.ping.pub/secret/tx/${txHash}"
     }

--- a/testnets/stargazetestnet/chain.json
+++ b/testnets/stargazetestnet/chain.json
@@ -66,7 +66,7 @@
   },
   "explorers": [
     {
-      "kind": "ping-pub",
+      "kind": "ping.pub",
       "url": "https://testnet-explorer.publicawesome.dev/stargaze",
       "tx_page": "https://testnet-explorer.publicawesome.dev/stargaze/tx/${txHash}"
     }

--- a/testnets/stateset/chain.json
+++ b/testnets/stateset/chain.json
@@ -62,7 +62,7 @@
   },
   "explorers": [
     {
-      "kind": "bigdipper2.0",
+      "kind": "bigdipper",
       "url": "https://explore.stateset.zone",
       "tx_page": "https://explore.stateset.zone/transactions/${txHash}"
     }

--- a/umee/chain.json
+++ b/umee/chain.json
@@ -107,7 +107,7 @@
       "tx_page": "https://www.mintscan.io/umee/txs/${txHash}"
     },
     {
-      "kind": "ping-pub",
+      "kind": "ping.pub",
       "url": "https://ping.pub/umee",
       "tx_page": "https://ping.pub/umee/tx/${txHash}"
     },

--- a/vidulum/chain.json
+++ b/vidulum/chain.json
@@ -120,12 +120,12 @@
   },
   "explorers": [
     {
-      "kind": "Ping",
+      "kind": "ping.pub",
       "url": "https://explorers.vidulum.app/vidulum",
       "tx_page": "https://explorers.vidulum.app/vidulum/tx/${txHash}"
     },
     {
-      "kind": "Ping",
+      "kind": "ping.pub",
       "url": "https://ping.pub/vidulum",
       "tx_page": "https://ping.pub/vidulum/tx/${txHash}"
     },


### PR DESCRIPTION
renames the following to the more popular occurrence of itself
```
- ping-pub -> ping.pub
- big-dipper -> bigdipper 
- SkyNet -> skynetexplorers
- crypto-org -> crypto.org
```