### PR TITLE
Bumping Canto fixed_min_gas_price

### DIFF
--- a/canto/chain.json
+++ b/canto/chain.json
@@ -14,10 +14,10 @@
     "fee_tokens": [
       {
         "denom": "acanto",
-        "fixed_min_gas_price": 125000000000,
-        "low_gas_price": 125000000000,
-        "average_gas_price": 250000000000,
-        "high_gas_price": 375000000000
+        "fixed_min_gas_price": 1000000000000,
+        "low_gas_price": 1000000000000,
+        "average_gas_price": 2000000000000,
+        "high_gas_price": 3000000000000
       }
     ]
   },


### PR DESCRIPTION
Recently Canto passed a proposal to enable CSR and bump feemarket to 10000gwei
https://canto.io/governance/proposal/43

Shortly thereafter, Canto passed a proposal setting the feemarket price to 1000gwei
https://canto.io/governance/proposal/44

This should address: https://github.com/eco-stake/restake/issues/702
