### PR TITLE
Del kingnodes REST endpoint

### DIFF
--- a/evmos/chain.json
+++ b/evmos/chain.json
@@ -270,10 +270,6 @@
     ],
     "rest": [
       {
-        "address": "https://evmos.kingnodes.com",
-        "provider": "kingnodes"
-      },
-      {
         "address": "https://lcd-evmos.whispernode.com:443",
         "provider": "WhisperNode🤐"
       },


### PR DESCRIPTION
https://evmos.kingnodes.com is not REST endpoint. @kingnodes, please be more careful and check what you add to the registry.