### PR TITLE
revert mars-protocol coingecko-id

### DIFF
--- a/mars/assetlist.json
+++ b/mars/assetlist.json
@@ -22,7 +22,7 @@
         "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/mars/images/mars-token.png",
         "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/mars/images/mars-token.svg"
       },
-      "coingecko_id": "mars-protocol"
+      "coingecko_id": "mars-protocol-a7fcbcfb-fd61-4017-92f0-7ee9f9cc6da3"
     }
   ]
 }


### PR DESCRIPTION
the longer string works, the shorter one shows a price, but it is incorrect. If you would like to verify it is displayed - https://www.coingecko.com/en/coins/mars-protocol