### PR TITLE
Add tx fee rates

### DIFF
--- a/chain.schema.json
+++ b/chain.schema.json
@@ -460,6 +460,15 @@
         },
         "high_gas_price": {
           "type": "number"
+        },
+        "low_tx_price": {
+          "type": "number"
+        },
+        "average_tx_price": {
+          "type": "number"
+        },
+        "high_tx_price": {
+          "type": "number"
         }
       },
       "additionalProperties": false

--- a/chain.schema.json
+++ b/chain.schema.json
@@ -461,13 +461,13 @@
         "high_gas_price": {
           "type": "number"
         },
-        "low_tx_price": {
+        "low_transaction_price": {
           "type": "number"
         },
-        "average_tx_price": {
+        "average_transaction_price": {
           "type": "number"
         },
-        "high_tx_price": {
+        "high_transaction_price": {
           "type": "number"
         }
       },


### PR DESCRIPTION
Some chains have flat fee rates for certain transaction types, and do not go by a variable rate based on gas usage. The need initially arose with Carbon chain using this. Alternate frontends may also wish to propose a flat tx fee override for certain tokens, (such as for IBC Deposit of SWTH onto Osmosis). Thus, I propose stepped (low, average, and high) transaction prices.   