### PR TITLE
Fixing path to genesis file in migaloo.

### DIFF
--- a/migaloo/chain.json
+++ b/migaloo/chain.json
@@ -49,7 +49,7 @@
     "cosmwasm_version": "0.28",
     "cosmwasm_enabled": true,
     "genesis": {
-      "genesis_url": "https://raw.githubusercontent.com/White-Whale-Defi-Platform/migaloo-chain/main/networks/mainnet/genesis.json"
+      "genesis_url": "https://raw.githubusercontent.com/White-Whale-Defi-Platform/migaloo-chain/release/v2.0.x/networks/mainnet/genesis.json"
     },
     "versions": [
       {

--- a/testnets/migalootestnet/chain.json
+++ b/testnets/migalootestnet/chain.json
@@ -49,7 +49,7 @@
     "cosmwasm_version": "0.28",
     "cosmwasm_enabled": true,
     "genesis": {
-      "genesis_url": "https://raw.githubusercontent.com/White-Whale-Defi-Platform/migaloo-chain/main/networks/mainnet/genesis.json"
+      "genesis_url": "https://raw.githubusercontent.com/White-Whale-Defi-Platform/migaloo-chain/release/v2.0.x/networks/testnet/genesis.json"
     },
     "versions": [
       {


### PR DESCRIPTION
Existing paths do not exist.  Reached out to white-whale team and they advised it's available on the `v2.0.x` branch and upwards.