### PR TITLE
enable per version binaries

### DIFF
--- a/chain.schema.json
+++ b/chain.schema.json
@@ -273,6 +273,32 @@
               "next_version_name": {
                 "type": "string",
                 "description": "[Optional] Name of the following version"
+              },
+              "binaries": {
+                "type": "object",
+                "properties": {
+                  "linux/amd64": {
+                    "type": "string",
+                    "format": "uri"
+                  },
+                  "linux/arm64": {
+                    "type": "string",
+                    "format": "uri"
+                  },
+                  "darwin/amd64": {
+                    "type": "string",
+                    "format": "uri"
+                  },
+                  "darwin/arm64": {
+                    "type": "string",
+                    "format": "uri"
+                  },
+                  "windows/amd64": {
+                    "type": "string",
+                    "format": "uri"
+                  }
+                },
+                "additionalProperties": false
               }
             },
             "additionalProperties": false


### PR DESCRIPTION
This PR would enable (optional) per version binaries in the existing "versions" sections of the chains-schema.json file.
This would allow for the automation of binary downloads particularly in cases where chain upgrade proposals were submitted with incomplete information, or a non-consensus breaking upgrade has occurred.