### PR TITLE
Upgrade Secret to v1.6

### DIFF
--- a/secretnetwork/chain.json
+++ b/secretnetwork/chain.json
@@ -30,9 +30,9 @@
   },
   "codebase": {
     "git_repo": "https://github.com/scrtlabs/SecretNetwork",
-    "recommended_version": "v1.5",
+    "recommended_version": "v1.6",
     "binaries": {
-      "linux/amd64": "https://github.com/scrtlabs/SecretNetwork/releases/download/v1.5/secretnetwork_1.5_mainnet_goleveldb_amd64.deb"
+      "linux/amd64": "https://github.com/scrtlabs/SecretNetwork/releases/download/v1.6/secretnetwork_1.6_mainnet_goleveldb_amd64.deb"
     },
     "compatible_versions": [
       "v1.5"
@@ -53,17 +53,23 @@
         "height": 3343000,
         "next_version_name": "v1.4"
       },
-                {
+      {
         "name": "v1.4",
         "tag": "v1.4",
         "height": 5309200,
         "next_version_name": "v1.5"
       },
-                {
+      {
         "name": "v1.5",
         "tag": "v1.5",
         "height": 5941700,
         "next_version_name": "v1.6"
+      },
+      {
+        "name": "v1.6",
+        "tag": "v1.6",
+        "height": 6537300,
+        "next_version_name": "v1.7"
       }
     ]
   },


### PR DESCRIPTION
block: https://www.mintscan.io/secret/blocks/6537300
tag: https://github.com/scrtlabs/SecretNetwork/releases/tag/v1.6.0
date: `Tue Dec 13 2022 00:48:41 GMT-0800`