### PR TITLE
Remove Incorrect CoinGecko IDs

### DIFF
--- a/axelar/assetlist.json
+++ b/axelar/assetlist.json
@@ -53,8 +53,7 @@
       "logo_URIs": {
         "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/axelar/images/usdc.svg",
         "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/axelar/images/usdc.png"
-      },
-      "coingecko_id": "usd-coin"
+      }
     },
     {
       "description": "Frax's fractional-algorithmic stablecoin on Axelar",
@@ -85,8 +84,7 @@
       "logo_URIs": {
         "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/axelar/images/frax.svg",
         "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/axelar/images/frax.png"
-      },
-      "coingecko_id": "frax"
+      }
     },
     {
       "description": "Dai stablecoin on Axelar",
@@ -117,8 +115,7 @@
       "logo_URIs": {
         "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/axelar/images/dai.svg",
         "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/axelar/images/dai.png"
-      },
-      "coingecko_id": "dai"
+      }
     },
     {
       "description": "Tether's USD stablecoin on Axelar",
@@ -149,8 +146,7 @@
       "logo_URIs": {
         "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/axelar/images/usdt.svg",
         "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/axelar/images/usdt.png"
-      },
-      "coingecko_id": "tether"
+      }
     },
     {
       "description": "Wrapped Ether on Axelar",
@@ -180,8 +176,7 @@
       ],
       "logo_URIs": {
         "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/axelar/images/weth.png"
-      },
-      "coingecko_id": "weth"
+      }
     },
     {
       "description": "Wrapped Bitcoin on Axelar",
@@ -211,8 +206,7 @@
       ],
       "logo_URIs": {
         "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/axelar/images/wbtc.png"
-      },
-      "coingecko_id": "wrapped-bitcoin"
+      }
     },
     {
       "description": "Aave on Axelar",
@@ -242,8 +236,7 @@
       ],
       "logo_URIs": {
         "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/_non-cosmos/ethereum/images/aave.svg"
-      },
-      "coingecko_id": "aave"
+      }
     },
     {
       "description": "ApeCoin on Axelar",
@@ -273,8 +266,7 @@
       ],
       "logo_URIs": {
         "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/_non-cosmos/ethereum/images/ape.svg"
-      },
-      "coingecko_id": "apecoin"
+      }
     },
     {
       "description": "Axie Infinity Shard on Axelar",
@@ -304,8 +296,7 @@
       ],
       "logo_URIs": {
         "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/_non-cosmos/ethereum/images/axs.svg"
-      },
-      "coingecko_id": "axie-infinity"
+      }
     },
     {
       "description": "Chainlink on Axelar",
@@ -336,8 +327,7 @@
       "logo_URIs": {
 	      "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/_non-cosmos/ethereum/images/link.png",
         "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/_non-cosmos/ethereum/images/link.svg"
-      },
-      "coingecko_id": "chainlink"
+      }
     },
     {
       "description": "Maker on Axelar",
@@ -367,8 +357,7 @@
       ],
       "logo_URIs": {
         "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/_non-cosmos/ethereum/images/mkr.svg"
-      },
-      "coingecko_id": "maker"
+      }
     },
     {
       "description": "Rai Reflex Index on Axelar",
@@ -398,8 +387,7 @@
       ],
       "logo_URIs": {
         "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/_non-cosmos/ethereum/images/rai.svg"
-      },
-      "coingecko_id": "rai"
+      }
     },
     {
       "description": "Shiba Inu on Axelar",
@@ -429,8 +417,7 @@
       ],
       "logo_URIs": {
         "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/_non-cosmos/ethereum/images/shib.svg"
-      },
-      "coingecko_id": "shiba-inu"
+      }
     },
     {
       "description": "Lido Staked Ether on Axelar",
@@ -460,8 +447,7 @@
       ],
       "logo_URIs": {
         "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/_non-cosmos/ethereum/images/steth.svg"
-      },
-      "coingecko_id": "staked-ether"
+      }
     },
     {
       "description": "Uniswap on Axelar",
@@ -491,8 +477,7 @@
       ],
       "logo_URIs": {
         "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/_non-cosmos/ethereum/images/uni.svg"
-      },
-      "coingecko_id": "uniswap"
+      }
     },
     {
       "description": "Chain on Axelar",
@@ -522,8 +507,7 @@
       ],
       "logo_URIs": {
         "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/_non-cosmos/ethereum/images/xcn.svg"
-      },
-      "coingecko_id": "chain-2"
+      }
     },
     {
       "description": "Wrapped Polkadot on Axelar",
@@ -554,8 +538,7 @@
       "logo_URIs": {
         "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/_non-cosmos/polkadot/images/dot.svg",
         "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/_non-cosmos/polkadot/images/dot.png"
-      },
-      "coingecko_id": "polkadot"
+      }
     },
     {
       "description": "Wrapped Moonbeam on Axelar",
@@ -586,8 +569,7 @@
       "logo_URIs": {
         "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/_non-cosmos/moonbeam/images/glmr.svg",
         "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/_non-cosmos/moonbeam/images/glmr.png"
-      },
-      "coingecko_id": "wrapped-moonbeam"
+      }
     },
     {
       "description": "Wrapped Matic on Axelar",
@@ -618,8 +600,7 @@
       "logo_URIs": {
         "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/_non-cosmos/polygon/images/wmatic.png",
         "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/_non-cosmos/polygon/images/wmatic.svg"
-      },
-      "coingecko_id": "matic-network"
+      }
     },
     {
       "description": "Wrapped BNB on Axelar",
@@ -650,8 +631,7 @@
       "logo_URIs": {
         "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/_non-cosmos/binancesmartchain/images/wbnb.svg",
         "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/_non-cosmos/binancesmartchain/images/wbnb.png"
-      },
-      "coingecko_id": "wbnb"
+      }
     },
     {
       "description": "Binance USD on Axelar.",
@@ -681,8 +661,7 @@
       ],
       "logo_URIs": {
         "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/_non-cosmos/ethereum/images/busd.png"
-      },
-      "coingecko_id": "binance-usd"
+      }
     },
     {
       "description": "Wrapped AVAX on Axelar.",

--- a/carbon/assetlist.json
+++ b/carbon/assetlist.json
@@ -88,8 +88,7 @@
         "logo_URIs": {
           "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/_non-cosmos/binancesmartchain/images/bnb.png",
           "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/_non-cosmos/binancesmartchain/images/bnb.svg"
-        },
-        "coingecko_id": "binancecoin"
+        }
       },
       {
         "description": "bNEO token on Carbon",
@@ -127,8 +126,7 @@
         "logo_URIs": {
           "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/carbon/images/bneo.png",
           "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/carbon/images/bneo.svg"
-        },
-        "coingecko_id": "neo"
+        }
       },
       {
         "description": "BUSD (BEP-20) token on Carbon",
@@ -165,8 +163,7 @@
         ],
         "logo_URIs": {
           "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/_non-cosmos/ethereum/images/busd.png"
-        },
-        "coingecko_id": "binance-usd"
+        }
       },
       {
         "description": "ETH (Arbitrum) token on Carbon",
@@ -203,8 +200,7 @@
         ],
         "logo_URIs": {
           "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/_non-cosmos/ethereum/images/eth.svg"
-        },
-        "coingecko_id": "ethereum"
+        }
       },
       {
         "description": "ETH (ERC20) token on Carbon",
@@ -241,8 +237,7 @@
         ],
         "logo_URIs": {
           "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/_non-cosmos/ethereum/images/eth.svg"
-        },
-        "coingecko_id": "ethereum"
+        }
       },
       {
         "description": "STARS token on Carbon",
@@ -279,8 +274,7 @@
         ],
         "logo_URIs": {
           "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/stargaze/images/stars.png"
-        },
-        "coingecko_id": "stargaze"
+        }
       },
       {
         "description": "LUNA token on Carbon",
@@ -317,8 +311,7 @@
         ],
         "logo_URIs": {
           "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/terra2/images/luna.png"
-        },
-        "coingecko_id": "terra-luna-2"
+        }
       },
       {
         "description": "STRD token on Carbon",
@@ -356,8 +349,7 @@
         "logo_URIs": {
           "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/stride/images/strd.png",
           "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/stride/images/strd.svg"
-        },
-        "coingecko_id": "stride"
+        }
       },
       {
         "description": "KUJI token on Carbon",
@@ -394,8 +386,7 @@
         ],
         "logo_URIs": {
           "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/kujira/images/kuji.png"
-        },
-        "coingecko_id": "kujira"
+        }
       },
       {
         "description": "stOSMO token on Carbon",
@@ -433,8 +424,7 @@
         "logo_URIs": {
           "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/stride/images/stosmo.png",
           "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/stride/images/stosmo.svg"
-        },
-        "coingecko_id": "osmosis"
+        }
       },
       {
         "description": "CANTO token on Carbon",
@@ -471,8 +461,7 @@
         ],
         "logo_URIs": {
           "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/canto/images/canto.png"
-        },
-        "coingecko_id": "canto"
+        }
       },
       {
         "description": "Cosmos governance token on Carbon",
@@ -510,8 +499,7 @@
         "logo_URIs": {
           "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/cosmoshub/images/atom.png",
           "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/cosmoshub/images/atom.svg"
-        },
-        "coingecko_id": "cosmos"
+        }
       },
       {
         "description": "stATOM token on Carbon",
@@ -549,8 +537,7 @@
         "logo_URIs": {
           "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/stride/images/statom.png",
           "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/stride/images/statom.svg"
-        },
-        "coingecko_id": "stride-staked-atom"
+        }
       },
       {
         "description": "OSMO token on Carbon",
@@ -588,8 +575,7 @@
         "logo_URIs": {
           "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/osmosis/images/osmo.png",
           "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/osmosis/images/osmo.svg"
-        },
-        "coingecko_id": "osmosis"
+        }
       },
       {
         "description": "USDC (ERC20) token on Carbon",
@@ -626,8 +612,7 @@
         ],
         "logo_URIs": {
           "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/_non-cosmos/ethereum/images/usdc.svg"
-        },
-        "coingecko_id": "usd-coin"
+        }
       },
       {
         "description": "USD Coin (BEP-20) token on Carbon",
@@ -664,8 +649,7 @@
         ],
         "logo_URIs": {
           "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/_non-cosmos/ethereum/images/usdc.svg"
-        },
-        "coingecko_id": "usd-coin"
+        }
       }
     ]
   }

--- a/gravitybridge/assetlist.json
+++ b/gravitybridge/assetlist.json
@@ -61,8 +61,7 @@
       "logo_URIs": {
         "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/persistence/images/pstake.png",
         "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/persistence/images/pstake.svg"
-      },
-      "coingecko_id": "pstake-finance"
+      }
     },
     {
       "description": "Gravity Bridge WETH",

--- a/persistence/assetlist.json
+++ b/persistence/assetlist.json
@@ -100,8 +100,7 @@
         "logo_URIs": {
           "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/persistence/images/pstake.png",
           "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/persistence/images/pstake.svg"
-        },
-        "coingecko_id": "pstake-finance"
+        }
       }
     ]
  }


### PR DESCRIPTION
The coinGecko ID should reside only with the assets directly referred to by the entity on CoinGecko. E.g., ETH's id applies to the Ethereum asset, but should not be used with bridged forms in this registry. The `traces` information within each unoriginal asset can lead developers from that bridged/transformed variant to its origin asset to derive the CGID if needed.