### PR TITLE
Umee historical versions

### DIFF
--- a/umee/chain.json
+++ b/umee/chain.json
@@ -30,9 +30,9 @@
   },
   "codebase": {
     "git_repo": "https://github.com/umee-network/umee",
-    "recommended_version": "v4.2.0",
+    "recommended_version": "v4.3.0",
     "compatible_versions": [
-      "v4.2.0"
+      "v4.3.0"
     ],
     "binaries": {
       "linux/amd64": "https://github.com/umee-network/umee/releases/download/v4.2.0/umeed-v4.2.0-linux-amd64"

--- a/umee/chain.json
+++ b/umee/chain.json
@@ -52,6 +52,9 @@
     "versions": [
       {
         "name": "v1.0.1",
+        "tag": "v1.0.1",
+        "height": 0,
+        "next_version_name": "v1.1.0",
         "recommended_version": "v1.0.1",
         "compatible_versions": [
           "v1.0.1"
@@ -71,6 +74,9 @@
       },
       {
         "name": "v1.1.0",
+        "tag": "v1.1.0",
+        "height": 3023282,
+        "next_version_name": "v1.1-v3.0",
         "recommended_version": "v1.1.0",
         "compatible_versions": [
           "v1.1.0"
@@ -90,6 +96,9 @@
       },
       {
         "name": "v1.1-v3.0",
+        "tag": "v3.0.0",
+        "height": 3215778,
+        "next_version_name": "v3.1.0",
         "recommended_version": "v3.0.0",
         "compatible_versions": [
           "v3.0.0"
@@ -109,6 +118,9 @@
       },
       {
         "name": "v3.1.0",
+        "tag": "v3.1.0",
+        "height": 3623090,
+        "next_version_name": "v3.1-v3.3",
         "recommended_version": "v3.1.0",
         "compatible_versions": [
           "v3.1.0"
@@ -128,6 +140,9 @@
       },
       {
         "name": "v3.1-v3.3",
+        "tag": "v3.3.0",
+        "height": 4513362,
+        "next_version_name": "v4.0",
         "recommended_version": "v3.3.0",
         "compatible_versions": [
           "v3.3.0"
@@ -146,6 +161,9 @@
       },
       {
         "name": "v4.0",
+        "tag": "v4.0.0",
+        "height": 4949483,
+        "next_version_name": "v4.0.1",
         "recommended_version": "v4.0.0",
         "compatible_versions": [
           "v4.0.0"
@@ -164,6 +182,9 @@
       },
       {
         "name": "v4.0.1",
+        "tag": "v4.0.1",
+        "height": 5243631,
+        "next_version_name": "v4.1.0",
         "recommended_version": "v4.0.1",
         "compatible_versions": [
           "v4.0.1"
@@ -182,6 +203,9 @@
       },
       {
         "name": "v4.1.0",
+        "tag": "v4.1.0",
+        "height": 5433933,
+        "next_version_name": "v4.2",
         "recommended_version": "v4.1.0",
         "compatible_versions": [
           "v4.1.0"
@@ -200,6 +224,9 @@
       },
       {
         "name": "v4.2",
+        "tag": "v4.2.0",
+        "height": 5741480,
+        "next_version_name": "v4.3",
         "recommended_version": "v4.2.0",
         "compatible_versions": [
           "v4.2.0"
@@ -218,6 +245,8 @@
       },
       {
         "name": "v4.3",
+        "tag": "v4.3.0",
+        "height": 6049552,
         "recommended_version": "v4.3.0",
         "compatible_versions": [
           "v4.3.0"

--- a/umee/chain.json
+++ b/umee/chain.json
@@ -39,18 +39,18 @@
     },
     "cosmos_sdk_version": "0.46",
     "consensus": {
-      "type": "tendermint",
+      "type": "cometbft",
       "version": "0.34"
     },
-    "cosmwasm_version": "0.29",
+    "cosmwasm_version": "0.30",
     "cosmwasm_enabled": true,
-    "ibc_go_version": "5.2.0",
+    "ibc_go_version": "6.1.0",
     "genesis": {
       "genesis_url": "https://raw.githubusercontent.com/umee-network/mainnet/main/genesis.json"
     },
     "versions": [
       {
-        "name": "v4.2.0",
+        "name": "v4.2",
         "recommended_version": "v4.2.0",
         "compatible_versions": [
           "v4.2.0"
@@ -65,6 +65,24 @@
         "ibc_go_version": "5.2.0",
         "binaries": {
           "linux/amd64": "https://github.com/umee-network/umee/releases/download/v4.2.0/umeed-v4.2.0-linux-amd64"
+        }
+      },
+      {
+        "name": "v4.3",
+        "recommended_version": "v4.3.0",
+        "compatible_versions": [
+          "v4.3.0"
+        ],
+        "cosmos_sdk_version": "0.46",
+        "consensus": {
+          "type": "cometbft",
+          "version": "0.34"
+        },
+        "cosmwasm_version": "0.30",
+        "cosmwasm_enabled": true,
+        "ibc_go_version": "6.1.0",
+        "binaries": {
+          "linux/amd64": "https://github.com/umee-network/umee/releases/download/v4.3.0/umeed-v4.3.0-linux-amd64"
         }
       }
     ]

--- a/umee/chain.json
+++ b/umee/chain.json
@@ -46,9 +46,158 @@
     "cosmwasm_enabled": true,
     "ibc_go_version": "6.1.0",
     "genesis": {
+      "name": "v1.0.1",
       "genesis_url": "https://raw.githubusercontent.com/umee-network/mainnet/main/genesis.json"
     },
     "versions": [
+      {
+        "name": "v1.0.1",
+        "recommended_version": "v1.0.1",
+        "compatible_versions": [
+          "v1.0.1"
+        ],
+        "cosmos_sdk_version": "0.45",
+        "consensus": {
+          "type": "tendermint",
+          "version": "0.34"
+        },
+        "ibc_go_version": "2.0.3",
+        "binaries": {
+          "linux/amd64": "https://github.com/umee-network/umee/releases/download/v1.0.1/umeed-v1.0.1-linux-amd64.tar.gz",
+          "linux/arm64": "https://github.com/umee-network/umee/releases/download/v1.0.1/umeed-v1.0.1-linux-arm64.tar.gz",
+          "darwin/amd64": "https://github.com/umee-network/umee/releases/download/v1.0.1/umeed-v1.0.1-darwin-amd64.tar.gz",
+          "darwin/arm64": "https://github.com/umee-network/umee/releases/download/v1.0.1/umeed-v1.0.1-darwin-arm64.tar.gz"
+        }
+      },
+      {
+        "name": "v1.1.0",
+        "recommended_version": "v1.1.0",
+        "compatible_versions": [
+          "v1.1.0"
+        ],
+        "cosmos_sdk_version": "0.45",
+        "consensus": {
+          "type": "tendermint",
+          "version": "0.34"
+        },
+        "ibc_go_version": "2.0.3",
+        "binaries": {
+          "linux/amd64": "https://github.com/umee-network/umee/releases/download/v1.1.0/umeed-v1.1.0-linux-amd64.tar.gz",
+          "linux/arm64": "https://github.com/umee-network/umee/releases/download/v1.1.0/umeed-v1.1.0-linux-arm64.tar.gz",
+          "darwin/amd64": "https://github.com/umee-network/umee/releases/download/v1.1.0/umeed-v1.1.0-darwin-amd64.tar.gz",
+          "darwin/arm64": "https://github.com/umee-network/umee/releases/download/v1.1.0/umeed-v1.1.0-darwin-arm64.tar.gz"
+        }
+      },
+      {
+        "name": "v1.1-v3.0",
+        "recommended_version": "v3.0.0",
+        "compatible_versions": [
+          "v3.0.0"
+        ],
+        "cosmos_sdk_version": "0.46",
+        "consensus": {
+          "type": "tendermint",
+          "version": "0.34"
+        },
+        "ibc_go_version": "5.0.0",
+        "binaries": {
+          "linux/amd64": "https://github.com/umee-network/umee/releases/download/v3.0.0/umeed-v3.0.0-linux-amd64.tar.gz",
+          "linux/arm64": "https://github.com/umee-network/umee/releases/download/v3.0.0/umeed-v3.0.0-linux-arm64.tar.gz",
+          "darwin/amd64": "https://github.com/umee-network/umee/releases/download/v3.0.0/umeed-v3.0.0-darwin-amd64.tar.gz",
+          "darwin/arm64": "https://github.com/umee-network/umee/releases/download/v3.0.0/umeed-v3.0.0-darwin-arm64.tar.gz"
+        }
+      },
+      {
+        "name": "v3.1.0",
+        "recommended_version": "v3.1.0",
+        "compatible_versions": [
+          "v3.1.0"
+        ],
+        "cosmos_sdk_version": "0.46",
+        "consensus": {
+          "type": "tendermint",
+          "version": "0.34"
+        },
+        "ibc_go_version": "5.0.0",
+        "binaries": {
+          "linux/amd64": "https://github.com/umee-network/umee/releases/download/v3.1.0/umeed-v3.1.0-linux-amd64",
+          "linux/arm64": "https://github.com/umee-network/umee/releases/download/v3.1.0/umeed-v3.1.0-linux-arm64",
+          "darwin/amd64": "https://github.com/umee-network/umee/releases/download/v3.1.0/umeed-v3.1.0-darwin-amd64",
+          "darwin/arm64": "https://github.com/umee-network/umee/releases/download/v3.1.0/umeed-v3.1.0-darwin-arm64"
+        }
+      },
+      {
+        "name": "v3.1-v3.3",
+        "recommended_version": "v3.3.0",
+        "compatible_versions": [
+          "v3.3.0"
+        ],
+        "cosmos_sdk_version": "0.46",
+        "consensus": {
+          "type": "tendermint",
+          "version": "0.34"
+        },
+        "cosmwasm_version": "0.29",
+        "cosmwasm_enabled": true,
+        "ibc_go_version": "5.2.0",
+        "binaries": {
+          "linux/amd64": "https://github.com/umee-network/umee/releases/download/v3.3.0/umeed-v3.3.0-linux-amd64"
+        }
+      },
+      {
+        "name": "v4.0",
+        "recommended_version": "v4.0.0",
+        "compatible_versions": [
+          "v4.0.0"
+        ],
+        "cosmos_sdk_version": "0.46",
+        "consensus": {
+          "type": "tendermint",
+          "version": "0.34"
+        },
+        "cosmwasm_version": "0.29",
+        "cosmwasm_enabled": true,
+        "ibc_go_version": "5.2.0",
+        "binaries": {
+          "linux/amd64": "https://github.com/umee-network/umee/releases/download/v4.0.0/umeed-v4.0.0-linux-amd64"
+        }
+      },
+      {
+        "name": "v4.0.1",
+        "recommended_version": "v4.0.1",
+        "compatible_versions": [
+          "v4.0.1"
+        ],
+        "cosmos_sdk_version": "0.46",
+        "consensus": {
+          "type": "tendermint",
+          "version": "0.34"
+        },
+        "cosmwasm_version": "0.29",
+        "cosmwasm_enabled": true,
+        "ibc_go_version": "5.2.0",
+        "binaries": {
+          "linux/amd64": "https://github.com/umee-network/umee/releases/download/v4.0.1/umeed-v4.0.1-linux-amd64"
+        }
+      },
+      {
+        "name": "v4.1.0",
+        "recommended_version": "v4.1.0",
+        "compatible_versions": [
+          "v4.1.0"
+        ],
+        "cosmos_sdk_version": "0.46",
+        "consensus": {
+          "type": "tendermint",
+          "version": "0.34"
+        },
+        "cosmwasm_version": "0.29",
+        "cosmwasm_enabled": true,
+        "ibc_go_version": "5.2.0",
+        "binaries": {
+          "linux/amd64": "https://github.com/umee-network/umee/releases/download/v4.1.0/umeed-v4.1.0-linux-amd64"
+        }
+      },
       {
         "name": "v4.2",
         "recommended_version": "v4.2.0",


### PR DESCRIPTION
added versions for all umee-1 upgrades.

@JeremyParish69 I'm wondering if the `tag`, `height`, and `next_version_name` keys should appear as in [osmosis/chain.json](https://github.com/cosmos/chain-registry/blob/aa883fb98406e82ca53e70bcdbb156bfba0c83b8/osmosis/chain.json#L63)