### PR TITLE
Add Proposal to Versions

### DIFF
--- a/chain.schema.json
+++ b/chain.schema.json
@@ -277,6 +277,10 @@
                 "type": "number",
                 "description": "Block Height"
               },
+              "proposal": {
+                "type": "number",
+                "description": "Proposal that will officially signal community acceptance of the upgrade."
+              },
               "next_version_name": {
                 "type": "string",
                 "description": "[Optional] Name of the following version"


### PR DESCRIPTION
"Proposal that will officially signals community acceptance of the upgrade.

A proposal number added to the version object, which can be used by CI to indicate whether to update the 'current' version info. 