### PR TITLE
jq . chain.schema.json

### DIFF
--- a/chain.schema.json
+++ b/chain.schema.json
@@ -390,8 +390,8 @@
             "type": "object",
             "properties": {
               "primary_color_hex": {
-               "type": "string",
-               "pattern": "^#[0-9a-fA-F]{6}$"
+                "type": "string",
+                "pattern": "^#[0-9a-fA-F]{6}$"
               }
             },
             "additionalProperties": false
@@ -609,6 +609,5 @@
       },
       "additionalProperties": false
     }
-  },
-  "additionalProperties": false
+  }
 }


### PR DESCRIPTION
Ran the schema through `jq` to make it standard. Some Go libraries complain if your schema doesn't look nice.

"additionalProperties" in line 610 was already defined in line 505.