### PR TITLE
Fix chain schema for logo_URIs

### DIFF
--- a/chain.schema.json
+++ b/chain.schema.json
@@ -285,6 +285,29 @@
         "$ref": "#/$defs/explorer"
       }
     },
+    "logo_URIs": {
+      "type": "object",
+      "properties": {
+        "png": {
+          "type": "string",
+          "format": "uri-reference",
+          "pattern": "^https://raw\\.githubusercontent\\.com/cosmos/chain-registry/master/(|testnets/|_non-cosmos/)[a-z0-9]+/images/.+\\.png$"
+        },
+        "svg": {
+          "type": "string",
+          "format": "uri-reference",
+          "pattern": "^https://raw\\.githubusercontent\\.com/cosmos/chain-registry/master/(|testnets/|_non-cosmos/)[a-z0-9]+/images/.+\\.svg$"
+        }
+      },
+      "additionalProperties": false
+    },
+    "keywords": {
+      "type": "array",
+      "maxContains": 20,
+      "items": {
+        "type": "string"
+      }
+    },
     "extra_codecs": {
       "type": "array",
       "items": {
@@ -390,29 +413,6 @@
         }
       },
       "additionalProperties": false
-    },
-    "logo_URIs": {
-      "type": "object",
-      "properties": {
-        "png": {
-          "type": "string",
-          "format": "uri-reference",
-          "pattern": "^https://raw\\.githubusercontent\\.com/cosmos/chain-registry/master/(|testnets/|_non-cosmos/)[a-z0-9]+/images/.+\\.png$"
-        },
-        "svg": {
-          "type": "string",
-          "format": "uri-reference",
-          "pattern": "^https://raw\\.githubusercontent\\.com/cosmos/chain-registry/master/(|testnets/|_non-cosmos/)[a-z0-9]+/images/.+\\.svg$"
-        }
-      },
-      "additionalProperties": false
-    },
-    "keywords": {
-      "type": "array",
-      "maxContains": 20,
-      "items": {
-        "type": "string"
-      }
     }
   },
   "additionalProperties": false


### PR DESCRIPTION
Move logo_URIs and keywords to chain schema properties
was erroneously in '$defs'

resolves #1176 