### PR TITLE
Upgrade ki to v4.2.0

### DIFF
--- a/kichain/chain.json
+++ b/kichain/chain.json
@@ -23,9 +23,9 @@
   },
   "codebase": {
     "git_repo": "https://github.com/KiFoundation/ki-tools",
-    "recommended_version": "4.1.0",
+    "recommended_version": "4.2.0",
     "compatible_versions": [
-      "4.1.0"
+      "4.2.0"
     ],
     "genesis": {
       "genesis_url": "https://raw.githubusercontent.com/KiFoundation/ki-networks/v0.1/Mainnet/kichain-2/genesis.json"


### PR DESCRIPTION
Emergency upgrade due to chain halt, no proposal/etc.

<img width="1211" alt="Screenshot 2023-01-27 at 12 50 59 PM" src="https://user-images.githubusercontent.com/9121234/215194561-2b356681-946e-414d-8667-a6649730dc92.png">
