### PR TITLE
Add Osmosis testnet gRPC endpoint from Osmosis docs

### DIFF
--- a/testnets/osmosistestnet/chain.json
+++ b/testnets/osmosistestnet/chain.json
@@ -94,7 +94,12 @@
         "provider": ""
       }
     ],
-    "grpc": []
+    "grpc": [
+      {
+        "address": "https://grpc-test.osmosis.zone:443",
+        "provider": "Osmosis"
+      }
+    ]
   },
   "logo_URIs": {
     "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/osmosis/images/osmosis-chain-logo.png"


### PR DESCRIPTION
<img width="969" alt="Screen Shot 2023-01-02 at 1 49 23 PM" src="https://user-images.githubusercontent.com/1042667/210280460-2aa0810c-95ab-4a8b-bb55-135e405b570a.png">

https://docs.osmosis.zone/networks

Thought I'd lean in and add this since it seemed to be missing