### PR TITLE
Add cosmwasm path to chain-registry

### DIFF
--- a/chain.schema.json
+++ b/chain.schema.json
@@ -327,6 +327,11 @@
               "cosmwasm_enabled": {
                 "type": "boolean"
               },
+              "cosmwasm_path": {
+                "type": "string",
+                "description": "Relative path to the cosmwasm directory. ex. $HOME/.juno/data/wasm",
+                "pattern": "^\\$HOME.*$"
+              },
               "ibc_go_version": {
                 "type": "string"
               },

--- a/chain.schema.json
+++ b/chain.schema.json
@@ -225,6 +225,10 @@
         "cosmwasm_enabled": {
           "type": "boolean"
         },
+        "cosmwasm_path": {
+          "type": "string",
+          "description": "Relative path to the cosmwasm directory. ex. $HOME/.juno/data/wasm"
+        },
         "ibc_go_version": {
           "type": "string"
         },

--- a/chain.schema.json
+++ b/chain.schema.json
@@ -227,7 +227,8 @@
         },
         "cosmwasm_path": {
           "type": "string",
-          "description": "Relative path to the cosmwasm directory. ex. $HOME/.juno/data/wasm"
+          "description": "Relative path to the cosmwasm directory. ex. $HOME/.juno/data/wasm",
+          "pattern": "^\\$HOME.*$"
         },
         "ibc_go_version": {
           "type": "string"


### PR DESCRIPTION
@JeremyParish69 this is kind of odd, but currently cosmwasm networks don't have a standard location for where to store their wasm information. This is *100%* necessary to know, as using state sync requires this knowledge. 

A few examples of where networks store their wasm information:
| network | path |
| --- | --- |
| secret | `~/.secretd/.compute/wasm` |
| juno |  `~/.juno/data/wasm` |
| osmosis |  `~/.osmosisd/data/wasm` |
| comdex |  `~/.comdex/wasm` |

That's 3 different paths right there, and I *know* there's at least 1 more, I just can't remember it off-hand.

The ideal answer would be for everyone to just standardize around a single method of wasm storage (`juno`'s would be my preference), but I'm going to lean towards "fat chance."
