### PR TITLE
Revert "Del kingnodes REST endpoint"

### DIFF
--- a/evmos/chain.json
+++ b/evmos/chain.json
@@ -289,6 +289,10 @@
     ],
     "rest": [
       {
+        "address": "https://evmos.kingnodes.com",
+        "provider": "kingnodes"
+      },
+      {
         "address": "https://lcd-evmos.whispernode.com:443",
         "provider": "WhisperNode🤐"
       },


### PR DESCRIPTION
Reverts cosmos/chain-registry#1986

Hi @JeremyParish69.
Our rest endpoints are indeed REST endpoints. We use caddy to map the path to the cosmos API. There is nothing wrong with it other than we block some features. @staking-explorer should have messaged me rather than get our endpoints removed. Can you please revert this PR.