### PR TITLE
Update chain.json

### DIFF
--- a/desmos/chain.json
+++ b/desmos/chain.json
@@ -35,7 +35,7 @@
     "git_repo": "https://github.com/desmos-labs/desmos",
     "recommended_version": "v4.8.0",
     "compatible_versions": [
-      "v4.8.0"
+      "v4.8.0", "v4.8.1"
     ],
     "binaries": {
       "linux/amd64": "https://github.com/desmos-labs/desmos/releases/download/v4.8.0/desmos-4.8.0-linux-amd64",

--- a/desmos/chain.json
+++ b/desmos/chain.json
@@ -51,7 +51,7 @@
         "name": "v4.8.0",
         "recommended_version": "v4.8.0",
         "compatible_versions": [
-          "v4.8.0"
+          "v4.8.0", "v4.8.1"
         ],
         "binaries": {
           "linux/amd64": "https://github.com/desmos-labs/desmos/releases/download/v4.8.0/desmos-4.8.0-linux-amd64",

--- a/sommelier/chain.json
+++ b/sommelier/chain.json
@@ -56,7 +56,8 @@
           "darwin/amd64": "https://github.com/PeggyJV/sommelier/releases/download/v5.0.0/sommelier_5.0.0_darwin_amd64.tar.gz",
           "darwin/arm64": "https://github.com/PeggyJV/sommelier/releases/download/v5.0.0/sommelier_5.0.0_darwin_arm64.tar.gz",
           "windows/amd64": "https://github.com/PeggyJV/sommelier/releases/download/v5.0.0/sommelier_5.0.0_windows_amd64.tar.gz"
-        },
+        }
+      },
       {
         "name": "v6.0.0",
         "recommended_version": "v6.0.0",

--- a/sommelier/chain.json
+++ b/sommelier/chain.json
@@ -34,28 +34,28 @@
       "v6.0.0"
     ],
     "binaries": {
-      "linux/amd64": "https://github.com/PeggyJV/sommelier/releases/download/v5.0.0/sommelier_5.0.0_linux_amd64.tar.gz",
-      "linux/arm64": "https://github.com/PeggyJV/sommelier/releases/download/v5.0.0/sommelier_5.0.0_linux_arm64.tar.gz",
-      "darwin/amd64": "https://github.com/PeggyJV/sommelier/releases/download/v5.0.0/sommelier_5.0.0_darwin_amd64.tar.gz",
-      "darwin/arm64": "https://github.com/PeggyJV/sommelier/releases/download/v5.0.0/sommelier_5.0.0_darwin_arm64.tar.gz",
-      "windows/amd64": "https://github.com/PeggyJV/sommelier/releases/download/v5.0.0/sommelier_5.0.0_windows_amd64.tar.gz"
+      "linux/amd64": "https://github.com/PeggyJV/sommelier/releases/download/v6.0.0/sommelier_6.0.0_linux_amd64.tar.gz",
+      "linux/arm64": "https://github.com/PeggyJV/sommelier/releases/download/v6.0.0/sommelier_6.0.0_linux_arm64.tar.gz",
+      "darwin/amd64": "https://github.com/PeggyJV/sommelier/releases/download/v6.0.0/sommelier_6.0.0_darwin_amd64.tar.gz",
+      "darwin/arm64": "https://github.com/PeggyJV/sommelier/releases/download/v6.0.0/sommelier_6.0.0_darwin_arm64.tar.gz",
+      "windows/amd64": "https://github.com/PeggyJV/sommelier/releases/download/v6.0.0/sommelier_6.0.0_windows_amd64.tar.gz"
     },
     "genesis": {
       "genesis_url": "https://raw.githubusercontent.com/PeggyJV/sommelier/main/contrib/mainnet/sommelier-2/genesis.json"
     },
     "versions": [
       {
-        "name": "v5.0.0",
-        "recommended_version": "v5.0.0",
+        "name": "v6.0.0",
+        "recommended_version": "v6.0.0",
         "compatible_versions": [
-          "v5.0.0"
+          "v6.0.0"
         ],
         "binaries": {
-          "linux/amd64": "https://github.com/PeggyJV/sommelier/releases/download/v5.0.0/sommelier_5.0.0_linux_amd64.tar.gz",
-          "linux/arm64": "https://github.com/PeggyJV/sommelier/releases/download/v5.0.0/sommelier_5.0.0_linux_arm64.tar.gz",
-          "darwin/amd64": "https://github.com/PeggyJV/sommelier/releases/download/v5.0.0/sommelier_5.0.0_darwin_amd64.tar.gz",
-          "darwin/arm64": "https://github.com/PeggyJV/sommelier/releases/download/v5.0.0/sommelier_5.0.0_darwin_arm64.tar.gz",
-          "windows/amd64": "https://github.com/PeggyJV/sommelier/releases/download/v5.0.0/sommelier_5.0.0_windows_amd64.tar.gz"
+          "linux/amd64": "https://github.com/PeggyJV/sommelier/releases/download/v6.0.0/sommelier_6.0.0_linux_amd64.tar.gz",
+          "linux/arm64": "https://github.com/PeggyJV/sommelier/releases/download/v6.0.0/sommelier_6.0.0_linux_arm64.tar.gz",
+          "darwin/amd64": "https://github.com/PeggyJV/sommelier/releases/download/v6.0.0/sommelier_6.0.0_darwin_amd64.tar.gz",
+          "darwin/arm64": "https://github.com/PeggyJV/sommelier/releases/download/v6.0.0/sommelier_6.0.0_darwin_arm64.tar.gz",
+          "windows/amd64": "https://github.com/PeggyJV/sommelier/releases/download/v6.0.0/sommelier_6.0.0_windows_amd64.tar.gz"
         }
       }
     ]

--- a/sommelier/chain.json
+++ b/sommelier/chain.json
@@ -29,9 +29,9 @@
   },
   "codebase": {
     "git_repo": "https://github.com/PeggyJV/sommelier",
-    "recommended_version": "v5.0.0",
+    "recommended_version": "v6.0.0",
     "compatible_versions": [
-      "v5.0.0"
+      "v6.0.0"
     ],
     "binaries": {
       "linux/amd64": "https://github.com/PeggyJV/sommelier/releases/download/v5.0.0/sommelier_5.0.0_linux_amd64.tar.gz",

--- a/sommelier/chain.json
+++ b/sommelier/chain.json
@@ -45,6 +45,19 @@
     },
     "versions": [
       {
+        "name": "v5.0.0",
+        "recommended_version": "v5.0.0",
+        "compatible_versions": [
+          "v5.0.0"
+        ],
+        "binaries": {
+          "linux/amd64": "https://github.com/PeggyJV/sommelier/releases/download/v5.0.0/sommelier_5.0.0_linux_amd64.tar.gz",
+          "linux/arm64": "https://github.com/PeggyJV/sommelier/releases/download/v5.0.0/sommelier_5.0.0_linux_arm64.tar.gz",
+          "darwin/amd64": "https://github.com/PeggyJV/sommelier/releases/download/v5.0.0/sommelier_5.0.0_darwin_amd64.tar.gz",
+          "darwin/arm64": "https://github.com/PeggyJV/sommelier/releases/download/v5.0.0/sommelier_5.0.0_darwin_arm64.tar.gz",
+          "windows/amd64": "https://github.com/PeggyJV/sommelier/releases/download/v5.0.0/sommelier_5.0.0_windows_amd64.tar.gz"
+        },
+      {
         "name": "v6.0.0",
         "recommended_version": "v6.0.0",
         "compatible_versions": [

--- a/xpla/chain.json
+++ b/xpla/chain.json
@@ -53,6 +53,11 @@
         "id": "e7b6016ce5663a69ba71a982072315545eb0d5f6",
         "address": "seed.xpla.delightlabs.io:26656",
         "provider": "DELIGHT"
+      },
+      {
+        "id": "20e1000e88125698264454a884812746c2eb4807",
+        "address": "seeds.lavenderfive.com:20157",
+        "provider": "Lavender.Five Nodes 🐝"
       }
     ],
     "persistent_peers": [
@@ -103,6 +108,10 @@
       {
         "address": "https://dimension-rpc.xpla.dev",
         "provider": "Holdings"
+      },
+      {
+        "address": "https://xpla-rpc.lavenderfive.com:443",
+        "provider": "Lavender.Five Nodes 🐝"
       }
     ],
     "rest": [
@@ -117,6 +126,10 @@
       {
         "address": "http://xpla.api.staking-explorer.com",
         "provider": "xpla.staking-explorer.com"
+      },
+      {
+        "address": "https://xpla-api.lavenderfive.com:443",
+        "provider": "Lavender.Five Nodes 🐝"
       }
     ],
     "grpc": [],


### PR DESCRIPTION
Desmos
Adding 4.8.1 patch - https://github.com/desmos-labs/desmos/releases/tag/v4.8.1

Sommelier
Update from v5 to v6 at 8704480 pending approval of Prop 47: https://www.mintscan.io/sommelier/proposals/47

XPLA
Adding seed, RPC and REST for Lavender.Five Nodes