### PR TITLE
Remove problematic Osmosis testnet rpc endpoint

### DIFF
--- a/testnets/osmosistestnet/chain.json
+++ b/testnets/osmosistestnet/chain.json
@@ -74,10 +74,6 @@
       {
         "address": "https://osmosistest-rpc.quickapi.com/",
         "provider": "ChainLayer"
-      },
-      {
-        "address": "https://testnet-rpc.osmosis.zone/",
-        "provider": ""
       }
     ],
     "rest": [


### PR DESCRIPTION
There's been a problem with an endpoint that's been happened for a little while. I tracked it down to the endpoint `https://testnet-rpc.osmosis.zone`, so this PR removes that endpoint until it's fixed.

When using a daemon CLI, it can manifest with errors like:

>Error: error unmarshalling: invalid character '<' looking for beginning of value.

Note that this behavior is intermittent, perhaps because there's a load balancer hitting different nodes, but I'm just guessing. You can see that behavior in this screenshot where I run the exact same command twice, with the first failing and the second succeeding.

![telegram-cloud-photo-size-1-5057741531036887975-y](https://user-images.githubusercontent.com/1042667/224522023-b0a7ac72-b3d9-4ab1-b5c8-56233124f65b.jpg)

Note the reference to an invalid `'<'`, which makes more sense now. It seems the RPC endpoint is returning HTML.

I've included instructions on how to quickly reproduce this via CosmJS here:
https://github.com/mikedotexe/osmosistestnet-rpc-issue

The error manifests different when coming from JavaScript, throwing the error:

>Data must be JSON compatible dictionary

If you debug by printing what's returned, right above that error, you'll see it's HTML.

<img width="1043" alt="Screen Shot 2023-03-11 at 7 14 43 PM" src="https://user-images.githubusercontent.com/1042667/224522181-5ced9730-1d62-46e4-9033-b66209ef281e.png">

---

Given many dApps reliance on `chain-registry`, feels like a good idea to temporarily remove the endpoint until the team has the chance to address it.