### PR TITLE
update archwaytestnet to use new constantine-2 chain id

### DIFF
--- a/testnets/archwaytestnet/chain.json
+++ b/testnets/archwaytestnet/chain.json
@@ -1,7 +1,7 @@
 {
   "$schema": "../chain.schema.json",
   "chain_name": "archwaytestnet",
-  "chain_id": "constantine-1",
+  "chain_id": "constantine-2",
   "pretty_name": "Archway testnet",
   "status": "live",
   "network_type": "testnet",
@@ -26,13 +26,13 @@
   "apis": {
     "rpc": [
       {
-        "address": "https://rpc.constantine-1.archway.tech",
+        "address": "https://rpc.constantine-2.archway.tech",
         "provider": "Quickapi"
       }
     ],
     "rest": [
       {
-        "address": "https://api.constantine-1.archway.tech",
+        "address": "https://api.constantine-2.archway.tech",
         "provider": "Quickapi"
       }
     ]
@@ -40,8 +40,8 @@
   "explorers": [
     {
       "kind": "archwayscan",
-      "url": "https://explorer.constantine-1.archway.tech",
-      "tx_page": "https://explorer.constantine-1.archway.tech/transactions/${txHash}"
+      "url": "https://explorer.constantine-2.archway.tech",
+      "tx_page": "https://explorer.constantine-2.archway.tech/transactions/${txHash}"
     }
   ]
 }


### PR DESCRIPTION
Archwaytestnet had hard fork and chain id got bumped to constantine-2