### PR TITLE
Added "node_home" value

### DIFF
--- a/cudos/chain.json
+++ b/cudos/chain.json
@@ -7,6 +7,7 @@
   "chain_id": "cudos-1",
   "bech32_prefix": "cudos",
   "daemon_name": "cudos-noded",
+  "node_home": "$HOME/cudos-data",
   "key_algos": [
     "secp256k1"
   ],


### PR DESCRIPTION
We were contacted about the lack of a node_home variable by an operator that uses the chain data to build their networks.

Please consider this PR for inclusion

Andrew Meredith - Cudo Site Reliability Engineer (Blockchain)