### PR TITLE
Update chain.json to include extra RPC/REST/PEERS

### DIFF
--- a/persistence/chain.json
+++ b/persistence/chain.json
@@ -124,6 +124,11 @@
         "id": "ebc272824924ea1a27ea3183dd0b9ba713494f83",
         "address": "persistence.mainnet.peer.autostake.net:26896",
         "provider": "AutoStake.net"
+      },
+      {
+        "id": "137818b03a705cf86622b4d97a074091f2f22589",
+        "address": "185.225.233.30:26756",
+        "provider": "Cosmonaut Stakes"
       }
     ]
   },
@@ -152,6 +157,10 @@
       {
         "address": "https://rpc-persistence.architectnodes.com",
         "provider": "Architect Nodes"
+      },
+      {
+        "address": "https://persistence-mainnet-rpc.cosmonautstakes.com",
+        "provider": "Cosmonaut Stakes"
       }
     ],
     "rest": [
@@ -178,6 +187,10 @@
       {
         "address": "https://rest-persistence.architectnodes.com",
         "provider": "Architect Nodes"
+      },
+      {
+        "address": "https://persistence-mainnet-rest.cosmonautstakes.com",
+        "provider": "Cosmonaut Stakes"
       }
     ],
     "grpc": [


### PR DESCRIPTION
Update Persistence's `chain.json` file to include Cosmonaut Stakes' RPC / REST endpoints and persistent peer.