### PR TITLE
Cosmos Hub Testnet: Update Gaia to v8

### DIFF
--- a/testnets/cosmoshubtestnet/chain.json
+++ b/testnets/cosmoshubtestnet/chain.json
@@ -2,7 +2,7 @@
   "$schema": "../../chain.schema.json",
   "chain_name": "cosmoshubtestnet",
   "chain_id": "theta-testnet-001",
-  "pretty_name": "Theta Testnet",
+  "pretty_name": "Cosmos Hub Public Testnet",
   "status": "live",
   "network_type": "testnet",
   "bech32_prefix": "cosmos",
@@ -16,26 +16,26 @@
     "fee_tokens": [
       {
         "denom": "uatom",
-        "fixed_min_gas_price": 0
+        "fixed_min_gas_price": 0.0025
       }
     ]
   },
   "codebase": {
     "git_repo": "https://github.com/cosmos/gaia",
-    "recommended_version": "v7.0.2",
+    "recommended_version": "v8.0.0-rc5",
     "compatible_versions": [
-      "v7.0.0",
-      "v7.0.1",
-      "v7.0.2"
+      "v8.0.0-rc3",
+      "v8.0.0-rc5"
     ],
     "binaries": {
-      "linux/amd64": "https://github.com/cosmos/gaia/releases/download/v7.0.2/gaiad-v7.0.2-linux-amd64",
-      "linux/arm64": "https://github.com/cosmos/gaia/releases/download/v7.0.2/gaiad-v7.0.2-linux-arm64",
-      "darwin/amd64": "https://github.com/cosmos/gaia/releases/download/v7.0.2/gaiad-v7.0.2-darwin-amd64",
-      "windows/amd64": "https://github.com/cosmos/gaia/releases/download/v7.0.2/gaiad-v7.0.2-windows-amd64.exe"
+      "linux/amd64": "https://github.com/cosmos/gaia/releases/download/v8.0.0-rc5/gaiad-v8.0.0-rc5-linux-amd64",
+      "linux/arm64": "https://github.com/cosmos/gaia/releases/download/v8.0.0-rc5/gaiad-v8.0.0-rc5-linux-arm64",
+      "darwin/amd64": "https://github.com/cosmos/gaia/releases/download/v8.0.0-rc5/gaiad-v8.0.0-rc5-darwin-amd64",
+      "darwin/arm64": "https://github.com/cosmos/gaia/releases/download/v8.0.0-rc5/gaiad-v8.0.0-rc5-darwin-arm64",
+      "windows/amd64": "https://github.com/cosmos/gaia/releases/download/v8.0.0-rc5/gaiad-v8.0.0-rc5-windows-amd64.exe"
     },
     "genesis": {
-      "genesis_url": "https://github.com/cosmos/testnets/raw/master/v7-theta/public-testnet/genesis.json.gz"
+      "genesis_url": "https://github.com/cosmos/testnets/raw/master/public/genesis.json.gz"
     }
   },
   "peers": {


### PR DESCRIPTION
* Changed the pretty name to `Cosmos Hub Public Testnet`
* Updated min gas price to `0.0025`
* Updated gaiad recommended version to `v8.0.0-rc5`