### PR TITLE
Added the correct chain_name for the testnet

### DIFF
--- a/testnets/coreumtestnet/chain.json
+++ b/testnets/coreumtestnet/chain.json
@@ -1,6 +1,6 @@
 {
   "$schema": "../../chain.schema.json",
-  "chain_name": "coreum",
+  "chain_name": "coreumtestnet",
   "status": "live",
   "network_type": "testnet",
   "website": "https://www.coreum.com",


### PR DESCRIPTION
Restake app and restake-service use "chains.testcosmos.directory/:chain_name" and it is not returning any data because currently, the [chain_name](https://github.com/cosmos/chain-registry/blob/88080fec2c1edd1d91ea719532cdb7a13855c834/testnets/coreumtestnet/chain.json#L3) for testnet is `coreum` but it should be `coreumtestnet` as all other testnets have chain_name with testnet added in the end.