### PR TITLE
Upgrade Cosmos Hub Testnet to v9.0.0-rc3

### DIFF
--- a/testnets/cosmoshubtestnet/chain.json
+++ b/testnets/cosmoshubtestnet/chain.json
@@ -22,17 +22,16 @@
   },
   "codebase": {
     "git_repo": "https://github.com/cosmos/gaia",
-    "recommended_version": "v8.0.0-rc5",
+    "recommended_version": "v9.0.0-rc3",
     "compatible_versions": [
-      "v8.0.0-rc3",
-      "v8.0.0-rc5"
+      "v9.0.0-rc3"
     ],
     "binaries": {
-      "linux/amd64": "https://github.com/cosmos/gaia/releases/download/v8.0.0-rc5/gaiad-v8.0.0-rc5-linux-amd64",
-      "linux/arm64": "https://github.com/cosmos/gaia/releases/download/v8.0.0-rc5/gaiad-v8.0.0-rc5-linux-arm64",
-      "darwin/amd64": "https://github.com/cosmos/gaia/releases/download/v8.0.0-rc5/gaiad-v8.0.0-rc5-darwin-amd64",
-      "darwin/arm64": "https://github.com/cosmos/gaia/releases/download/v8.0.0-rc5/gaiad-v8.0.0-rc5-darwin-arm64",
-      "windows/amd64": "https://github.com/cosmos/gaia/releases/download/v8.0.0-rc5/gaiad-v8.0.0-rc5-windows-amd64.exe"
+      "linux/amd64": "https://github.com/cosmos/gaia/releases/download/v9.0.0-rc3/gaiad-v9.0.0-rc3-linux-amd64",
+      "linux/arm64": "https://github.com/cosmos/gaia/releases/download/v9.0.0-rc3/gaiad-v9.0.0-rc3-linux-arm64",
+      "darwin/amd64": "https://github.com/cosmos/gaia/releases/download/v9.0.0-rc3/gaiad-v9.0.0-rc3-darwin-amd64",
+      "darwin/arm64": "https://github.com/cosmos/gaia/releases/download/v9.0.0-rc3/gaiad-v9.0.0-rc3-darwin-arm64",
+      "windows/amd64": "https://github.com/cosmos/gaia/releases/download/v9.0.0-rc3/gaiad-v9.0.0-rc3-windows-amd64.exe"
     },
     "genesis": {
       "genesis_url": "https://github.com/cosmos/testnets/raw/master/public/genesis.json.gz"


### PR DESCRIPTION
Hi!
We upgraded the Cosmos Hub Public Testnet to Gaia `v9.0.0-rc3` on Feb 8, 2023.
https://explorer.theta-testnet.polypore.xyz/proposals/115