### PR TITLE
fix: length of pretty_names for celestiatestnets

### DIFF
--- a/testnets/celestiatestnet/chain.json
+++ b/testnets/celestiatestnet/chain.json
@@ -2,7 +2,7 @@
   "$schema": "../../chain.schema.json",
   "chain_name": "celestiatestnet",
   "chain_id": "blockspacerace-0",
-  "pretty_name": "Celestia's Blockspace Race testnet",
+  "pretty_name": "Blockspace Race Testnet",
   "status": "live",
   "network_type": "testnet",
   "bech32_prefix": "celestia",

--- a/testnets/celestiatestnet2/chain.json
+++ b/testnets/celestiatestnet2/chain.json
@@ -2,7 +2,7 @@
   "$schema": "../../chain.schema.json",
   "chain_name": "celestiatestnet2",
   "chain_id": "arabica-5",
-  "pretty_name": "Celestia's Arabica Testnet",
+  "pretty_name": "Arabica Testnet",
   "status": "live",
   "network_type": "testnet",
   "bech32_prefix": "celestia",

--- a/testnets/celestiatestnet3/chain.json
+++ b/testnets/celestiatestnet3/chain.json
@@ -2,7 +2,7 @@
   "$schema": "../../chain.schema.json",
   "chain_name": "celestiatestnet3",
   "chain_id": "mocha",
-  "pretty_name": "Celestia's Mocha Testnet",
+  "pretty_name": "Mocha Testnet",
   "status": "live",
   "network_type": "testnet",
   "bech32_prefix": "celestia",


### PR DESCRIPTION
Using Keplr and Cosmology, the tooling respectively errors (image 1) or is not made to support a name as long as the testnets are currently (images 2-3), so this PR shortens the length of Celestia testnet names.

<img width="409" alt="scrot 2023-04-13 at 6 36 34 PM" src="https://user-images.githubusercontent.com/46639943/231902997-b0dd06d5-c858-42df-8e23-b5acfe31c35d.png">

<img width="436" alt="scrot 2023-04-13 at 6 59 11 PM" src="https://user-images.githubusercontent.com/46639943/231902990-2b474b61-8ae3-4ec1-b6b3-07f037df7f3e.png">

<img width="358" alt="scrot 2023-04-13 at 7 04 17 PM" src="https://user-images.githubusercontent.com/46639943/231902978-33860dfa-be6d-4282-8d12-87b0bc366fa5.png">
