### PR TITLE
update persistence versions and coin-type.

### DIFF
--- a/persistence/chain.json
+++ b/persistence/chain.json
@@ -12,7 +12,7 @@
   "key_algos": [
     "secp256k1"
   ],
-  "slip44": 750,
+  "slip44": 118,
   "fees": {
     "fee_tokens": [
       {
@@ -30,12 +30,12 @@
   },
   "codebase": {
     "git_repo": "https://github.com/persistenceOne/persistenceCore",
-    "recommended_version": "v0.2.3",
+    "recommended_version": "v5.0.0",
     "compatible_versions": [
-      "v0.2.3"
+      "v5.0.0"
     ],
     "binaries": {
-      "linux/amd64": "https://github.com/persistenceOne/persistenceCore/releases/download/v0.2.3/persistenceCore-linux-amd64.tar.gz"
+      "linux/amd64": "https://github.com/persistenceOne/persistenceCore/releases/download/v5.0.0/persistenceCore-linux-amd64.tar.gz"
     },
     "genesis": {
       "genesis_url": "https://raw.githubusercontent.com/persistenceOne/genesisTransactions/master/core-1/final_genesis.json"
@@ -188,11 +188,6 @@
     ]
   },
   "explorers": [
-    {
-      "kind": "proprietary",
-      "url": "https://explorer.persistence.one",
-      "tx_page": "https://explorer.persistence.one/transactions/${txHash}"
-    },
     {
       "kind": "mintscan",
       "url": "https://www.mintscan.io/persistence",


### PR DESCRIPTION
Persistence moved to use 118 coin-type
persistence will use v5.0.0 from 24th Nov. 
removed persistence owned explorer.