### PR TITLE
Update alternative slip44s

### DIFF
--- a/agoric/chain.json
+++ b/agoric/chain.json
@@ -10,6 +10,9 @@
   "daemon_name": "agd",
   "node_home": "$HOME/.agoric",
   "slip44": 564,
+  "alternative_slip44s": [
+    118
+  ],
   "fees": {
     "fee_tokens": [
       {

--- a/cryptoorgchain/chain.json
+++ b/cryptoorgchain/chain.json
@@ -9,6 +9,9 @@
   "daemon_name": "chain-maind",
   "node_home": "$HOME/.chain-maind",
   "slip44": 394,
+  "alternative_slip44s": [
+    118
+  ],
   "fees": {
     "fee_tokens": [
       {

--- a/irisnet/chain.json
+++ b/irisnet/chain.json
@@ -12,6 +12,9 @@
     "secp256k1"
   ],
   "slip44": 118,
+  "alternative_slip44s": [
+    566
+  ],
   "fees": {
     "fee_tokens": [
       {

--- a/kava/chain.json
+++ b/kava/chain.json
@@ -10,6 +10,9 @@
   "daemon_name": "kava",
   "node_home": "$HOME/.kava",
   "slip44": 459,
+  "alternative_slip44s": [
+    118
+  ],
   "fees": {
     "fee_tokens": [
       {

--- a/mars/chain.json
+++ b/mars/chain.json
@@ -13,6 +13,9 @@
     "secp256k1"
   ],
   "slip44": 118,
+  "alternative_slip44s": [
+    330
+  ],
   "fees": {
     "fee_tokens": [
       {

--- a/persistence/chain.json
+++ b/persistence/chain.json
@@ -13,6 +13,9 @@
     "secp256k1"
   ],
   "slip44": 118,
+  "alternative_slip44s": [
+    750
+  ],
   "fees": {
     "fee_tokens": [
       {

--- a/secretnetwork/chain.json
+++ b/secretnetwork/chain.json
@@ -13,6 +13,9 @@
     "secp256k1"
   ],
   "slip44": 529,
+  "alternative_slip44s": [
+    118
+  ],
   "fees": {
     "fee_tokens": [
       {

--- a/starname/chain.json
+++ b/starname/chain.json
@@ -8,6 +8,9 @@
   "chain_id": "iov-mainnet-ibc",
   "bech32_prefix": "star",
   "slip44": 234,
+  "alternative_slip44s": [
+    118
+  ],
   "fees": {
     "fee_tokens": [
       {


### PR DESCRIPTION
IOV, IRIS, SCRT, XPRT, MARS, CRO, BLD, KAVA
mostly adding 118 as a secondary id

as per Keplr Chain Registry