### PR TITLE
Change gas price for Uptick

### DIFF
--- a/uptick/chain.json
+++ b/uptick/chain.json
@@ -17,10 +17,10 @@
     "fee_tokens": [
       {
         "denom": "auptick",
-        "fixed_min_gas_price": 10000000000,
-        "low_gas_price": 10000000000,
-        "average_gas_price": 25000000000,
-        "high_gas_price": 40000000000
+        "fixed_min_gas_price": 1000000000000000,
+        "low_gas_price": 1000000000000000,
+        "average_gas_price": 2500000000000000,
+        "high_gas_price": 4000000000000000
       }
     ]
   },


### PR DESCRIPTION
It is necessary to increase the gas price, otherwise, when trying to delegate, an error appears:  
`provided fee < minimum global fee (25auptick < 1000000000000000auptick). Please increase the gas price.: insufficient fee: unknown request`