### PR TITLE
Add Gas Costs to fee_tokens

### DIFF
--- a/chain.schema.json
+++ b/chain.schema.json
@@ -462,12 +462,17 @@
           "type": "number"
         },
         "gas_cost": {
-          "cosmos_send": {
-            "type": "number"
+          "type": "object",
+          "properties": {
+            "cosmos_send": {
+              "type": "number"
+            },
+            "ibc_transfer": {
+              "type": "number"
+            }
           },
-          "ibc_transfer": {
-            "type": "number"
-          }
+          "additionalProperties": false,
+          "minProperties": 1
         }
       },
       "additionalProperties": false

--- a/chain.schema.json
+++ b/chain.schema.json
@@ -460,6 +460,14 @@
         },
         "high_gas_price": {
           "type": "number"
+        },
+        "gas_cost": {
+          "cosmos_send": {
+            "type": "number"
+          },
+          "ibc_transfer": {
+            "type": "number"
+          }
         }
       },
       "additionalProperties": false

--- a/chain.schema.json
+++ b/chain.schema.json
@@ -461,7 +461,7 @@
         "high_gas_price": {
           "type": "number"
         },
-        "gas_cost": {
+        "gas_costs": {
           "type": "object",
           "properties": {
             "cosmos_send": {


### PR DESCRIPTION
Adding gas costs to fee tokens allows dapps and frontends to craft up to date transaction gas amount data. It can also be used to derive a fixed transaction cost (invariant to gas) based on transaction type.

Currently we see overcharges due to incorrectly high gas cost and sometimes failing transactions due to insufficient gas. 

For example, Carbon charges 1 SWTH per send or per ibc transfer. Combining the gas price (769.24) and gas cost of (130000), we can derive the fee of ~1 SWTH per transaction.
