### PR TITLE
fix REST endpoint address

### DIFF
--- a/quicksilver/chain.json
+++ b/quicksilver/chain.json
@@ -55,7 +55,7 @@
         "provider": "Quicksilver"
       },
       {
-        "address": "https://api-terra-ia.cosmosia.notional.ventures:443",
+        "address": "https://api-quicksilver-ia.cosmosia.notional.ventures:443",
         "provider": "Notional"
       }
     ],


### PR DESCRIPTION
` https://api-terra-ia.cosmosia.notional.ventures/cosmos/base/tendermint/v1beta1/node_info `  return ` "network": "columbus-5",` 

` https://api-quicksilver-ia.cosmosia.notional.ventures/cosmos/base/tendermint/v1beta1/node_info` return ` "network": "quicksilver-1",`