### PR TITLE
quicksilver: RPC cleanup

### DIFF
--- a/quicksilver/chain.json
+++ b/quicksilver/chain.json
@@ -104,6 +104,14 @@
         "provider": "Lavender.Five Nodes 🐝"
       },
       {
+        "address": "https://m-quicksilver.rpc.utsa.tech",
+        "provider": "lesnik | UTSA"
+      },
+      {
+        "address": "https://quicksilver-mainnet-rpc.autostake.com:443",
+        "provider": "AutoStake 🛡️ Slash Protected"
+      },
+      {
         "address": "https://quicksilver-rpc.ibs.team:443",
         "provider": "Inter Blockchain Services"
       }

--- a/quicksilver/chain.json
+++ b/quicksilver/chain.json
@@ -132,10 +132,6 @@
       {
         "address": "https://m-quicksilver.api.utsa.tech",
         "provider": "lesnik | UTSA"
-      },
-      {
-        "address": "https://api-quicksilver.nodeist.net",
-        "provider": "Nodeist"
       }
     ],
     "grpc": [

--- a/quicksilver/chain.json
+++ b/quicksilver/chain.json
@@ -104,24 +104,8 @@
         "provider": "Lavender.Five Nodes 🐝"
       },
       {
-        "address": "https://m-quicksilver.rpc.utsa.tech",
-        "provider": "lesnik | UTSA"
-      },
-      {
-        "address": "https://rpc-quicksilver.nodeist.net",
-        "provider": "Nodeist"
-      },
-      {
-        "address": "https://quicksilver-mainnet-rpc.autostake.com:443",
-        "provider": "AutoStake 🛡️ Slash Protected"
-      },
-      {
-        "address": "https://quicksilver-rpc.ibs.team",
+        "address": "https://quicksilver-rpc.ibs.team:443",
         "provider": "Inter Blockchain Services"
-      },
-      {
-        "address": "wss://gql-testnet.quicksilver.forbole.com/websocket",
-        "provider": "Forbole"
       }
     ],
     "rest": [


### PR DESCRIPTION
I don't know exactly how the cosmos.directory RPC proxy works (would love to know, if you care to share!) but I suspect it handles the last two, if it makes more sense to leave them in the config.  For whatever reason, though, the proxy seems to consistently route to the first endpoint below, and because that endpoint requires 25x higher fees than the chain itself, any dApp with hard-coded reliance on the proxy endpoint (e.g. restake.app) deterministically fails.  Apologies for my ignorance if my understanding is somehow off base!

This PR...
- removes the `lesnik | UTSA` RPC endpoint (fee settings appear to be misaligned, causing tx failure)
- removes the `Nodeist` RPC endpoint (all API calls timeout)
- removes the `Forbole` RPC endpoint (the binary, at least, has no idea what to do with the `wss://` scheme)

