### PR TITLE
Update Sei testnet: devnet3

### DIFF
--- a/testnets/seidevnet3/chain.json
+++ b/testnets/seidevnet3/chain.json
@@ -49,14 +49,28 @@
   "apis": {
     "rpc": [
       {
+        "address": "https://rpc.sei-devnet-3.seinetwork.io",
+        "provider": "Sei Foundation"
+      },
+      {
         "address": "https://sei-testnet-2-rpc.brocha.in",
         "provider": "Brochain"
       }
     ],
     "rest": [
       {
+        "address": "https://rest.sei-devnet-3.seinetwork.io",
+        "provider": "Sei Foundation"
+      },
+      {
         "address": "https://sei-testnet-2-rest.brocha.in",
         "provider": "Brochain"
+      }
+    ],
+    "grpc": [
+      {
+        "address": "https://grpc.sei-devnet-3.seinetwork.io",
+        "provider": "Sei Foundation"
       }
     ]
   },

--- a/testnets/seidevnet3/chain.json
+++ b/testnets/seidevnet3/chain.json
@@ -1,6 +1,6 @@
 {
   "$schema": "../../chain.schema.json",
-  "chain_name": "seitestnet2",
+  "chain_name": "seidevnet3",
   "chain_id": "sei-devnet-3",
   "pretty_name": "Sei Devnet 3",
   "status": "live",


### PR DESCRIPTION
It looks like there might have been an accidental copy/paste error with the `chain_name` field, so I corrected it.

You can see this chain name exists already here: https://github.com/cosmos/chain-registry/blob/aa80cc7a6a0ffe29c727265b8dc2c266b9dceabd/testnets/seitestnet2/chain.json#L3

Also took the RPC, REST, and gRPC endpoints located from the Sei docs:
https://docs.seinetwork.io/nodes-and-validators/public-endpoints

and added them, attributing them to the "Sei Foundation"
