### PR TITLE
Uni-5 -> Uni-6

### DIFF
--- a/testnets/junotestnet/chain.json
+++ b/testnets/junotestnet/chain.json
@@ -4,7 +4,7 @@
   "status": "live",
   "network_type": "testnet",
   "pretty_name": "Juno Testnet",
-  "chain_id": "uni-5",
+  "chain_id": "uni-6",
   "bech32_prefix": "juno",
   "daemon_name": "junod",
   "node_home": "$HOME/.juno",
@@ -31,32 +31,32 @@
   },
   "codebase": {
     "git_repo": "https://github.com/CosmosContracts/juno",
-    "recommended_version": "v12.0.0-alpha",
+    "recommended_version": "v12.0.0-beta.1",
     "compatible_versions": [
-       "v12.0.0-alpha"
+       "v12.0.0-beta.1"
     ],
     "cosmos_sdk_version": "0.45",
     "tendermint_version": "0.34",
-    "cosmwasm_version": "0.30",
+    "cosmwasm_version": "0.29",
     "cosmwasm_enabled": true,
-    "ibc_go_version": "4.2.0",
+    "ibc_go_version": "3.3.1",
     "genesis": {
-      "genesis_url": "https://raw.githubusercontent.com/CosmosContracts/testnets/main/uni-5/genesis.json"
+      "genesis_url": "https://raw.githubusercontent.com/CosmosContracts/testnets/main/uni-6/genesis.json"
     }
   },
   "peers": {
     "seeds": [
       {
-        "id": "08bde9dda7cc7898b7426387281cdd492f4488af",
-        "address": "tenderseed.ccvalidators.com:29003",
-        "provider": "CryptoCrew"
+        "id": "babc3f3f7804933265ec9c40ad94f4da8e9e0017",
+        "address": "testnet-seed.rhinostake.com:12656",
+        "provider": "RHINO"
       }
     ],
     "persistent_peers": [
       {
-        "id": "ed90921d43ede634043d152d7a87e8881fb85e90",
-        "address": "65.108.77.106:26709",
-        "provider": "EZStaking.io"
+        "id": "c54bf418fb542634495f57a1e36c9bd057d55e1b",
+        "address": "5.161.80.115:26656",
+        "provider": "Reecepbcups"
       }
     ]
   },
@@ -69,6 +69,10 @@
       {
         "address": "https://juno-testnet-rpc.polkachu.com",
         "provider": "Polkachu"
+      },
+      {
+        "address": "https://uni-rpc.reece.sh",
+        "provider": "Reecepbcups"
       }
     ],
     "rest": [
@@ -79,6 +83,10 @@
       {
         "address": "https://juno-testnet-api.polkachu.com",
         "provider": "Polkachu"
+      },
+      {
+        "address": "https://uni-api.reece.sh",
+        "provider": "Reecepbcups"
       }
     ],
     "grpc": [


### PR DESCRIPTION
Chain is currently on v11.0.0, but we are upgrading to v12.0.0-beta.1 tag Wednesday

- updates name to uni-6
- Adds my RPC
- Adds my REST
- Adds my Peer
- [Uses Rhinos seed from our repo for Uni-6](https://github.com/CosmosContracts/testnets/blob/main/uni-6/seeds.txt)
- Updates versions to match v12.0.0-beta.1