### PR TITLE
Update ATOMScan explorer info

### DIFF
--- a/akash/chain.json
+++ b/akash/chain.json
@@ -245,7 +245,8 @@
     {
       "kind": "atomscan",
       "url": "https://atomscan.com/akash",
-      "tx_page": "https://atomscan.com/akash/transactions/${txHash}"
+      "tx_page": "https://atomscan.com/akash/transactions/${txHash}",
+      "account_page": "https://atomscan.com/akash/accounts/${accountAddress}"
     },
     {
       "kind": "cloudmos",

--- a/assetmantle/chain.json
+++ b/assetmantle/chain.json
@@ -257,7 +257,8 @@
     {
       "kind": "atomscan",
       "url": "https://atomscan.com/assetmantle",
-      "tx_page": "https://atomscan.com/assetmantle/transactions/${txHash}"
+      "tx_page": "https://atomscan.com/assetmantle/transactions/${txHash}",
+      "account_page": "https://atomscan.com/assetmantle/accounts/${accountAddress}"
     },
     {
       "kind": "bigdipper",

--- a/axelar/chain.json
+++ b/axelar/chain.json
@@ -281,7 +281,8 @@
     {
       "kind": "atomscan",
       "url": "https://atomscan.com/axelar",
-      "tx_page": "https://atomscan.com/axelar/transactions/${txHash}"
+      "tx_page": "https://atomscan.com/axelar/transactions/${txHash}",
+      "account_page": "https://atomscan.com/axelar/accounts/${accountAddress}"
     }
   ]
 }

--- a/bandchain/chain.json
+++ b/bandchain/chain.json
@@ -147,7 +147,8 @@
     {
       "kind": "atomscan",
       "url": "https://atomscan.com/band-protocol",
-      "tx_page": "https://atomscan.com/band-protocol/transactions/${txHash}"
+      "tx_page": "https://atomscan.com/band-protocol/transactions/${txHash}",
+      "account_page": "https://atomscan.com/band-protocol/accounts/${accountAddress}"
     },
     {
       "kind": "bigdipper",

--- a/bitcanna/chain.json
+++ b/bitcanna/chain.json
@@ -291,7 +291,8 @@
     {
       "kind": "atomscan",
       "url": "https://atomscan.com/bitcanna",
-      "tx_page": "https://atomscan.com/bitcanna/transactions/${txHash}"
+      "tx_page": "https://atomscan.com/bitcanna/transactions/${txHash}",
+      "account_page": "https://atomscan.com/bitcanna/accounts/${accountAddress}"
     }
   ]
 }

--- a/bitsong/chain.json
+++ b/bitsong/chain.json
@@ -205,7 +205,8 @@
     {
       "kind": "atomscan",
       "url": "https://atomscan.com/bitsong",
-      "tx_page": "https://atomscan.com/bitsong/transactions/${txHash}"
+      "tx_page": "https://atomscan.com/bitsong/transactions/${txHash}",
+      "account_page": "https://atomscan.com/bitsong/accounts/${accountAddress}"
     }
   ]
 }

--- a/bostrom/chain.json
+++ b/bostrom/chain.json
@@ -119,7 +119,8 @@
     {
       "kind": "atomscan",
       "url": "https://atomscan.com/bostrom",
-      "tx_page": "https://atomscan.com/bostrom/transactions/${txHash}"
+      "tx_page": "https://atomscan.com/bostrom/transactions/${txHash}",
+      "account_page": "https://atomscan.com/bostrom/accounts/${accountAddress}"
     }
   ]
 }

--- a/carbon/chain.json
+++ b/carbon/chain.json
@@ -364,6 +364,12 @@
       "kind": "ping.pub",
       "url": "https://ping.pub/carbon",
       "tx_page": "https://ping.pub/carbon/tx/${txHash}"
+    },
+    {
+      "kind": "atomscan",
+      "url": "https://atomscan.com/carbon",
+      "tx_page": "https://atomscan.com/carbon/transactions/${txHash}",
+      "account_page": "https://atomscan.com/carbon/accounts/${accountAddress}"
     }
   ]
 }

--- a/chain4energy/chain.json
+++ b/chain4energy/chain.json
@@ -221,6 +221,12 @@
       "kind": "NODEXPLORER",
       "url": "https://explorer.nodexcapital.com/c4e",
       "tx_page": "https://explorer.nodexcapital.com/c4e/transactions/${txHash}"
+    },
+    {
+      "kind": "atomscan",
+      "url": "https://atomscan.com/chain4energy",
+      "tx_page": "https://atomscan.com/chain4energy/transactions/${txHash}",
+      "account_page": "https://atomscan.com/chain4energy/accounts/${accountAddress}"
     }
   ]
 }

--- a/chihuahua/chain.json
+++ b/chihuahua/chain.json
@@ -239,7 +239,8 @@
     {
       "kind": "atomscan",
       "url": "https://atomscan.com/chihuahua",
-      "tx_page": "https://atomscan.com/chihuahua/transactions/${txHash}"
+      "tx_page": "https://atomscan.com/chihuahua/transactions/${txHash}",
+      "account_page": "https://atomscan.com/chihuahua/accounts/${accountAddress}"
     }
   ]
 }

--- a/chronicnetwork/chain.json
+++ b/chronicnetwork/chain.json
@@ -74,6 +74,12 @@
       "kind": "Zenscan.io",
       "url": "https://www.chronic.zenscan.io",
       "tx_page": ""
+    },
+    {
+      "kind": "atomscan",
+      "url": "https://atomscan.com/chronicnetwork",
+      "tx_page": "https://atomscan.com/chronicnetwork/transactions/${txHash}",
+      "account_page": "https://atomscan.com/chronicnetwork/accounts/${accountAddress}"
     }
   ]
 }

--- a/comdex/chain.json
+++ b/comdex/chain.json
@@ -241,7 +241,8 @@
     {
       "kind": "atomscan",
       "url": "https://atomscan.com/comdex",
-      "tx_page": "https://atomscan.com/comdex/transactions/${txHash}"
+      "tx_page": "https://atomscan.com/comdex/transactions/${txHash}",
+      "account_page": "https://atomscan.com/comdex/accounts/${accountAddress}"
     },
     {
       "kind": "bigdipper",

--- a/cosmoshub/chain.json
+++ b/cosmoshub/chain.json
@@ -355,7 +355,8 @@
     {
       "kind": "atomscan",
       "url": "https://atomscan.com",
-      "tx_page": "https://atomscan.com/transactions/${txHash}"
+      "tx_page": "https://atomscan.com/transactions/${txHash}",
+      "account_page": "https://atomscan.com/accounts/${accountAddress}"
     },
     {
       "kind": "unichain",

--- a/crescent/chain.json
+++ b/crescent/chain.json
@@ -172,7 +172,8 @@
     {
       "kind": "atomscan",
       "url": "https://atomscan.com/crescent",
-      "tx_page": "https://atomscan.com/crescent/transactions/${txHash}"
+      "tx_page": "https://atomscan.com/crescent/transactions/${txHash}",
+      "account_page": "https://atomscan.com/crescent/accounts/${accountAddress}"
     },
     {
       "kind": "bigdipper",

--- a/cudos/chain.json
+++ b/cudos/chain.json
@@ -181,7 +181,8 @@
     {
       "kind": "atomscan",
       "url": "https://atomscan.com/cudos",
-      "tx_page": "https://atomscan.com/cudos/transactions/${txHash}"
+      "tx_page": "https://atomscan.com/cudos/transactions/${txHash}",
+      "account_page": "https://atomscan.com/cudos/accounts/${accountAddress}"
     }
   ]
 }

--- a/decentr/chain.json
+++ b/decentr/chain.json
@@ -233,7 +233,8 @@
     {
       "kind": "atomscan",
       "url": "https://atomscan.com/decentr",
-      "tx_page": "https://atomscan.com/decentr/transactions/${txHash}"
+      "tx_page": "https://atomscan.com/decentr/transactions/${txHash}",
+      "account_page": "https://atomscan.com/decentr/accounts/${accountAddress}"
     },
     {
       "kind": "Nodine.ID",

--- a/echelon/chain.json
+++ b/echelon/chain.json
@@ -144,12 +144,8 @@
     {
       "kind": "atomscan",
       "url": "https://atomscan.com/echelon",
-      "tx_page": "https://atomscan.com/echelon/tx/${txHash}"
-    },
-    {
-      "kind": "atomscan",
-      "url": "https://atomscan.com/echelon",
-      "tx_page": "https://atomscan.com/echelon/transactions/${txHash}"
+      "tx_page": "https://atomscan.com/echelon/transactions/${txHash}",
+      "account_page": "https://atomscan.com/echelon/accounts/${accountAddress}"
     }
   ]
 }

--- a/emoney/chain.json
+++ b/emoney/chain.json
@@ -209,7 +209,8 @@
     {
       "kind": "atomscan",
       "url": "https://atomscan.com/emoney",
-      "tx_page": "https://atomscan.com/emoney/transactions/${txHash}"
+      "tx_page": "https://atomscan.com/emoney/transactions/${txHash}",
+      "account_page": "https://atomscan.com/emoney/accounts/${accountAddress}"
     }
   ]
 }

--- a/evmos/chain.json
+++ b/evmos/chain.json
@@ -476,7 +476,8 @@
     {
       "kind": "atomscan",
       "url": "https://atomscan.com/evmos",
-      "tx_page": "https://atomscan.com/evmos/transactions/${txHash}"
+      "tx_page": "https://atomscan.com/evmos/transactions/${txHash}",
+      "account_page": "https://atomscan.com/evmos/accounts/${accountAddress}"
     },
     {
       "kind": "tcnetwork",

--- a/fetchhub/chain.json
+++ b/fetchhub/chain.json
@@ -232,7 +232,8 @@
     {
       "kind": "atomscan",
       "url": "https://atomscan.com/fetchai",
-      "tx_page": "https://atomscan.com/fetchai/transactions/${txHash}"
+      "tx_page": "https://atomscan.com/fetchai/transactions/${txHash}",
+      "account_page": "https://atomscan.com/fetchai/accounts/${accountAddress}"
     },
     {
       "kind": "bigdipper",

--- a/firmachain/chain.json
+++ b/firmachain/chain.json
@@ -139,6 +139,12 @@
       "kind": "explorer.ChainTools",
       "url": "https://explorer.chaintools.tech/firmachain",
       "tx_page": "https://explorer.chaintools.tech/firmachain/tx/${txHash}"
+    },
+    {
+      "kind": "atomscan",
+      "url": "https://atomscan.com/firmachain",
+      "tx_page": "https://atomscan.com/firmachain/transactions/${txHash}",
+      "account_page": "https://atomscan.com/firmachain/accounts/${accountAddress}"
     }
   ]
 }

--- a/genesisl1/chain.json
+++ b/genesisl1/chain.json
@@ -88,9 +88,10 @@
       "tx_page": "https://exp.utsa.tech/genesis/tx/${txHash}"
     },
     {
-      "kind": "ATOMScan",
+      "kind": "atomscan",
       "url": "https://atomscan.com/genesisl1",
-      "tx_page": "https://atomscan.com/genesisl1/transactions/${txHash}"
+      "tx_page": "https://atomscan.com/genesisl1/transactions/${txHash}",
+      "account_page": "https://atomscan.com/genesisl1/accounts/${accountAddress}"
     }
   ]
 }

--- a/gravitybridge/chain.json
+++ b/gravitybridge/chain.json
@@ -238,7 +238,8 @@
     {
       "kind": "atomscan",
       "url": "https://atomscan.com/gravity-bridge",
-      "tx_page": "https://atomscan.com/gravity-bridge/transactions/${txHash}"
+      "tx_page": "https://atomscan.com/gravity-bridge/transactions/${txHash}",
+      "account_page": "https://atomscan.com/gravity-bridge/accounts/${accountAddress}"
     },
     {
       "kind": "TC Network",

--- a/idep/chain.json
+++ b/idep/chain.json
@@ -101,7 +101,8 @@
     {
       "kind": "atomscan",
       "url": "https://atomscan.com/idep",
-      "tx_page": "https://atomscan.com/idep/transactions/${txHash}"
+      "tx_page": "https://atomscan.com/idep/transactions/${txHash}",
+      "account_page": "https://atomscan.com/idep/accounts/${accountAddress}"
     },
     {
       "kind": "TC Network",

--- a/impacthub/chain.json
+++ b/impacthub/chain.json
@@ -152,7 +152,8 @@
     {
       "kind": "atomscan",
       "url": "https://atomscan.com/ixo",
-      "tx_page": "https://atomscan.com/ixo/transactions/${txHash}"
+      "tx_page": "https://atomscan.com/ixo/transactions/${txHash}",
+      "account_page": "https://atomscan.com/ixo/accounts/${accountAddress}"
     },
     {
       "kind": "Mintscan",

--- a/injective/chain.json
+++ b/injective/chain.json
@@ -287,7 +287,8 @@
     {
       "kind": "atomscan",
       "url": "https://atomscan.com/injective",
-      "tx_page": "https://atomscan.com/injective/transactions/${txHash}"
+      "tx_page": "https://atomscan.com/injective/transactions/${txHash}",
+      "account_page": "https://atomscan.com/injective/accounts/${accountAddress}"
     },
     {
       "kind": "mintscan",

--- a/irisnet/chain.json
+++ b/irisnet/chain.json
@@ -136,7 +136,8 @@
     {
       "kind": "atomscan",
       "url": "https://atomscan.com/iris-network",
-      "tx_page": "https://atomscan.com/iris-network/transactions/${txHash}"
+      "tx_page": "https://atomscan.com/iris-network/transactions/${txHash}",
+      "account_page": "https://atomscan.com/iris-network/accounts/${accountAddress}"
     }
   ]
 }

--- a/juno/chain.json
+++ b/juno/chain.json
@@ -419,7 +419,8 @@
     {
       "kind": "atomscan",
       "url": "https://atomscan.com/juno",
-      "tx_page": "https://atomscan.com/juno/transactions/${txHash}"
+      "tx_page": "https://atomscan.com/juno/transactions/${txHash}",
+      "account_page": "https://atomscan.com/juno/accounts/${accountAddress}"
     },
     {
       "kind": "TC Network",

--- a/kava/chain.json
+++ b/kava/chain.json
@@ -163,7 +163,8 @@
     {
       "kind": "atomscan",
       "url": "https://atomscan.com/kava",
-      "tx_page": "https://atomscan.com/kava/transactions/${txHash}"
+      "tx_page": "https://atomscan.com/kava/transactions/${txHash}",
+      "account_page": "https://atomscan.com/kava/accounts/${accountAddress}"
     }
   ]
 }

--- a/kichain/chain.json
+++ b/kichain/chain.json
@@ -174,7 +174,8 @@
     {
       "kind": "atomscan",
       "url": "https://atomscan.com/ki-chain",
-      "tx_page": "https://atomscan.com/ki-chain/transactions/${txHash}"
+      "tx_page": "https://atomscan.com/ki-chain/transactions/${txHash}",
+      "account_page": "https://atomscan.com/ki-chain/accounts/${accountAddress}"
     }
   ]
 }

--- a/kujira/chain.json
+++ b/kujira/chain.json
@@ -275,7 +275,8 @@
     {
       "kind": "atomscan",
       "url": "https://atomscan.com/kujira",
-      "tx_page": "https://atomscan.com/kujira/transactions/${txHash}"
+      "tx_page": "https://atomscan.com/kujira/transactions/${txHash}",
+      "account_page": "https://atomscan.com/kujira/accounts/${accountAddress}"
     },
     {
       "kind": "Nodeist Explorer",

--- a/lambda/chain.json
+++ b/lambda/chain.json
@@ -111,6 +111,12 @@
       "kind": "NodeStake",
       "url": "https://explorer.nodestake.top/lambda",
       "tx_page": "https://explorer.nodestake.top/lambda/txs/${txHash}"
+    },
+    {
+      "kind": "atomscan",
+      "url": "https://atomscan.com/lambda",
+      "tx_page": "https://atomscan.com/lambda/transactions/${txHash}",
+      "account_page": "https://atomscan.com/lambda/accounts/${accountAddress}"
     }
   ]
 }

--- a/likecoin/chain.json
+++ b/likecoin/chain.json
@@ -176,7 +176,8 @@
     {
       "kind": "atomscan",
       "url": "https://atomscan.com/likecoin",
-      "tx_page": "https://atomscan.com/likecoin/transactions/${txHash}"
+      "tx_page": "https://atomscan.com/likecoin/transactions/${txHash}",
+      "account_page": "https://atomscan.com/likecoin/accounts/${accountAddress}"
     }
   ],
   "logo_URIs": {

--- a/lumenx/chain.json
+++ b/lumenx/chain.json
@@ -159,6 +159,12 @@
       "kind": "Nodine.ID",
       "url": "https://explorer.co.id/lumenx",
       "tx_page": "https://explorer.co.id/lumenx/tx/${txHash}"
+    },
+    {
+      "kind": "atomscan",
+      "url": "https://atomscan.com/lumenx",
+      "tx_page": "https://atomscan.com/lumenx/transactions/${txHash}",
+      "account_page": "https://atomscan.com/lumenx/accounts/${accountAddress}"
     }
   ]
 }

--- a/lumnetwork/chain.json
+++ b/lumnetwork/chain.json
@@ -169,7 +169,8 @@
     {
       "kind": "atomscan",
       "url": "https://atomscan.com/lum-network",
-      "tx_page": "https://atomscan.com/lum-network/transactions/${txHash}"
+      "tx_page": "https://atomscan.com/lum-network/transactions/${txHash}",
+      "account_page": "https://atomscan.com/lum-network/accounts/${accountAddress}"
     }
   ]
 }

--- a/meme/chain.json
+++ b/meme/chain.json
@@ -156,7 +156,8 @@
     {
       "kind": "atomscan",
       "url": "https://atomscan.com/meme",
-      "tx_page": "https://atomscan.com/meme/transactions/${txHash}"
+      "tx_page": "https://atomscan.com/meme/transactions/${txHash}",
+      "account_page": "https://atomscan.com/meme/accounts/${accountAddress}"
     },
     {
       "kind": "Brochain",

--- a/migaloo/chain.json
+++ b/migaloo/chain.json
@@ -216,6 +216,12 @@
       "url": "https://explorer.silknodes.io/migaloo",
       "tx_page": "https://explorer.silknodes.io/migaloo/tx/${txHash}",
       "account_page": "https://explorer.silknodes.io/migaloo/account/${accountAddress}"
+    },
+    {
+      "kind": "atomscan",
+      "url": "https://atomscan.com/migaloo",
+      "tx_page": "https://atomscan.com/migaloo/transactions/${txHash}",
+      "account_page": "https://atomscan.com/migaloo/accounts/${accountAddress}"
     }
   ]
 }

--- a/omniflixhub/chain.json
+++ b/omniflixhub/chain.json
@@ -211,7 +211,8 @@
     {
       "kind": "atomscan",
       "url": "https://atomscan.com/omniflixhub",
-      "tx_page": "https://atomscan.com/omniflixhub/transactions/${txHash}"
+      "tx_page": "https://atomscan.com/omniflixhub/transactions/${txHash}",
+      "account_page": "https://atomscan.com/omniflixhub/accounts/${accountAddress}"
     }
   ]
 }

--- a/oraichain/chain.json
+++ b/oraichain/chain.json
@@ -160,6 +160,12 @@
       "kind": "Nodine Explorer",
       "url": "https://explorer.co.id/orai",
       "tx_page": "https://explorer.co.id/orai/tx/${txHash}"
+    },
+    {
+      "kind": "atomscan",
+      "url": "https://atomscan.com/orai",
+      "tx_page": "https://atomscan.com/orai/transactions/${txHash}",
+      "account_page": "https://atomscan.com/orai/accounts/${accountAddress}"
     }
   ]
 }

--- a/osmosis/chain.json
+++ b/osmosis/chain.json
@@ -399,7 +399,8 @@
     {
       "kind": "atomscan",
       "url": "https://atomscan.com/osmosis",
-      "tx_page": "https://atomscan.com/osmosis/transactions/${txHash}"
+      "tx_page": "https://atomscan.com/osmosis/transactions/${txHash}",
+      "account_page": "https://atomscan.com/osmosis/accounts/${accountAddress}"
     },
     {
       "kind": "bigdipper",

--- a/passage/chain.json
+++ b/passage/chain.json
@@ -224,6 +224,12 @@
       "url": "https://www.mintscan.io/passage",
       "tx_page": "https://www.mintscan.io/passage/txs/${txHash}",
       "account_page": "https://www.mintscan.io/passage/account/${accountAddress}"
+    },
+    {
+      "kind": "atomscan",
+      "url": "https://atomscan.com/passage",
+      "tx_page": "https://atomscan.com/passage/transactions/${txHash}",
+      "account_page": "https://atomscan.com/passage/accounts/${accountAddress}"
     }
   ],
   "logo_URIs": {

--- a/persistence/chain.json
+++ b/persistence/chain.json
@@ -260,7 +260,8 @@
     {
       "kind": "atomscan",
       "url": "https://atomscan.com/persistence",
-      "tx_page": "https://atomscan.com/persistence/transactions/${txHash}"
+      "tx_page": "https://atomscan.com/persistence/transactions/${txHash}",
+      "account_page": "https://atomscan.com/persistence/accounts/${accountAddress}"
     },
     {
       "kind": "bigdipper",

--- a/planq/chain.json
+++ b/planq/chain.json
@@ -245,6 +245,12 @@
       "kind": "NODEXPLORER",
       "url": "https://explorer.nodexcapital.com/planq",
       "tx_page": "https://explorer.nodexcapital.com/planq/tx/${txHash}"
+    },
+    {
+      "kind": "atomscan",
+      "url": "https://atomscan.com/planq",
+      "tx_page": "https://atomscan.com/planq/transactions/${txHash}",
+      "account_page": "https://atomscan.com/planq/accounts/${accountAddress}"
     }
   ]
 }

--- a/point/chain.json
+++ b/point/chain.json
@@ -144,6 +144,12 @@
       "kind": "NODEXPLORER",
       "url": "https://explorer.nodexcapital.com/point",
       "tx_page": "https://explorer.nodexcapital.com/point/tx/${txHash}"
+    },
+    {
+      "kind": "atomscan",
+      "url": "https://atomscan.com/point",
+      "tx_page": "https://atomscan.com/point/transactions/${txHash}",
+      "account_page": "https://atomscan.com/point/accounts/${accountAddress}"
     }
   ]
 }

--- a/provenance/chain.json
+++ b/provenance/chain.json
@@ -144,7 +144,8 @@
     {
       "kind": "atomscan",
       "url": "https://atomscan.com/provenance",
-      "tx_page": "https://atomscan.com/provenance/transactions/${txHash}"
+      "tx_page": "https://atomscan.com/provenance/transactions/${txHash}",
+      "account_page": "https://atomscan.com/provenance/accounts/${accountAddress}"
     },
     {
       "kind": "bigdipper",

--- a/rebus/chain.json
+++ b/rebus/chain.json
@@ -243,6 +243,12 @@
       "kind": "tcnetwork",
       "url": "https://rebus.tcnetwork.io",
       "tx_page": "https://rebus.tcnetwork.io/transaction/${txHash}"
+    },
+    {
+      "kind": "atomscan",
+      "url": "https://atomscan.com/rebus",
+      "tx_page": "https://atomscan.com/rebus/transactions/${txHash}",
+      "account_page": "https://atomscan.com/rebus/accounts/${accountAddress}"
     }
   ]
 }

--- a/regen/chain.json
+++ b/regen/chain.json
@@ -199,7 +199,8 @@
     {
       "kind": "atomscan",
       "url": "https://atomscan.com/regen-network",
-      "tx_page": "https://atomscan.com/regen-network/transactions/${txHash}"
+      "tx_page": "https://atomscan.com/regen-network/transactions/${txHash}",
+      "account_page": "https://atomscan.com/regen-network/accounts/${accountAddress}"
     }
   ],
   "logo_URIs": {

--- a/rizon/chain.json
+++ b/rizon/chain.json
@@ -152,7 +152,8 @@
     {
       "kind": "atomscan",
       "url": "https://atomscan.com/rizon",
-      "tx_page": "https://atomscan.com/rizon/transactions/${txHash}"
+      "tx_page": "https://atomscan.com/rizon/transactions/${txHash}",
+      "account_page": "https://atomscan.com/rizon/accounts/${accountAddress}"
     },
     {
       "kind": "bigdipper",

--- a/secretnetwork/chain.json
+++ b/secretnetwork/chain.json
@@ -204,7 +204,8 @@
     {
       "kind": "atomscan",
       "url": "https://atomscan.com/secret-network",
-      "tx_page": "https://atomscan.com/secret-network/transactions/${txHash}"
+      "tx_page": "https://atomscan.com/secret-network/transactions/${txHash}",
+      "account_page": "https://atomscan.com/secret-network/accounts/${accountAddress}"
     }
   ]
 }

--- a/sentinel/chain.json
+++ b/sentinel/chain.json
@@ -167,6 +167,12 @@
       "url": "https://www.mintscan.io/sentinel",
       "tx_page": "https://www.mintscan.io/sentinel/txs/${txHash}",
       "account_page": "https://www.mintscan.io/sentinel/account/${accountAddress}"
+    },
+    {
+      "kind": "atomscan",
+      "url": "https://atomscan.com/sentinel",
+      "tx_page": "https://atomscan.com/sentinel/transactions/${txHash}",
+      "account_page": "https://atomscan.com/sentinel/accounts/${accountAddress}"
     }
   ]
 }

--- a/shentu/chain.json
+++ b/shentu/chain.json
@@ -161,8 +161,9 @@
     },
     {
       "kind": "atomscan",
-      "url": "https://atomscan.com/certik",
-      "tx_page": "https://atomscan.com/certik/transactions/${txHash}"
+      "url": "https://atomscan.com/shentu",
+      "tx_page": "https://atomscan.com/shentu/transactions/${txHash}",
+      "account_page": "https://atomscan.com/shentu/accounts/${accountAddress}"
     },
     {
       "kind": "bigdipper",

--- a/sifchain/chain.json
+++ b/sifchain/chain.json
@@ -181,7 +181,8 @@
     {
       "kind": "atomscan",
       "url": "https://atomscan.com/sifchain",
-      "tx_page": "https://atomscan.com/sifchain/transactions/${txHash}"
+      "tx_page": "https://atomscan.com/sifchain/transactions/${txHash}",
+      "account_page": "https://atomscan.com/sifchain/accounts/${accountAddress}"
     }
   ]
 }

--- a/sommelier/chain.json
+++ b/sommelier/chain.json
@@ -195,6 +195,12 @@
       "url": "https://explorer.nodexcapital.com/sommelier",
       "tx_page": "https://explorer.nodexcapital.com/sommelier/tx/${txHash}",
       "account_page": "https://explorer.nodexcapital.com/sommelier/account/${accountAddress}"
+    },
+    {
+      "kind": "atomscan",
+      "url": "https://atomscan.com/sommelier",
+      "tx_page": "https://atomscan.com/sommelier/transactions/${txHash}",
+      "account_page": "https://atomscan.com/sommelier/accounts/${accountAddress}"
     }
   ]
 }

--- a/stafihub/chain.json
+++ b/stafihub/chain.json
@@ -137,6 +137,12 @@
       "kind": "ping-pub",
       "url": "https://ping.pub/stafihub",
       "tx_page": "https://ping.pub/stafihub/tx/${txHash}"
+    },
+    {
+      "kind": "atomscan",
+      "url": "https://atomscan.com/stafihub",
+      "tx_page": "https://atomscan.com/stafihub/transactions/${txHash}",
+      "account_page": "https://atomscan.com/stafihub/accounts/${accountAddress}"
     }
   ],
   "logo_URIs": {

--- a/stargaze/chain.json
+++ b/stargaze/chain.json
@@ -259,7 +259,8 @@
     {
       "kind": "atomscan",
       "url": "https://atomscan.com/stargaze",
-      "tx_page": "https://atomscan.com/stargaze/transactions/${txHash}"
+      "tx_page": "https://atomscan.com/stargaze/transactions/${txHash}",
+      "account_page": "https://atomscan.com/stargaze/accounts/${accountAddress}"
     }
   ]
 }

--- a/starname/chain.json
+++ b/starname/chain.json
@@ -116,7 +116,8 @@
     {
       "kind": "atomscan",
       "url": "https://atomscan.com/starname",
-      "tx_page": "https://atomscan.com/starname/transactions/${txHash}"
+      "tx_page": "https://atomscan.com/starname/transactions/${txHash}",
+      "account_page": "https://atomscan.com/starname/accounts/${accountAddress}"
     }
   ]
 }

--- a/stride/chain.json
+++ b/stride/chain.json
@@ -344,6 +344,12 @@
       "url": "https://bigdipper.live/stride",
       "tx_page": "https://bigdipper.live/stride/transactions/${txHash}",
       "account_page": "https://bigdipper.live/stride/accounts/${accountAddress}"
+    },
+    {
+      "kind": "atomscan",
+      "url": "https://atomscan.com/stride",
+      "tx_page": "https://atomscan.com/stride/transactions/${txHash}",
+      "account_page": "https://atomscan.com/stride/accounts/${accountAddress}"
     }
   ],
   "logo_URIs": {

--- a/teritori/chain.json
+++ b/teritori/chain.json
@@ -345,6 +345,12 @@
       "kind": "TC Network",
       "url": "https://explorer.tcnetwork.io/teritori",
       "tx_page": "https://explorer.tcnetwork.io/teritori/transaction/${txHash}"
+    },
+    {
+      "kind": "atomscan",
+      "url": "https://atomscan.com/teritori",
+      "tx_page": "https://atomscan.com/teritori/transactions/${txHash}",
+      "account_page": "https://atomscan.com/teritori/accounts/${accountAddress}"
     }
   ]
 }

--- a/terra/chain.json
+++ b/terra/chain.json
@@ -318,7 +318,8 @@
     {
       "kind": "atomscan",
       "url": "https://atomscan.com/terra",
-      "tx_page": "https://atomscan.com/terra/transactions/${txHash}"
+      "tx_page": "https://atomscan.com/terra/transactions/${txHash}",
+      "account_page": "https://atomscan.com/terra/accounts/${accountAddress}"
     },
     {
       "kind": "finder",

--- a/terra2/chain.json
+++ b/terra2/chain.json
@@ -254,7 +254,8 @@
     {
       "kind": "atomscan",
       "url": "https://atomscan.com/terra2",
-      "tx_page": "https://atomscan.com/terra/transactions/${txHash}"
+      "tx_page": "https://atomscan.com/terra2/transactions/${txHash}",
+      "account_page": "https://atomscan.com/terra2/accounts/${accountAddress}"
     },
     {
       "kind": "finder",

--- a/umee/chain.json
+++ b/umee/chain.json
@@ -396,7 +396,8 @@
     {
       "kind": "atomscan",
       "url": "https://atomscan.com/umee",
-      "tx_page": "https://atomscan.com/umee/transactions/${txHash}"
+      "tx_page": "https://atomscan.com/umee/transactions/${txHash}",
+      "account_page": "https://atomscan.com/umee/accounts/${accountAddress}"
     }
   ]
 }

--- a/unification/chain.json
+++ b/unification/chain.json
@@ -111,6 +111,12 @@
       "kind": "ping.pub",
       "url": "https://explorer.unification.chainmasters.ninja/unification",
       "tx_page": "https://explorer.unification.chainmasters.ninja/unification/tx/${txHash}"
+    },
+    {
+      "kind": "atomscan",
+      "url": "https://atomscan.com/unification",
+      "tx_page": "https://atomscan.com/unification/transactions/${txHash}",
+      "account_page": "https://atomscan.com/unification/accounts/${accountAddress}"
     }
   ]
 }

--- a/vidulum/chain.json
+++ b/vidulum/chain.json
@@ -128,7 +128,8 @@
     {
       "kind": "atomscan",
       "url": "https://atomscan.com/vidulum",
-      "tx_page": "https://atomscan.com/vidulum/transactions/${txHash}"
+      "tx_page": "https://atomscan.com/vidulum/transactions/${txHash}",
+      "account_page": "https://atomscan.com/vidulum/accounts/${accountAddress}"
     },
     {
       "kind": "Nodine Explorer",


### PR DESCRIPTION
- Updated a number of existing chains to add `account_page` link
- Added ATOMScan links to most supported chains