### PR TITLE
Upgrade from ixo-4 to ixo-5

### DIFF
--- a/impacthub/chain.json
+++ b/impacthub/chain.json
@@ -5,7 +5,7 @@
   "network_type": "mainnet",
   "website": "https://www.ixo.world/",
   "pretty_name": "ixo",
-  "chain_id": "ixo-4",
+  "chain_id": "ixo-5",
   "bech32_prefix": "ixo",
   "daemon_name": "ixod",
   "node_home": "$HOME/.ixod",
@@ -34,12 +34,12 @@
   },
   "codebase": {
     "git_repo": "https://github.com/ixofoundation/ixo-blockchain",
-    "recommended_version": "v0.19.3",
+    "recommended_version": "v0.20.0",
     "compatible_versions": [
-      "v0.19.3"
+      "v0.20.0"
     ],
     "genesis": {
-      "genesis_url": "https://raw.githubusercontent.com/ixofoundation/genesis/980961a8e344dd39bd092493e58b4421aa1c0014/ixo-4/genesis.json"
+      "genesis_url": "https://github.com/ixofoundation/genesis/blob/bc042e1223d551b22d55c155de06e662ca24d2f2/ixo-5/genesis.json.tar.gz"
     }
   },
   "peers": {


### PR DESCRIPTION
ixo upgraded it's chain today with the following changes:
- chain-id from ixo-4 to ixo-5
- codebase -> version change from v0.19.3 to v0.20.0
- genesis url changed