### PR TITLE
Update version and binary links

### DIFF
--- a/jackal/chain.json
+++ b/jackal/chain.json
@@ -33,13 +33,13 @@
   },
   "codebase": {
     "git_repo": "https://github.com/JackalLabs/canine-chain",
-    "recommended_version": "v1.1.2-hotfix",
+    "recommended_version": "v1.2.1",
     "compatible_versions": [
-      "v1.1.2-hotfix"
+      "v1.2.1"
     ],
     "binaries": {
-      "linux/amd64": "https://github.com/JackalLabs/canine-chain/releases/download/v1.1.2/canined-Linux",
-      "darwin/amd64": "https://github.com/JackalLabs/canine-chain/releases/download/v1.1.2/canined-macOS"
+      "linux/amd64": "https://github.com/JackalLabs/canine-chain/releases/download/v1.2.1/canined-Linux",
+      "darwin/amd64": "https://github.com/JackalLabs/canine-chain/releases/download/v1.2.1/canined-macOS"
     },
     "genesis": {
       "genesis_url": "https://cdn.discordapp.com/attachments/1002389406650466405/1034968352591986859/updated_genesis2.json"


### PR DESCRIPTION
Update version to 1.2.1 and update links to binary downloads for Linux/OSX

Block Height: 2080380
Prop: https://ping.pub/jackal/gov/2