### PR TITLE
Re-add ivaldilabs endpoints

### DIFF
--- a/akash/chain.json
+++ b/akash/chain.json
@@ -131,6 +131,10 @@
       {
         "address": "https://akash-mainnet-rpc.autostake.net:443",
         "provider": "AutoStake 🛡️ Slash Protected"
+      },
+      {
+        "address": "https://akash.rpc.interchain.ivaldilabs.xyz",
+        "provider": "ivaldilabs"
       }
     ],
     "rest": [
@@ -161,6 +165,10 @@
       {
         "address": "https://akash-mainnet-lcd.autostake.net:443",
         "provider": "AutoStake 🛡️ Slash Protected"
+      },
+      {
+        "address": "https://akash.rest.interchain.ivaldilabs.xyz",
+        "provider": "ivaldilabs"
       }
     ],
     "grpc": [
@@ -179,6 +187,10 @@
       {
         "address": "akash-mainnet-grpc.autostake.net:443",
         "provider": "AutoStake 🛡️ Slash Protected"
+      },
+      {
+        "address": "akash.grpc.interchain.ivaldilabs.xyz:443",
+        "provider": "ivaldilabs"
       }
     ]
   },

--- a/axelar/chain.json
+++ b/axelar/chain.json
@@ -144,6 +144,10 @@
       {
         "address": "https://axelar-rpc.rockrpc.net/",
         "provider": "RockawayX Infra"
+      },
+      {
+        "address": "https://axelar.rpc.interchain.ivaldilabs.xyz",
+        "provider": "ivaldilabs"
       }
     ],
     "rest": [
@@ -198,6 +202,10 @@
       {
         "address": "https://axelar-lcd.quantnode.tech/",
         "provider": "QuantNode"
+      },
+      {
+        "address": "https://axelar.rest.interchain.ivaldilabs.xyz",
+        "provider": "ivaldilabs"
       }
     ],
     "grpc": [
@@ -228,6 +236,10 @@
       {
         "address": "axelar-mainnet-grpc.autostake.net:443",
         "provider": "AutoStake 🛡️ Slash Protected"
+      },
+      {
+        "address": "axelar.grpc.interchain.ivaldilabs.xyz:443",
+        "provider": "ivaldilabs"
       }
     ]
   },

--- a/cosmoshub/chain.json
+++ b/cosmoshub/chain.json
@@ -156,6 +156,10 @@
       {
         "address": "http://rpc-cosmoshub.freshstaking.com:26657",
         "provider": "FreshSTAKING"
+      },
+      {
+        "address": "https://cosmoshub.rpc.interchain.ivaldilabs.xyz",
+        "provider": "ivaldilabs"
       }
     ],
     "rest": [
@@ -198,6 +202,10 @@
       {
         "address": "https://rest-cosmoshub.ecostake.com",
         "provider": "ecostake"
+      },
+      {
+        "address": "https://cosmoshub.rest.interchain.ivaldilabs.xyz",
+        "provider": "ivaldilabs"
       }
     ],
     "grpc": [
@@ -224,6 +232,10 @@
       {
         "address": "cosmoshub.grpc.stakin-nodes.com:443",
         "provider": "Stakin"
+      },
+      {
+        "address": "cosmoshub.grpc.interchain.ivaldilabs.xyz:443",
+        "provider": "ivaldilabs"
       }
     ]
   },

--- a/evmos/chain.json
+++ b/evmos/chain.json
@@ -218,6 +218,10 @@
       {
         "address": "https://evmos-rpc.stakeandrelax.net",
         "provider": "Stake&Relax Validator 🦥"
+      },
+      {
+        "address": "https://evmos.rpc.interchain.ivaldilabs.xyz",
+        "provider": "ivaldilabs"
       }
     ],
     "rest": [
@@ -288,6 +292,10 @@
       {
         "address": "https://rest-evmos.ecostake.com",
         "provider": "ecostake"
+      },
+      {
+        "address": "https://evmos.rest.interchain.ivaldilabs.xyz",
+        "provider": "ivaldilabs"
       }
     ],
     "grpc": [
@@ -326,6 +334,10 @@
       {
         "address": "evmos.grpc.stakin-nodes.com:443",
         "provider": "Stakin"
+      },
+      {
+        "address": "evmos.grpc.interchain.ivaldilabs.xyz:443",
+        "provider": "ivaldilabs"
       }
     ],
     "evm-http-jsonrpc": [

--- a/juno/chain.json
+++ b/juno/chain.json
@@ -33,9 +33,9 @@
   },
   "codebase": {
     "git_repo": "https://github.com/CosmosContracts/juno",
-    "recommended_version": "v13.0.0",
+    "recommended_version": "v12.0.0",
     "compatible_versions": [
-      "v13.0.0"
+      "v12.0.0"
     ],
     "cosmos_sdk_version": "0.45",
     "tendermint_version": "0.34",
@@ -190,6 +190,10 @@
       {
         "address": "https://rpc-juno.architectnodes.com",
         "provider": "Architect Nodes"
+      },
+      {
+        "address": "https://juno.rpc.interchain.ivaldilabs.xyz",
+        "provider": "ivaldilabs"
       }
     ],
     "rest": [
@@ -256,6 +260,10 @@
       {
         "address": "https://juno-mainnet-lcd.autostake.net:443",
         "provider": "AutoStake 🛡️ Slash Protected"
+      },
+      {
+        "address": "https://juno.rest.interchain.ivaldilabs.xyz",
+        "provider": "ivaldilabs"
       }
     ],
     "grpc": [
@@ -290,6 +298,10 @@
       {
         "address": "juno-mainnet-grpc.autostake.net:443",
         "provider": "AutoStake 🛡️ Slash Protected"
+      },
+      {
+        "address": "juno.grpc.interchain.ivaldilabs.xyz:443",
+        "provider": "ivaldilabs"
       }
     ]
   },

--- a/osmosis/chain.json
+++ b/osmosis/chain.json
@@ -233,6 +233,10 @@
       {
         "address": "https://osmosis-mainnet-rpc.autostake.net:443",
         "provider": "AutoStake 🛡️ Slash Protected"
+      },
+      {
+        "address": "https://osmosis.rpc.interchain.ivaldilabs.xyz",
+        "provider": "ivaldilabs"
       }
     ],
     "rest": [
@@ -279,6 +283,10 @@
       {
         "address": "https://osmosis-mainnet-lcd.autostake.net:443",
         "provider": "AutoStake 🛡️ Slash Protected"
+      },
+      {
+        "address": "https://osmosis.rest.interchain.ivaldilabs.xyz",
+        "provider": "ivaldilabs"
       }
     ],
     "grpc": [
@@ -293,6 +301,10 @@
       {
         "address": "osmosis.grpc.stakin-nodes.com:443",
         "provider": "Stakin"
+      },
+      {
+        "address": "osmosis.grpc.interchain.ivaldilabs.xyz:433",
+        "provider": "ivaldilabs"
       }
     ]
   },

--- a/stride/chain.json
+++ b/stride/chain.json
@@ -170,7 +170,11 @@
       {
         "address": "https://stride-rpc.stakeandrelax.net",
         "provider": "Stake&Relax Validator 🦥"
-      }      
+      },
+      {
+        "address": "https://stride.rpc.interchain.ivaldilabs.xyz",
+        "provider": "ivaldilabs"
+      }
     ],
     "rest": [
       {
@@ -224,7 +228,11 @@
       {
         "address": "https://stride-api.stakeandrelax.net",
         "provider": "Stake&Relax Validator 🦥"
-      }      
+      },
+      {
+        "address": "https://stride.rest.interchain.ivaldilabs.xyz",
+        "provider": "ivaldilabs"
+      }
     ],
     "grpc": [
       {
@@ -242,6 +250,10 @@
       {
         "address": "stride-mainnet-grpc.autostake.net:443",
         "provider": "AutoStake 🛡️ Slash Protected"
+      },
+      {
+        "address": "stride.grpc.interchain.ivaldilabs.xyz:443",
+        "provider": "ivaldilabs"
       }
     ]
   },


### PR DESCRIPTION
These were removed in a previous clean-up PR, but wrongly so we believe