### PR TITLE
Fix Checks

### DIFF
--- a/.github/workflows/utility/validate_data.py
+++ b/.github/workflows/utility/validate_data.py
@@ -1,5 +1,5 @@
 import json
-import urllib.request
+import urllib3
 import os
 from os import getcwd
 

--- a/.github/workflows/utility/validate_data.py
+++ b/.github/workflows/utility/validate_data.py
@@ -1,5 +1,6 @@
 import json
 import urllib3
+urllib3.__version__ = "1.26.5"
 import os
 from os import getcwd
 


### PR DESCRIPTION
All my github checks are failing
Run snapcart/json-schema-validator@v1.0.0
Traceback (most recent call last):
 File "/usr/local/lib/python3.7/site-packages/urllib3/__init__.py", line 39, in <module>
    "urllib3 v2.0 only supports OpenSSL 1.1.1+, currently "

It seems that the error you're encountering is related to the version compatibility of urllib3 and OpenSSL. Specifically, the version of urllib3 you're using (v2.0) requires OpenSSL version 1.1.1+, but the version of OpenSSL you have installed (1.1.0l) is not compatible.

If upgrading OpenSSL is not feasible, you could try downgrading urllib3 to a version that is compatible with the version of OpenSSL you have installed. You can check the urllib3 documentation or release notes to find out which version(s) of OpenSSL are supported by each version of urllib3.