### PR TITLE
Fix banana display denom

### DIFF
--- a/juno/assetlist.json
+++ b/juno/assetlist.json
@@ -631,13 +631,13 @@
             "exponent": 0
           },
           {
-            "denom": "BANANA",
+            "denom": "banana",
             "exponent": 6
           }
         ],
         "base": "juno1s2dp05rspeuzzpzyzdchk262szehrtfpz847uvf98cnwh53ulx4qg20qwj",
         "name": "Banana Token",
-        "display": "Banana Token",
+        "display": "banana",
         "symbol": "BANANA",
         "logo_URIs": {
           "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/juno/images/banana.png"


### PR DESCRIPTION
-was invalid before. Display denom must be one of the defined denom units, which "banana Token" was not.