### PR TITLE
new path for odin osmosis

### DIFF
--- a/_IBC/odin-osmosis.json
+++ b/_IBC/odin-osmosis.json
@@ -2,22 +2,22 @@
   "$schema": "../ibc_data.schema.json",
   "chain_1": {
     "chain_name": "odin",
-    "client_id": "07-tendermint-10",
-    "connection_id": "connection-9"
+    "client_id": "07-tendermint-64",
+    "connection_id": "connection-49"
   },
   "chain_2": {
     "chain_name": "osmosis",
-    "client_id": "07-tendermint-2007",
-    "connection_id": "connection-1551"
+    "client_id": "07-tendermint-2786",
+    "connection_id": "connection-2286"
   },
   "channels": [
     {
       "chain_1": {
-        "channel_id": "channel-3",
+        "channel_id": "channel-35",
         "port_id": "transfer"
       },
       "chain_2": {
-        "channel_id": "channel-258",
+        "channel_id": "channel-780",
         "port_id": "transfer"
       },
       "ordering": "unordered",


### PR DESCRIPTION
The path for odin <> osmosis expired, and [Anant](https://t.me/anantsingh) from odin protocol asked me to create a new path, instead of re-activating the previous path via a governance proposal.    I have done so, and  Defiant will be relaying this path. 

[client Open](https://www.mintscan.io/osmosis/txs/5D16EB498DD8C4EB2AC02EB08960C68AA33B37F13D0D597FD55FB977768EF8AE?height=9706872)  
[connection open](https://www.mintscan.io/osmosis/txs/7CD116A395C5BDCDEA5A60048004F60F98ADEA49FAA098D99A085F06FB1A6DA1?height=9706886)  
[channel open](https://www.mintscan.io/osmosis/txs/86A94D43E2E96F7111F1C52DA831DDEE09CA354B283898E2DDCAA388139B0D86?height=9706896)
[ibc test](https://www.mintscan.io/osmosis/txs/F6317CAEE53DBC8E56AD8153E1CD4051D148BC2DF15DD7333972AAE3930A6EB9?height=9707035)