### PR TITLE
Add consensus to chain.json

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,10 @@ A sample `chain.json` includes the following information.
       "v12.2.0"
     ],
     "cosmos_sdk_version": "0.46",
-    "tendermint_version": "0.34",
+    "consensus": {
+      "type": "tendermint",
+      "version": "0.34"
+    },
     "cosmwasm_version": "0.28",
     "cosmwasm_enabled": true,
     "ibc_go_version": "3.0.0",

--- a/bluzelle/chain.json
+++ b/bluzelle/chain.json
@@ -38,7 +38,10 @@
       "v2.0"
     ],
     "cosmos_sdk_version": "0.44.3",
-    "tendermint_version": "0.34.14",
+    "consensus": {
+      "type": "tendermint",
+      "version": "0.34.14"
+    },
     "genesis": {
       "genesis_url": "https://a.client.sentry.net.bluzelle.com:26657/genesis"
     }

--- a/chain.schema.json
+++ b/chain.schema.json
@@ -209,7 +209,7 @@
         "cosmos_sdk_version": {
           "type": "string"
         },
-        "concensus": {
+        "consensus": {
           "type": "object",
           "required": [
             "type"

--- a/chain.schema.json
+++ b/chain.schema.json
@@ -227,7 +227,7 @@
             }
           },
           "additionalProperties": false
-        }
+        },
         "cosmwasm_version": {
           "type": "string"
         },

--- a/chain.schema.json
+++ b/chain.schema.json
@@ -209,9 +209,25 @@
         "cosmos_sdk_version": {
           "type": "string"
         },
-        "tendermint_version": {
-          "type": "string"
-        },
+        "concensus": {
+          "type": "object",
+          "required": [
+            "type"
+          ],
+          "properties": {
+            "type": {
+              "type": "string",
+              "enum": [
+                "tendermint",
+                "cometbft"
+              ]
+            },
+            "version": {
+              "type": "string"
+            }
+          },
+          "additionalProperties": false
+        }
         "cosmwasm_version": {
           "type": "string"
         },

--- a/cheqd/chain.json
+++ b/cheqd/chain.json
@@ -40,7 +40,10 @@
       "linux/arm64": "https://github.com/cheqd/cheqd-node/releases/download/v1.2.2/cheqd-noded-1.2.2-Linux-arm64.tar.gz"
     },
     "cosmos_sdk_version": "0.46.8",
-    "tendermint_version": "0.34.24",
+    "consensus": {
+      "type": "tendermint",
+      "version": "0.34.24"
+    },
     "genesis": {
       "genesis_url": "https://raw.githubusercontent.com/cheqd/cheqd-node/main/networks/mainnet/genesis.json"
     }

--- a/coreum/chain.json
+++ b/coreum/chain.json
@@ -45,7 +45,10 @@
       "linux/arm64": "https://github.com/CoreumFoundation/coreum/releases/download/v1.0.0/cored-linux-arm64?checksum=sha256:3ced97f06607f0cdaf77e7ff0b36b2011d101c660684e4f3e54c2ac6bf344dd6"
     },
     "cosmos_sdk_version": "0.45",
-    "tendermint_version": "0.34",
+    "consensus": {
+      "type": "tendermint",
+      "version": "0.34"
+    },
     "cosmwasm_version": "0.30",
     "cosmwasm_enabled": true,
     "genesis": {
@@ -113,7 +116,6 @@
         "address": "https://full-node.mainnet-1.coreum.dev:9090",
         "provider": "Coreum Foundation"
       },
-
       {
         "address": "https://full-node-californium.mainnet-1.coreum.dev:9090",
         "provider": "Coreum Foundation"

--- a/evmos/chain.json
+++ b/evmos/chain.json
@@ -50,7 +50,10 @@
       "windows/amd64": "https://github.com/evmos/evmos/releases/download/v11.0.2/evmos_11.0.2_Windows_amd64.zip"
     },
     "cosmos_sdk_version": "0.46",
-    "tendermint_version": "0.34",
+    "consensus": {
+      "type": "tendermint",
+      "version": "0.34"
+    },
     "ibc_go_version": "6.1.0",
     "genesis": {
       "genesis_url": "https://archive.evmos.org/mainnet/genesis.json"
@@ -112,7 +115,7 @@
         "id": "e726816f42831689eab9378d5d577f1d06d25716",
         "address": "evmos-seed-2.allnodes.me:26656",
         "provider": "Allnodes.com ⚡️ Nodes & Staking"
-      }      
+      }
     ],
     "persistent_peers": [
       {

--- a/juno/chain.json
+++ b/juno/chain.json
@@ -38,7 +38,10 @@
       "v13.0.0"
     ],
     "cosmos_sdk_version": "0.45",
-    "tendermint_version": "0.34",
+    "consensus": {
+      "type": "tendermint",
+      "version": "0.34"
+    },
     "cosmwasm_version": "0.30",
     "cosmwasm_enabled": true,
     "genesis": {

--- a/likecoin/chain.json
+++ b/likecoin/chain.json
@@ -44,7 +44,10 @@
       "windows/amd64": "https://github.com/likecoin/likecoin-chain/releases/download/v3.1.0/likecoin-chain_3.1.0_Windows_x86_64.zip"
     },
     "cosmos_sdk_version": "0.45",
-    "tendermint_version": "0.34",
+    "consensus": {
+      "type": "tendermint",
+      "version": "0.34"
+    },
     "genesis": {
       "genesis_url": "https://raw.githubusercontent.com/likecoin/mainnet/982c14399089950a59d3ebbedcbbc7ead6040457/genesis.json"
     }

--- a/mars/chain.json
+++ b/mars/chain.json
@@ -41,7 +41,10 @@
       "v1.0.0"
     ],
     "cosmos_sdk_version": "0.46.7",
-    "tendermint_version": "0.34.24",
+    "consensus": {
+      "type": "tendermint",
+      "version": "0.34.24"
+    },
     "cosmwasm_version": "0.30.0",
     "cosmwasm_enabled": true,
     "ibc_go_version": "6.1.0",

--- a/migaloo/chain.json
+++ b/migaloo/chain.json
@@ -17,10 +17,10 @@
     "fee_tokens": [
       {
         "denom": "uwhale",
-        "fixed_min_gas_price": 0.0,
-        "low_gas_price": 0.0,
-        "average_gas_price": 0.0,
-        "high_gas_price": 0.0
+        "fixed_min_gas_price": 0,
+        "low_gas_price": 0,
+        "average_gas_price": 0,
+        "high_gas_price": 0
       }
     ]
   },
@@ -38,7 +38,10 @@
       "v1.0.0"
     ],
     "cosmos_sdk_version": "0.45",
-    "tendermint_version": "0.34",
+    "consensus": {
+      "type": "tendermint",
+      "version": "0.34"
+    },
     "cosmwasm_version": "0.28",
     "cosmwasm_enabled": true,
     "genesis": {

--- a/onomy/chain.json
+++ b/onomy/chain.json
@@ -41,7 +41,10 @@
       "linux/arm64": "https://github.com/onomyprotocol/onomy/releases/download/v1.0.1/onomyd-arm"
     },
     "cosmos_sdk_version": "0.44",
-    "tendermint_version": "0.34",
+    "consensus": {
+      "type": "tendermint",
+      "version": "0.34"
+    },
     "ibc_go_version": "2.0.4",
     "genesis": {
       "genesis_url": "https://raw.githubusercontent.com/onomyprotocol/onomy/main/genesis/mainnet/genesis-mainnet-1.json"

--- a/osmosis/chain.json
+++ b/osmosis/chain.json
@@ -46,7 +46,10 @@
       "linux/arm64": "https://github.com/osmosis-labs/osmosis/releases/download/v15.0.0/osmosisd-15.0.0-linux-arm64?checksum=sha256:94aee34e288148b155a2b0fdfe268a0bdc0d4a90de6db8f8a9cee74c2e829294"
     },
     "cosmos_sdk_version": "0.45",
-    "tendermint_version": "0.34",
+    "consensus": {
+      "type": "tendermint",
+      "version": "0.34"
+    },
     "cosmwasm_version": "0.30",
     "cosmwasm_enabled": true,
     "ibc_go_version": "4.3.0",

--- a/quasar/chain.json
+++ b/quasar/chain.json
@@ -43,7 +43,10 @@
       "v0.1.0"
     ],
     "cosmos_sdk_version": "0.46",
-    "tendermint_version": "0.34",
+    "consensus": {
+      "type": "tendermint",
+      "version": "0.34"
+    },
     "cosmwasm_version": "0.27",
     "cosmwasm_enabled": true,
     "genesis": {
@@ -74,7 +77,8 @@
       }
     ],
     "persistent_peers": [
-      { "id": "298e0e1faf8a5da43514cc2908d2908658e732a0",
+      {
+        "id": "298e0e1faf8a5da43514cc2908d2908658e732a0",
         "address": "298e0e1faf8a5da43514cc2908d2908658e732a0@38.146.3.148:18256"
       }
     ]

--- a/quicksilver/chain.json
+++ b/quicksilver/chain.json
@@ -35,7 +35,10 @@
       "v1.2.7"
     ],
     "cosmos_sdk_version": "0.46",
-    "tendermint_version": "0.34",
+    "consensus": {
+      "type": "tendermint",
+      "version": "0.34"
+    },
     "cosmwasm_version": "0.29",
     "cosmwasm_enabled": true,
     "ibc_go_version": "5.2.0",

--- a/regen/chain.json
+++ b/regen/chain.json
@@ -43,7 +43,10 @@
       "darwin/arm64": "https://github.com/regen-network/regen-ledger/releases/download/v5.0.0/regen-ledger_5.0.0_darwin_arm64.zip"
     },
     "cosmos_sdk_version": "0.46",
-    "tendermint_version": "0.34",
+    "consensus": {
+      "type": "tendermint",
+      "version": "0.34"
+    },
     "ibc_go_version": "5.2",
     "ics_enabled": [
       "ics20-1",

--- a/shareledger/chain.json
+++ b/shareledger/chain.json
@@ -41,7 +41,10 @@
       "linux/amd64": "https://github.com/ShareRing/Shareledger/releases/download/v1.4.1/shareledger"
     },
     "cosmos_sdk_version": "0.45",
-    "tendermint_version": "0.34",
+    "consensus": {
+      "type": "tendermint",
+      "version": "0.34"
+    },
     "cosmwasm_version": "0.27",
     "cosmwasm_enabled": true,
     "ibc_go_version": "3.0.0",

--- a/stride/chain.json
+++ b/stride/chain.json
@@ -38,7 +38,10 @@
       "v7.0.0"
     ],
     "cosmos_sdk_version": "0.46",
-    "tendermint_version": "0.34",
+    "consensus": {
+      "type": "tendermint",
+      "version": "0.34"
+    },
     "cosmwasm_version": "0.29",
     "cosmwasm_enabled": true,
     "ibc_go_version": "5.1.0",

--- a/testnets/cheqdtestnet/chain.json
+++ b/testnets/cheqdtestnet/chain.json
@@ -32,7 +32,10 @@
       "linux/arm64": "https://github.com/cheqd/cheqd-node/releases/download/v1.2.2/cheqd-noded-1.2.2-Linux-arm64.tar.gz"
     },
     "cosmos_sdk_version": "0.46.8",
-    "tendermint_version": "0.34.24",
+    "consensus": {
+      "type": "tendermint",
+      "version": "0.34.24"
+    },
     "genesis": {
       "genesis_url": "https://raw.githubusercontent.com/cheqd/cheqd-node/main/networks/testnet/genesis.json"
     }

--- a/testnets/coreumtestnet/chain.json
+++ b/testnets/coreumtestnet/chain.json
@@ -45,7 +45,10 @@
       "linux/arm64": "https://github.com/CoreumFoundation/coreum/releases/download/v0.1.1/cored-linux-arm64?checksum=sha256:7d383d1a1bc9185677b25c05ebbe01cf20dd6c779ca4301065359ea6e3bcefa3"
     },
     "cosmos_sdk_version": "0.45",
-    "tendermint_version": "0.34",
+    "consensus": {
+      "type": "tendermint",
+      "version": "0.34"
+    },
     "cosmwasm_version": "0.30",
     "cosmwasm_enabled": true,
     "genesis": {

--- a/testnets/cosmwasmtestnet/chain.json
+++ b/testnets/cosmwasmtestnet/chain.json
@@ -36,7 +36,10 @@
       "v0.27"
     ],
     "cosmos_sdk_version": "0.45",
-    "tendermint_version": "0.34",
+    "consensus": {
+      "type": "tendermint",
+      "version": "0.34"
+    },
     "cosmwasm_version": "0.27",
     "cosmwasm_enabled": true,
     "genesis": {

--- a/testnets/evmostestnet/chain.json
+++ b/testnets/evmostestnet/chain.json
@@ -39,7 +39,10 @@
       "v11.0.0-rc3"
     ],
     "cosmos_sdk_version": "0.46",
-    "tendermint_version": "0.34",
+    "consensus": {
+      "type": "tendermint",
+      "version": "0.34"
+    },
     "ibc_go_version": "v6.1.0",
     "genesis": {
       "genesis_url": "https://github.com/evmos/testnets/raw/main/evmos_9000-4/genesis.zip"

--- a/testnets/junotestnet/chain.json
+++ b/testnets/junotestnet/chain.json
@@ -33,10 +33,13 @@
     "git_repo": "https://github.com/CosmosContracts/juno",
     "recommended_version": "v13.0.0-beta.1",
     "compatible_versions": [
-       "v13.0.0-beta.1"
+      "v13.0.0-beta.1"
     ],
     "cosmos_sdk_version": "0.45",
-    "tendermint_version": "0.34",
+    "consensus": {
+      "type": "tendermint",
+      "version": "0.34"
+    },
     "cosmwasm_version": "0.30",
     "cosmwasm_enabled": true,
     "ibc_go_version": "4.3.0",

--- a/testnets/neutrontestnet/chain.json
+++ b/testnets/neutrontestnet/chain.json
@@ -27,7 +27,10 @@
     "recommended_version": "v0.2.0",
     "compatible_versions": [],
     "cosmos_sdk_version": "0.45",
-    "tendermint_version": "0.34",
+    "consensus": {
+      "type": "tendermint",
+      "version": "0.34"
+    },
     "cosmwasm_version": "0.30",
     "cosmwasm_enabled": true,
     "ibc_go_version": "4.2.0",

--- a/testnets/osmosistestnet/chain.json
+++ b/testnets/osmosistestnet/chain.json
@@ -37,7 +37,10 @@
       "v14.0.0-rc1"
     ],
     "cosmos_sdk_version": "0.45",
-    "tendermint_version": "0.34",
+    "consensus": {
+      "type": "tendermint",
+      "version": "0.34"
+    },
     "cosmwasm_version": "0.29",
     "cosmwasm_enabled": true,
     "genesis": {

--- a/testnets/quasartestnet/chain.json
+++ b/testnets/quasartestnet/chain.json
@@ -25,7 +25,10 @@
       "v0.0.2-alpha-11"
     ],
     "cosmos_sdk_version": "0.46",
-    "tendermint_version": "0.34",
+    "consensus": {
+      "type": "tendermint",
+      "version": "0.34"
+    },
     "cosmwasm_version": "0.27",
     "cosmwasm_enabled": true,
     "genesis": {
@@ -46,55 +49,68 @@
       }
     ],
     "persistent_peers": [
-      { "id": "8a19aa6e874ed5720aad2e7d02567ec932d92d22",
+      {
+        "id": "8a19aa6e874ed5720aad2e7d02567ec932d92d22",
         "address": "141.94.248.63:26656",
         "provider": ""
       },
-      { "id": "444b80ce750976df59b88ac2e08d720e1dbbf230",
+      {
+        "id": "444b80ce750976df59b88ac2e08d720e1dbbf230",
         "address": "68.183.75.239:26666",
         "provider": ""
       },
-      { "id": "20b4f9207cdc9d0310399f848f057621f7251846",
+      {
+        "id": "20b4f9207cdc9d0310399f848f057621f7251846",
         "address": "222.106.187.13:40606",
         "provider": ""
       },
-      { "id": "7ef67269c8ec37ff8a538a5ae83ca670fd2da686",
+      {
+        "id": "7ef67269c8ec37ff8a538a5ae83ca670fd2da686",
         "address": "137.184.192.123:26656",
         "provider": ""
       },
-      { "id": "19afe579cc0a2b38ca87143f779f45e9a7f18a2f",
+      {
+        "id": "19afe579cc0a2b38ca87143f779f45e9a7f18a2f",
         "address": "18.134.191.148:26656",
         "provider": ""
       },
-      { "id": "a23f002bda10cb90fa441a9f2435802b35164441",
+      {
+        "id": "a23f002bda10cb90fa441a9f2435802b35164441",
         "address": "38.146.3.203:18256",
         "provider": ""
       },
-      { "id": "bba6e85e3d1f1d9c127324e71a982ddd86af9a99",
+      {
+        "id": "bba6e85e3d1f1d9c127324e71a982ddd86af9a99",
         "address": "88.99.3.158:18256",
         "provider": ""
       },
-      { "id": "966acc999443bae0857604a9fce426b5e09a7409",
+      {
+        "id": "966acc999443bae0857604a9fce426b5e09a7409",
         "address": "65.108.105.48:18256 ",
         "provider": ""
       },
-      { "id": "177144bed1e280a6f2435d253441e3e4f1699c6d",
+      {
+        "id": "177144bed1e280a6f2435d253441e3e4f1699c6d",
         "address": "65.109.85.226:8090",
         "provider": ""
       },
-      { "id": "769ebaa9942375e70cebc21a75a2cfda41049d99",
+      {
+        "id": "769ebaa9942375e70cebc21a75a2cfda41049d99",
         "address": "135.181.210.186:26656",
         "provider": ""
       },
-      { "id": "8937bdacf1f0c8b2d1ffb4606554eaf08bd55df4",
+      {
+        "id": "8937bdacf1f0c8b2d1ffb4606554eaf08bd55df4",
         "address": "5.75.255.107:26656",
         "provider": ""
       },
-      { "id": "99a0695a7358fa520e6fcd46f91492f7cf205d4d",
+      {
+        "id": "99a0695a7358fa520e6fcd46f91492f7cf205d4d",
         "address": "34.175.159.249:26656",
         "provider": ""
       },
-      { "id": "47401f4ac3f934afad079ddbe4733e66b58b67da",
+      {
+        "id": "47401f4ac3f934afad079ddbe4733e66b58b67da",
         "address": "34.175.244.202:26656",
         "provider": ""
       }

--- a/testnets/quicksilvertestnet/chain.json
+++ b/testnets/quicksilvertestnet/chain.json
@@ -30,7 +30,10 @@
       "v1.4.0-rc7"
     ],
     "cosmos_sdk_version": "0.46",
-    "tendermint_version": "0.34",
+    "consensus": {
+      "type": "tendermint",
+      "version": "0.34"
+    },
     "cosmwasm_version": "0.29",
     "cosmwasm_enabled": true,
     "ibc_go_version": "5.2.0",

--- a/testnets/qwoyntestnet/chain.json
+++ b/testnets/qwoyntestnet/chain.json
@@ -37,7 +37,10 @@
       "linux/amd64": "https://github.com/cosmic-horizon/QWOYN/releases/download/v1.0.0/qwoynd_1.0.0_linux_amd64.zip"
     },
     "cosmos_sdk_version": "0.42.10",
-    "tendermint_version": "0.34",
+    "consensus": {
+      "type": "tendermint",
+      "version": "0.34"
+    },
     "ibc_go_version": "3.0.0",
     "ics_enabled": [
       "ics20-1",

--- a/testnets/sourcetestnet/chain.json
+++ b/testnets/sourcetestnet/chain.json
@@ -33,10 +33,13 @@
     "git_repo": "https://github.com/Source-Protocol-Cosmos/source",
     "recommended_version": "v1.0.0",
     "compatible_versions": [
-       "v1.0.0"
+      "v1.0.0"
     ],
     "cosmos_sdk_version": "0.45",
-    "tendermint_version": "0.34",
+    "consensus": {
+      "type": "tendermint",
+      "version": "0.34"
+    },
     "cosmwasm_version": "0.25",
     "cosmwasm_enabled": true,
     "ibc_go_version": "2.2.0",
@@ -58,11 +61,13 @@
         "address": "164.92.98.17:26656",
         "provider": "Source"
       },
-      { "id": "b02e2bd359623aeee2d4fad94d37af8b064508f6",
+      {
+        "id": "b02e2bd359623aeee2d4fad94d37af8b064508f6",
         "address": "167.235.224.141:26656",
         "provider": ""
       },
-      { "id": "bdf9b6ad38b803358e7fd99f35b14795ebcd8144",
+      {
+        "id": "bdf9b6ad38b803358e7fd99f35b14795ebcd8144",
         "address": "190.2.155.67:29656",
         "provider": ""
       }

--- a/testnets/stargazetestnet/chain.json
+++ b/testnets/stargazetestnet/chain.json
@@ -27,7 +27,10 @@
       "v7.0.0"
     ],
     "cosmos_sdk_version": "0.45",
-    "tendermint_version": "0.34",
+    "consensus": {
+      "type": "tendermint",
+      "version": "0.34"
+    },
     "cosmwasm_version": "0.28",
     "cosmwasm_enabled": true,
     "genesis": {

--- a/testnets/stridetestnet/chain.json
+++ b/testnets/stridetestnet/chain.json
@@ -34,7 +34,10 @@
       "v5.1.1-testnet"
     ],
     "cosmos_sdk_version": "0.46",
-    "tendermint_version": "0.34",
+    "consensus": {
+      "type": "tendermint",
+      "version": "0.34"
+    },
     "ibc_go_version": "5.1.0",
     "genesis": {
       "genesis_url": "https://raw.githubusercontent.com/Stride-Labs/mainnet/main/testnet/genesis.json"

--- a/testnets/terpnettestnet/chain.json
+++ b/testnets/terpnettestnet/chain.json
@@ -8,16 +8,16 @@
   "bech32_prefix": "terp",
   "daemon_name": "terp",
   "node_home": "$HOME/.terp",
-  
   "codebase": {
     "git_repo": "github.com/terpnetwork/terp-core.git",
     "recommended_version": "v0.4.0",
-    "tendermint_version": "0.34.24",
-
+    "consensus": {
+      "type": "tendermint",
+      "version": "0.34.24"
+    },
     "compatible_versions": [
       "v0.4.0",
       "v0.4.0-1-g8ef7c32"
-
     ],
     "genesis": {
       "genesis_url": "https://raw.githubusercontent.com/terpnetwork/test-net/master/athena-4/genesis.json"
@@ -81,7 +81,6 @@
         "address": "grpc-t.terp.nodestake.top/",
         "provider": "nodestake"
       }
-
     ]
   },
   "explorers": [

--- a/umee/chain.json
+++ b/umee/chain.json
@@ -38,7 +38,10 @@
       "linux/amd64": "https://github.com/umee-network/umee/releases/download/v4.2.0/umeed-v4.2.0-linux-amd64"
     },
     "cosmos_sdk_version": "0.46",
-    "tendermint_version": "0.34",
+    "consensus": {
+      "type": "tendermint",
+      "version": "0.34"
+    },
     "cosmwasm_version": "0.29",
     "cosmwasm_enabled": true,
     "ibc_go_version": "5.2.0",


### PR DESCRIPTION
Resolves https://github.com/cosmos/chain-registry/issues/1517

for now the type enum includes: 'tendermint' and 'cometbft'

DONE -- requires conversion of all existing chain.json files to replace tendermint_version with consensus: type: "tendermint"; version: [tendermint_version.value]  
