### PR TITLE
Updated chain database for new node hostnames

### DIFF
--- a/testnets/cudostestnet/chain.json
+++ b/testnets/cudostestnet/chain.json
@@ -3,7 +3,7 @@
   "chain_name": "cudostestnet",
   "status": "live",
   "network_type": "testnet",
-  "pretty_name": "Cudos testnet",
+  "pretty_name": "Cudos Testnet",
   "chain_id": "cudos-testnet-public-3",
   "bech32_prefix": "cudos",
   "key_algos": [
@@ -12,36 +12,46 @@
   "slip44": 118,
   "codebase": {
     "git_repo": "https://github.com/CudoVentures/cudos-node",
-    "recommended_version": "v0.9.0",
+    "recommended_version": "v1.1.0",
     "compatible_versions": [
-      "v0.9.0"
+      "v1.1.0"
     ],
     "genesis": {
-      "genesis_url": "https://github.com/CudoVentures/cudos-builders/blob/v0.9.0/docker/config/genesis.testnet.public.json"
+      "genesis_url": "https://raw.githubusercontent.com/CudoVentures/cudos-builders/cudos-master/docker/config/genesis.testnet.public.json"
     }
   },
   "peers": {
     "seeds": [
       {
-        "id": "86a2f5d723718a030ee436dc792d14c42ba0bd3f",
-        "address": "34.67.137.129:26656",
+        "id": "ee9f57fa3d29a7b88df01dd69f1537c5687b8fd6",
+        "address": "seed-01.hosts.testnet.cudos.org:26656",
         "provider": "cudo"
       },
       {
-        "id": "a48e90ce5e7d01c40bc4352794f034880c2f2041",
-        "address": "34.102.114.30:26656",
+        "id": "8c9f61d1783b4ab9707ef4dc99d07c9cd0ae5155",
+        "address": "seed-02.hosts.testnet.cudos.org:26656",
         "provider": "cudo"
-      },
+      },        
       {
-        "id": "f93e129f120fd1de3e9d60d2bd376ae96af325dd",
-        "address": "34.141.129.16:26656",
+        "id": "56543c24150a939095558c16dee031bf2fb2feb5",
+        "address": "seed-03.hosts.testnet.cudos.org:26656",
         "provider": "cudo"
       }
     ],
     "persistent_peers": [
       {
-        "id": "b48994dd2f25de4c2355cbda1681c5e8bbc1e8f2",
-        "address": "34.91.31.157:26656",
+        "id": "0ccf54158f9c340f1fdacf6b4884ca8c8372a923",
+        "address": "sentry-01.hosts.testnet.cudos.org:26656",
+        "provider": "cudo"
+      },
+      {
+        "id": "7c48114327bfd3ff3b396cda8b33a24c5d0ad172",
+        "address": "sentry-02.hosts.testnet.cudos.org:26656",
+        "provider": "cudo"
+      },
+      {
+        "id": "d2693512dc45cc856300bcc1b8fd518ab5b2d343",
+        "address": "sentry-03.hosts.testnet.cudos.org:26656",
         "provider": "cudo"
       }
     ]
@@ -49,79 +59,55 @@
   "apis": {
     "rpc": [
       {
-        "address": "http://sentry1.gcp-uscentral1.cudos.org:26657",
+        "address": "https://rpc.testnet.cudos.org:443/",
         "provider": "cudo"
       },
       {
-        "address": "https://sentry1.gcp-uscentral1.cudos.org:36657",
+        "address": "http://sentry-01.hosts.testnet.cudos.org:26657",
         "provider": "cudo"
       },
       {
-        "address": "http://sentry2.gcp-uswest2.cudos.org:26657",
+        "address": "http://sentry-02.hosts.testnet.cudos.org:26657",
         "provider": "cudo"
       },
       {
-        "address": "https://sentry2.gcp-uswest2.cudos.org:36657",
-        "provider": "cudo"
-      },
-      {
-        "address": "http://sentry3.gcp-euwest4.cudos.org:26657",
-        "provider": "cudo"
-      },
-      {
-        "address": "https://sentry3.gcp-euwest4.cudos.org:36657",
+        "address": "http://sentry-03.hosts.testnet.cudos.org:26657",
         "provider": "cudo"
       }
     ],
     "rest": [
       {
-        "address": "http://sentry1.gcp-uscentral1.cudos.org:1317",
+        "address": "https://rest.testnet.cudos.org:443",
         "provider": "cudo"
       },
       {
-        "address": "https://sentry1.gcp-uscentral1.cudos.org:31317",
+        "address": "http://sentry-01.hosts.testnet.cudos.org:1317/",
         "provider": "cudo"
       },
       {
-        "address": "http://sentry2.gcp-uswest2.cudos.org:1317",
+        "address": "http://sentry-02.hosts.testnet.cudos.org:1317/",
         "provider": "cudo"
       },
       {
-        "address": "https://sentry2.gcp-uswest2.cudos.org:31317",
-        "provider": "cudo"
-      },
-      {
-        "address": "http://sentry3.gcp-euwest4.cudos.org:1317",
-        "provider": "cudo"
-      },
-      {
-        "address": "https://sentry3.gcp-euwest4.cudos.org:31317",
+        "address": "http://sentry-03.hosts.testnet.cudos.org:1317/",
         "provider": "cudo"
       }
     ],
     "grpc": [
       {
-        "address": "http://sentry1.gcp-uscentral1.cudos.org:9090",
+        "address": "https://grpc.testnet.cudos.org:433",
         "provider": "cudo"
       },
       {
-        "address": "https://sentry1.gcp-uscentral1.cudos.org:39090",
+        "address": "http://sentry-01.hosts.testnet.cudos.org:9090",
         "provider": "cudo"
       },
       {
-        "address": "http://sentry2.gcp-uswest2.cudos.org:9090",
+        "address": "http://sentry-02.hosts.testnet.cudos.org:9090",
         "provider": "cudo"
       },
       {
-        "address": "https://sentry2.gcp-uswest2.cudos.org:39090",
-        "provider": "cudo"
-      },
-      {
-        "address": "http://sentry3.gcp-euwest4.cudos.org:9090",
-        "provider": "cudo"
-      },
-      {
-        "address": "https://sentry3.gcp-euwest4.cudos.org:39090",
+        "address": "http://sentry-03.hosts.testnet.cudos.org:9090",
         "provider": "cudo"
       }
     ]


### PR DESCRIPTION
The Cudos public testnet machines have recently been migrated to a new set of platforms and have now been given more generic names for future proofing.