### PR TITLE
mainnet/testnet `noble` update

### DIFF
--- a/noble/chain.json
+++ b/noble/chain.json
@@ -72,6 +72,27 @@
         "ibc_go_version": "v3.4.0",
         "ics_enabled": [
           "ics20-1"
+        ],
+        "next_version_name": "neon"
+
+      },
+      {
+        "name": "neon",
+        "tag": "v2.0.0",
+        "height": 119000,
+        "recommended_version": "v2.0.0",
+        "compatible_versions": [
+          "v2.0.0"
+        ],
+        "cosmos_sdk_version": "v0.45",
+        "consensus": {
+          "type": "tendermint",
+          "version": "v0.34"
+        },
+        "cosmwasm_enabled": false,
+        "ibc_go_version": "v3.4.0",
+        "ics_enabled": [
+          "ics20-1"
         ]
       }
     ]
@@ -102,6 +123,11 @@
       "url": "https://www.mintscan.io/noble",
       "tx_page": "https://www.mintscan.io/noble/txs/${txHash}",
       "account_page": "https://www.mintscan.io/noble/account/${accountAddress}"
+    },
+    {
+      "kind": "ping.pub",
+      "url": "https://explore.strange.love/noble-1",
+      "tx_page": "https://explore.strange.love/noble-1/tx/${txHash}"
     }
   ]
 }

--- a/testnets/_IBC/nobletestnet-osmosistestnet.json
+++ b/testnets/_IBC/nobletestnet-osmosistestnet.json
@@ -1,23 +1,23 @@
 {
   "$schema": "../ibc_data.schema.json",
   "chain_1": {
-    "chain_name": "noble",
-    "client_id": "07-tendermint-0",
-    "connection_id": "connection-0"
+    "chain_name": "nobletestnet",
+    "client_id": "07-tendermint-6",
+    "connection_id": "connection-6"
   },
   "chain_2": {
-    "chain_name": "osmosis",
-    "client_id": "07-tendermint-4362",
-    "connection_id": "connection-3779"
+    "chain_name": "osmosistestnet",
+    "client_id": "07-tendermint-4504",
+    "connection_id": "connection-3905"
   },
   "channels": [
     {
       "chain_1": {
-        "channel_id": "channel-0",
+        "channel_id": "channel-4",
         "port_id": "transfer"
       },
       "chain_2": {
-        "channel_id": "channel-3140",
+        "channel_id": "channel-3651",
         "port_id": "transfer"
       },
       "ordering": "unordered",

--- a/testnets/nobletestnet/chain.json
+++ b/testnets/nobletestnet/chain.json
@@ -1,7 +1,7 @@
 {
   "$schema": "../chain.schema.json",
   "chain_name": "nobltestnet",
-  "chain_id": "noble-1",
+  "chain_id": "grand-1",
   "website": "https://nobleassets.xyz/",
   "pretty_name": "Noble",
   "status": "live",
@@ -25,9 +25,9 @@
   },
   "codebase": {
     "git_repo": "https://github.com/strangelove-ventures/noble",
-    "recommended_version": "v1.0.0",
+    "recommended_version": "v0.4.1",
     "compatible_versions": [
-      "v1.0.0"
+      "v0.4.1"
     ],
     "cosmos_sdk_version": "v0.45",
     "consensus": {
@@ -54,23 +54,6 @@
         "name": "v0.4.1",
         "tag": "v0.4.2",
         "height": 302000
-      },
-      {
-        "name": "v1.0.0",
-        "recommended_version": "v1.0.0",
-        "compatible_versions": [
-          "v1.0.0"
-        ],
-        "cosmos_sdk_version": "v0.45",
-        "consensus": {
-          "type": "tendermint",
-          "version": "0.34"
-        },
-        "cosmwasm_enabled": false,
-        "ibc_go_version": "v3.4.0",
-        "ics_enabled": [
-          "ics20-1"
-        ]
       }
     ]
   },
@@ -102,5 +85,12 @@
         "provider": "Everstake"
       }
     ]
-  }
+  },
+  "explorers": [
+    {
+      "kind": "ping.pub",
+      "url": "https://explore.strange.love/grand-1",
+      "tx_page": "https://explore.strange.love/grand-1/tx/${txHash}"
+    }
+  ]
 }


### PR DESCRIPTION
Version upgrade info was accidentally put in the testnet chain.json file. This moves it to the mainnet chain.json file.

Is also:

Mainnet: 
- Adds explorer info

Testnet:
- Updates the ibc path info between osmosis and noble
- Adds explorer info