### PR TITLE
Add bech32 config to chain schema

### DIFF
--- a/chain.schema.json
+++ b/chain.schema.json
@@ -47,13 +47,12 @@
       ]
     },
     "bech32_prefix": {
-      "type": "string"
+      "type": "string",
+      "description": "The default prefix for the human-readable part that identifies the coin type. Must be registered with SLIP-0173. E.g., 'cosmos'"
     },
     "bech32_config": {
       "type": "object",
-      "required": [
-        "bech32PrefixAccAddr"
-      ],
+      "description": "Used to override the bech32_prefix for specific uses.",
       "properties": {
         "bech32PrefixAccAddr": {
           "type": "string",
@@ -79,7 +78,8 @@
           "type": "string",
           "description": "e.g., 'cosmosvalconspub'"
         },
-        "additionalProperties": false
+        "additionalProperties": false,
+        "minProperties": 1
       }
     },
     "daemon_name": {

--- a/chain.schema.json
+++ b/chain.schema.json
@@ -50,6 +50,7 @@
       "type": "string"
     },
     "bech32_config": {
+      "type": "object",
       "required": [
         "bech32PrefixAccAddr"
       ],

--- a/chain.schema.json
+++ b/chain.schema.json
@@ -48,7 +48,7 @@
     },
     "bech32_prefix": {
       "type": "string",
-      "description": "The default prefix for the human-readable part that identifies the coin type. Must be registered with SLIP-0173. E.g., 'cosmos'"
+      "description": "The default prefix for the human-readable part of addresses that identifies the coin type. Must be registered with SLIP-0173. E.g., 'cosmos'"
     },
     "bech32_config": {
       "type": "object",

--- a/chain.schema.json
+++ b/chain.schema.json
@@ -49,6 +49,38 @@
     "bech32_prefix": {
       "type": "string"
     },
+    "bech32_config": {
+      "required": [
+        "bech32PrefixAccAddr"
+      ],
+      "properties": {
+        "bech32PrefixAccAddr": {
+          "type": "string",
+          "description": "e.g., 'cosmos'"
+        }
+        "bech32PrefixAccPub": {
+          "type": "string",
+          "description": "e.g., 'cosmospub'"
+        }
+        "bech32PrefixValAddr": {
+          "type": "string",
+          "description": "e.g., 'cosmosvaloper'"
+        }
+        "bech32PrefixValPub": {
+          "type": "string",
+          "description": "e.g., 'cosmosvaloperpub'"
+        }
+        "bech32PrefixConsAddr": {
+          "type": "string",
+          "description": "e.g., 'cosmosvalcons'"
+        }
+        "bech32PrefixConsPub": {
+          "type": "string",
+          "description": "e.g., 'cosmosvalconspub'"
+        },
+        "additionalProperties": false
+      }
+    },
     "daemon_name": {
       "type": "string"
     },


### PR DESCRIPTION
-adds bech32_config object, with 6 optional properties
-bech32_prefix is still required, and the config is for override.

closes #665 