### PR TITLE
Update chain rpc and api URL's

### DIFF
--- a/lumenx/chain.json
+++ b/lumenx/chain.json
@@ -71,22 +71,30 @@
   "apis": {
     "rpc": [
       {
-        "address": "https://rpc.helios-1.lumenex.io",
-        "provider": "metaprotocol"
+        "address": "https://rpc.lumenx.chaintools.tech/",
+        "provider": "ChainTools"
+      },
+      {
+        "address": "https://rpc-lumenx.cryptonet.pl/",
+        "provider": "CryptoNet"        
       }
     ],
     "rest": [
       {
-        "address": "https://api.helios-1.lumenex.io/",
-        "provider": "metaprotocol"
-      }
+        "address": "https://api.lumenx.chaintools.tech/",
+        "provider": "ChainTools"
+      },
+      {
+        "address": "https://api-lumenx.cryptonet.pl/",
+        "provider": "CryptoNet"
+      }      
     ]
   },
   "explorers": [
     {
       "kind": "ping.pub",
-      "url": "https://scope.helios-1.lumenex.io/lumenx",
-      "tx_page": "https://scope.helios-1.lumenex.io/lumenx/tx/${txHash}"
+      "url": "https://explorer.chaintools.tech/lumenx",
+      "tx_page": "https://explorer.chaintools.tech/lumenx/tx/${txHash}"
     }
   ]
 }


### PR DESCRIPTION
Previous endpoints are not available. Validators have delivered the new ones, which provide access to chain resources.