### PR TITLE
fix: add display_denom details for NCT and update coingecko id

### DIFF
--- a/regen/assetlist.json
+++ b/regen/assetlist.json
@@ -29,6 +29,10 @@
       "denom_units": [
         {
           "denom": "eco.uC.NCT",
+          "exponent": 0
+        },
+        {
+          "denom": "NCT",
           "exponent": 6
         }
       ],
@@ -39,7 +43,8 @@
       "logo_URIs": {
         "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/regen/images/nct.svg",
         "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/regen/images/nct.png"
-      }
+      },
+      "coingecko_id": "toucan-protocol-nature-carbon-tonne"
     }
   ]
 }


### PR DESCRIPTION
This PR:
- updates `denom_units` of Regen's NCT asset to include proper info for the `display_denom`
- adds a coingecko API id corresponding to NCT (https://www.coingecko.com/en/coins/toucan-protocol-nature-carbon-tonne)