### PR TITLE
Change recommended gravity version to v1.9.1

### DIFF
--- a/gravitybridge/chain.json
+++ b/gravitybridge/chain.json
@@ -45,12 +45,12 @@
   },
   "codebase": {
     "git_repo": "https://github.com/Gravity-Bridge/Gravity-Bridge",
-    "recommended_version": "v1.9.0",
+    "recommended_version": "v1.9.1",
     "compatible_versions": [
-      "v1.9.0"
+      "v1.9.0", "v1.9.1"
     ],
     "binaries": {
-      "linux/amd64": "https://github.com/Gravity-Bridge/Gravity-Bridge/releases/download/v1.9.0/gravity-linux-amd64"
+      "linux/amd64": "https://github.com/Gravity-Bridge/Gravity-Bridge/releases/download/v1.9.1/gravity-linux-amd64"
     },
     "genesis": {
       "genesis_url": "https://raw.githubusercontent.com/Gravity-Bridge/Gravity-Docs/main/genesis.json"
@@ -73,13 +73,13 @@
       {
         "name": "orion",
         "height": 6698820,
-        "recommended_version": "v1.9.0",
+        "recommended_version": "v1.9.1",
         "proposal": 172,
         "compatible_versions": [
-          "v1.9.0"
+          "v1.9.0", "v1.9.1"
         ],
         "binaries": {
-          "linux/amd64": "https://github.com/Gravity-Bridge/Gravity-Bridge/releases/download/v1.9.0/gravity-linux-amd64"
+          "linux/amd64": "https://github.com/Gravity-Bridge/Gravity-Bridge/releases/download/v1.9.1/gravity-linux-amd64"
         }
       }
     ]


### PR DESCRIPTION
Adding v1.9.1 as recommended version and under compatible versions for v1.9.x. Even though it's not required for everyone, it is required if your validator is doing ETH relaying so it's probably best to set this as recommended.