### PR TITLE
Deleted broken API

### DIFF
--- a/shentu/chain.json
+++ b/shentu/chain.json
@@ -92,10 +92,6 @@
       {
         "address": "https://certik-api.polkachu.com",
         "provider": "Polkachu"
-      },
-      {
-        "address": "https://api-shentu.starsquid.io",
-        "provider": "Starsquid"
       }
     ],
     "grpc": [


### PR DESCRIPTION
Deleted https://api-shentu.starsquid.io as this API from another project (Bitsong). https://api-shentu.starsquid.io/cosmos/staking/v1beta1/params OUTPUTS "bond_denom": "ubtsg" (WRONG!!!) https://certik-api.polkachu.com/cosmos/staking/v1beta1/params OUTPUTS "bond_denom": "uctk" (CORRECT) This wrong API is broking our project https://staking-explorer.com/