### PR TITLE
Rebranding freak12techno -> Quokka Stake on Sentinel

### DIFF
--- a/sentinel/chain.json
+++ b/sentinel/chain.json
@@ -152,8 +152,8 @@
         "provider": "ChainTools"
       },
       {
-        "address": "https://rpc.sentinel.freak12techno.io/",
-        "provider": "freak12techno"
+        "address": "https://rpc.sentinel.quokkastake.io/",
+        "provider": "Quokka Stake"
       },
       {
         "address": "https://sentinel-rpc.badgerbite.io/",
@@ -182,8 +182,8 @@
         "provider": "ChainTools"
       },
       {
-        "address": "https://api.sentinel.freak12techno.io/",
-        "provider": "freak12techno"
+        "address": "https://api.sentinel.quokkastake.io/",
+        "provider": "Quokka Stake"
       },
       {
         "address": "https://sentinel-mainnet-lcd-autostake.net:443",


### PR DESCRIPTION
I'm doing a validator rebrand: https://t.me/quokkastake/100, more PRs with other public nodes domain changes will follow a bit later