### PR TITLE
fix(crescent): correct coingecko_id for ubcre token

### DIFF
--- a/crescent/assetlist.json
+++ b/crescent/assetlist.json
@@ -48,7 +48,7 @@
         "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/crescent/images/bcre.png",
         "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/crescent/images/bcre.svg"
       },
-      "coingecko_id": "crescent-network"
+      "coingecko_id": "liquid-staking-crescent"
     }
   ]
 }


### PR DESCRIPTION
#1108 