### PR TITLE
fix: 🐛 fix minor alias typo

### DIFF
--- a/testnets/elystestnet/assetlist.json
+++ b/testnets/elystestnet/assetlist.json
@@ -16,7 +16,7 @@
           "denom": "melys",
           "exponent": 3,
           "aliases": [
-            "milliscrt"
+            "millielys"
           ]
         },
         {


### PR DESCRIPTION
@JeremyParish69 this is a minor PR to fix a typo in the elys testnet network assetlist file