### PR TITLE
Update version information for Cronos

### DIFF
--- a/cronos/chain.json
+++ b/cronos/chain.json
@@ -22,20 +22,18 @@
   },
   "codebase": {
     "git_repo": "https://github.com/crypto-org-chain/cronos",
-    "recommended_version": "v0.8.3",
+    "recommended_version": "v1.0.4",
     "compatible_versions": [
-      "v0.7.0",
-      "v0.7.1",
-      "v0.8.0",
-      "v0.8.1",
-      "v0.8.2"
+      "v1.0.2",
+      "v1.0.3",
+      "v1.0.4"
     ],
     "binaries": {
-      "linux/amd64": "https://github.com/crypto-org-chain/cronos/releases/download/v0.8.3/cronos_0.8.3_Linux_x86_64.tar.gz",
-      "linux/arm64": "https://github.com/crypto-org-chain/cronos/releases/download/v0.8.3/cronos_0.8.3_Linux_arm64.tar.gz",
-      "darwin/amd64": "https://github.com/crypto-org-chain/cronos/releases/download/v0.8.3/cronos_0.8.3_Darwin_x86_64.tar.gz",
-      "darwin/arm64": "https://github.com/crypto-org-chain/cronos/releases/download/v0.8.3/cronos_0.8.3_Darwin_arm64.tar.gz",
-      "windows/amd64": "https://github.com/crypto-org-chain/cronos/releases/download/v0.8.3/cronos_0.8.3_Windows_x86_64.zip"
+      "linux/amd64": "https://github.com/crypto-org-chain/cronos/releases/download/v1.0.4/cronos_1.0.4_Linux_x86_64.tar.gz",
+      "linux/arm64": "https://github.com/crypto-org-chain/cronos/releases/download/v1.0.4/cronos_1.0.4_Linux_arm64.tar.gz",
+      "darwin/amd64": "https://github.com/crypto-org-chain/cronos/releases/download/v1.0.4/cronos_1.0.4_Darwin_x86_64.tar.gz",
+      "darwin/arm64": "https://github.com/crypto-org-chain/cronos/releases/download/v1.0.4/cronos_1.0.4_Darwin_arm64.tar.gz",
+      "windows/amd64": "https://github.com/crypto-org-chain/cronos/releases/download/v1.0.4/cronos_1.0.4_Windows_x86_64.zip"
     },
     "genesis": {
       "genesis_url": "https://raw.githubusercontent.com/crypto-org-chain/cronos-mainnet/master/cronosmainnet_25-1/genesis.json"


### PR DESCRIPTION
Cronos' latest binary is now v1.0.4.