### PR TITLE
Add Images Array

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,9 +136,16 @@ A sample `chain.json` includes the following information.
       }
     ]
   },
+  "images": [
+    {
+      "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/osmosis/images/osmosis-chain-logo.png"
+      "theme": {
+        "primary_color_hex": "#231D4B"
+      }
+    }
+  ],
   "logo_URIs": {
-    "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/osmosis/images/osmosis-chain-logo.png",
-    "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/osmosis/images/osmosis-chain-logo.svg"
+    "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/osmosis/images/osmosis-chain-logo.png"
   },
   "peers": {
     "seeds": [

--- a/README.md
+++ b/README.md
@@ -261,6 +261,15 @@ An example assetlist json contains the following structure:
         "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/osmosis/images/osmo.png",
         "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/osmosis/images/osmo.svg"
       },
+      "images": [
+        {
+          "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/osmosis/images/osmo.png",
+          "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/osmosis/images/osmo.svg",
+          "theme": {
+            "primary_color_hex": "#5c09a0"
+          }
+        }
+      ],
       "coingecko_id": "osmosis",
       "keywords": [
         "dex",
@@ -286,6 +295,15 @@ An example assetlist json contains the following structure:
         "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/osmosis/images/ion.png",
         "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/osmosis/images/ion.svg"
       },
+      "images": [
+        {
+          "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/osmosis/images/ion.png",
+          "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/osmosis/images/ion.svg",
+          "theme": {
+            "primary_color_hex": "#3f97fc"
+          }
+        }
+      ],
       "coingecko_id": "ion",
       "keywords": [
         "memecoin"

--- a/README.md
+++ b/README.md
@@ -138,7 +138,7 @@ A sample `chain.json` includes the following information.
   },
   "images": [
     {
-      "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/osmosis/images/osmosis-chain-logo.png"
+      "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/osmosis/images/osmosis-chain-logo.png",
       "theme": {
         "primary_color_hex": "#231D4B"
       }

--- a/README.md
+++ b/README.md
@@ -144,9 +144,6 @@ A sample `chain.json` includes the following information.
       }
     }
   ],
-  "logo_URIs": {
-    "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/osmosis/images/osmosis-chain-logo.png"
-  },
   "peers": {
     "seeds": [
       {
@@ -264,10 +261,6 @@ An example assetlist json contains the following structure:
       "name": "Osmosis",
       "display": "osmo",
       "symbol": "OSMO",
-      "logo_URIs": {
-        "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/osmosis/images/osmo.png",
-        "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/osmosis/images/osmo.svg"
-      },
       "images": [
         {
           "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/osmosis/images/osmo.png",
@@ -298,10 +291,6 @@ An example assetlist json contains the following structure:
       "name": "Ion",
       "display": "ion",
       "symbol": "ION",
-      "logo_URIs": {
-        "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/osmosis/images/ion.png",
-        "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/osmosis/images/ion.svg"
-      },
       "images": [
         {
           "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/osmosis/images/ion.png",

--- a/assetlist.schema.json
+++ b/assetlist.schema.json
@@ -131,7 +131,8 @@
         "images": {
           "type": "array",
           "items": {
-            "image": {
+            "type": "object",
+            "properties": {
               "png": {
                 "type": "string",
                 "format": "uri-reference",

--- a/assetlist.schema.json
+++ b/assetlist.schema.json
@@ -128,6 +128,35 @@
           },
           "additionalProperties": false
         },
+        "images": {
+          "type": "array",
+          "items": {
+            "image": {
+              "png": {
+                "type": "string",
+                "format": "uri-reference",
+                "pattern": "^https://raw\\.githubusercontent\\.com/cosmos/chain-registry/master/(|testnets/|_non-cosmos/)[a-z0-9]+/images/.+\\.png$"
+              },
+              "svg": {
+                "type": "string",
+                "format": "uri-reference",
+                "pattern": "^https://raw\\.githubusercontent\\.com/cosmos/chain-registry/master/(|testnets/|_non-cosmos/)[a-z0-9]+/images/.+\\.svg$"
+              },
+              "theme": {
+                "type": "object",
+                "properties": {
+                  "primary_color_hex": {
+                   "type": "string",
+                   "pattern": "^#[0-9a-fA-F]{6}$"
+                  }
+                },
+                "additionalProperties": false
+              }
+            },
+            "additionalProperties": false
+          },
+          "minItems": 1
+        },
         "coingecko_id": {
           "type": "string",
           "description": "[OPTIONAL] The coingecko id to fetch asset data from coingecko v3 api. See https://api.coingecko.com/api/v3/coins/list"

--- a/chain.schema.json
+++ b/chain.schema.json
@@ -281,6 +281,35 @@
       },
       "additionalProperties": false
     },
+    "images": {
+      "type": "array",
+      "items": {
+        "image": {
+          "png": {
+            "type": "string",
+            "format": "uri-reference",
+            "pattern": "^https://raw\\.githubusercontent\\.com/cosmos/chain-registry/master/(|testnets/|_non-cosmos/)[a-z0-9]+/images/.+\\.png$"
+          },
+          "svg": {
+            "type": "string",
+            "format": "uri-reference",
+            "pattern": "^https://raw\\.githubusercontent\\.com/cosmos/chain-registry/master/(|testnets/|_non-cosmos/)[a-z0-9]+/images/.+\\.svg$"
+          },
+          "theme": {
+            "type": "object",
+            "properties": {
+              "primary_color_hex": {
+               "type": "string",
+               "pattern": "^#[0-9a-fA-F]{6}$"
+              }
+            },
+            "additionalProperties": false
+          }
+        },
+        "additionalProperties": false
+      },
+      "minItems": 1
+    },
     "logo_URIs": {
       "type": "object",
       "properties": {

--- a/chain.schema.json
+++ b/chain.schema.json
@@ -284,7 +284,8 @@
     "images": {
       "type": "array",
       "items": {
-        "image": {
+        "type": "object",
+        "properties": {
           "png": {
             "type": "string",
             "format": "uri-reference",

--- a/osmosis/chain.json
+++ b/osmosis/chain.json
@@ -113,6 +113,14 @@
       }
     ]
   },
+  "images": [
+    {
+      "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/osmosis/images/osmosis-chain-logo.png",
+      "theme": {
+        "primary_color_hex": "#231D4B"
+      }
+    }
+  ],
   "logo_URIs": {
     "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/osmosis/images/osmosis-chain-logo.png"
   },


### PR DESCRIPTION
Each asset and chain will eventually instead use an array of images (but for now it will just be added--not removing the old logo_URIs just yet), and each 'image' object in the array can have 'svg', 'png', and 'theme', where theme contains (for now) 'primary_color_hex'. Theme can be expanded later.
Meant to address issue : https://github.com/cosmos/chain-registry/issues/462