### PR TITLE
Add Stargaze testnet gRPC endpoints from Stargaze docs

### DIFF
--- a/testnets/stargazetestnet/chain.json
+++ b/testnets/stargazetestnet/chain.json
@@ -62,7 +62,16 @@
         "provider": "Stargaze Foundation"
       }
     ],
-    "grpc": []
+    "grpc": [
+      {
+        "address": "http://grpc-1.elgafar-1.stargaze-apis.com:26660",
+        "provider": "Stargaze Foundation"
+      },
+      {
+        "address": "http://grpc-2.elgafar-1.stargaze-apis.com:26660",
+        "provider": "Stargaze Foundation"
+      }
+    ]
   },
   "explorers": [
     {


### PR DESCRIPTION
<img width="1069" alt="Screen Shot 2023-01-02 at 2 11 35 PM" src="https://user-images.githubusercontent.com/1042667/210281312-06c38619-f77c-4658-a5a3-cd32aae28496.png">

https://docs.stargaze.zone/developers/testnet

Thought I'd lean in and add this since it seemed to be missing