### PR TITLE
Upgrade Terra2 to v2.2.0

### DIFF
--- a/terra2/chain.json
+++ b/terra2/chain.json
@@ -30,13 +30,13 @@
   },
   "codebase": {
     "git_repo": "https://github.com/terra-money/core/",
-    "recommended_version": "v2.1.2",
+    "recommended_version": "v2.2.0",
     "compatible_versions": [
-      "v2.1.2"
+      "v2.2.0"
     ],
     "binaries": {
-      "linux/amd64": "https://github.com/terra-money/core/releases/download/v2.1.2/terra_2.1.2_Linux_x86_64.tar.gz",
-      "darwin/amd64": "https://github.com/terra-money/core/releases/download/v2.1.2/terra_2.1.2_Darwin_x86_64.tar.gz"
+      "linux/amd64": "https://github.com/terra-money/core/releases/download/v2.2.0/terra_2.2.0_Linux_x86_64.tar.gz",
+      "darwin/amd64": "https://github.com/terra-money/core/releases/download/v2.2.0/terra_2.2.0_Darwin_x86_64.tar.gz"
     },
     "genesis": {
       "genesis_url": "https://phoenix-genesis.s3.us-west-1.amazonaws.com/genesis.json"


### PR DESCRIPTION
tag: https://github.com/terra-money/core/releases/tag/v2.2.0
expected date: December 21, 2022 11:00 AM
block: 2979805