### PR TITLE
add extra_codecs for cronos

### DIFF
--- a/cronos/chain.json
+++ b/cronos/chain.json
@@ -12,6 +12,9 @@
   "key_algos": [
     "ethsecp256k1"
   ],
+  "extra_codecs": [
+    "ethermint"
+  ],
   "slip44": 60,
   "fees": {
     "fee_tokens": [


### PR DESCRIPTION
To allow work with custom message types with [support](https://github.com/cosmos/relayer/pull/1048/files#diff-8d7de192d295dddfbcfecb3e5785a1e50a567d7a86e246c7bda327d6a7a0b007) from relayer.