### PR TITLE
:bug: UWHALE from migaloo fix coingecko

### DIFF
--- a/migaloo/assetlist.json
+++ b/migaloo/assetlist.json
@@ -22,7 +22,7 @@
         "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/migaloo/images/white-whale.svg",
         "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/migaloo/images/white-whale.png"
       },
-      "coingecko_id": "white-whale"
+      "coingecko_id": "whale"
     },
     {
       "description": "ampWHALE",


### PR DESCRIPTION
The UWHALE native token from migaloo chain has the wrong coingecko id, its pointing to its old whale token from terra (white whale) instead of the correct one (whale)