### PR TITLE
Del Easy 2 Stake API endpoints due to incorrect chain id

### DIFF
--- a/agoric/chain.json
+++ b/agoric/chain.json
@@ -105,10 +105,6 @@
       {
         "address": "https://agoric-mainnet-rpc.autostake.com:443",
         "provider": "AutoStake 🛡️ Slash Protected"
-      },
-      {
-        "address": "https://agoric-rpc.easy2stake.com",
-        "provider": "Easy 2 Stake"
       }
     ],
     "rest": [
@@ -130,10 +126,6 @@
       {
         "address": "https://agoric-mainnet-lcd.autostake.com:443",
         "provider": "AutoStake 🛡️ Slash Protected"
-      },
-      {
-        "address": "https://agoric-lcd.easy2stake.com",
-        "provider": "Easy 2 Stake"
       }
     ],
     "grpc": [


### PR DESCRIPTION
From https://staking-explorer.com log file...
15 Apr 01:35:23 ~ we need to check REST API endpoint: https://agoric-lcd.easy2stake.com/
15 Apr 01:35:23 ~ https://agoric-lcd.easy2stake.com/cosmos/base/tendermint/v1beta1/blocks/latest ERROR CHAIN (returns cosmoshub-4 but must be agoric-3)