### PR TITLE
Update umee foundation rpc & api endpoints

### DIFF
--- a/umee/chain.json
+++ b/umee/chain.json
@@ -70,7 +70,7 @@
   "apis": {
     "rpc": [
       {
-        "address": "https://rpc.barnacle.mainnet.network.umee.cc",
+        "address": "https://rpc.mainnet.network.umee.cc",
         "provider": "umee Foundation"
       },
       {
@@ -88,7 +88,7 @@
     ],
     "rest": [
       {
-        "address": "https://api.barnacle.mainnet.network.umee.cc",
+        "address": "https://api.mainnet.network.umee.cc",
         "provider": "umee Foundation"
       },
       {


### PR DESCRIPTION
Replaces the inactive `barnacle` endpoints with the load-balanced `mainnet` endpoints