### PR TITLE
Update chain.json

### DIFF
--- a/quicksilver/chain.json
+++ b/quicksilver/chain.json
@@ -30,9 +30,9 @@
   },
   "codebase": {
     "git_repo": "https://github.com/ingenuity-build/quicksilver",
-    "recommended_version": "v1.2.7",
+    "recommended_version": "v1.2.9-hotfix.0",
     "compatible_versions": [
-      "v1.2.7"
+      "v1.2.9-hotfix.0"
     ],
     "cosmos_sdk_version": "0.46",
     "consensus": {


### PR DESCRIPTION
Upgrade to v1.2.9. Using v1.2.9-hotfix.0 as current version as it was required for the upgrade.