### PR TITLE
Update CoinGecko ID for Mars token

### DIFF
--- a/mars/assetlist.json
+++ b/mars/assetlist.json
@@ -22,7 +22,7 @@
         "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/mars/images/mars-token.png",
         "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/mars/images/mars-token.svg"
       },
-      "coingecko_id": "mars-protocol-a7fcbcfb-fd61-4017-92f0-7ee9f9cc6da3"
+      "coingecko_id": "mars-protocol"
     }
   ]
 }


### PR DESCRIPTION
CoinGecko _finally_ gave us a permanent token ID...