### PR TITLE
Upgrade Evmos to v12.1.3 

### DIFF
--- a/evmos/chain.json
+++ b/evmos/chain.json
@@ -36,18 +36,19 @@
   },
   "codebase": {
     "git_repo": "https://github.com/evmos/evmos",
-    "recommended_version": "v12.1.2",
+    "recommended_version": "v12.1.3",
     "compatible_versions": [
+      "v12.1.3",
       "v12.1.2",
       "v12.1.1",
       "v12.1.0"
     ],
     "binaries": {
-      "linux/amd64": "https://github.com/evmos/evmos/releases/download/v12.1.0/evmos_12.1.0_Linux_amd64.tar.gz",
-      "linux/arm64": "https://github.com/evmos/evmos/releases/download/v12.1.0/evmos_12.1.0_Linux_arm64.tar.gz",
-      "darwin/amd64": "https://github.com/evmos/evmos/releases/download/v12.1.0/evmos_12.1.0_Darwin_amd64.tar.gz",
-      "darwin/arm64": "https://github.com/evmos/evmos/releases/download/v12.1.0/evmos_12.1.0_Darwin_arm64.tar.gz",
-      "windows/amd64": "https://github.com/evmos/evmos/releases/download/v12.1.0/evmos_12.1.0_Windows_amd64.zip"
+      "linux/amd64": "https://github.com/evmos/evmos/releases/download/v12.1.3/evmos_12.1.3_Linux_amd64.tar.gz",
+      "linux/arm64": "https://github.com/evmos/evmos/releases/download/v12.1.3/evmos_12.1.3_Darwin_arm64.tar.gz",
+      "darwin/amd64": "https://github.com/evmos/evmos/releases/download/v12.1.3/evmos_12.1.3_Darwin_amd64.tar.gz",
+      "darwin/arm64": "https://github.com/evmos/evmos/releases/download/v12.1.3/evmos_12.1.3_Darwin_arm64.tar.gzz",
+      "windows/amd64": "https://github.com/evmos/evmos/releases/download/v12.1.3/evmos_12.1.3_Windows_amd64.zip"
     },
     "cosmos_sdk_version": "0.46",
     "consensus": {
@@ -61,8 +62,9 @@
     "versions": [
       {
         "name": "v12",
-        "recommended_version": "v12.1.2",
+        "recommended_version": "v12.1.3",
         "compatible_versions": [
+          "v12.1.3",
           "v12.1.2",
           "v12.1.1",
           "v12.1.0"
@@ -74,11 +76,11 @@
         },
         "ibc_go_version": "6.1.0",
         "binaries": {
-          "linux/amd64": "https://github.com/evmos/evmos/releases/download/v12.1.0/evmos_12.1.0_Linux_amd64.tar.gz",
-          "linux/arm64": "https://github.com/evmos/evmos/releases/download/v12.1.0/evmos_12.1.0_Linux_arm64.tar.gz",
-          "darwin/amd64": "https://github.com/evmos/evmos/releases/download/v12.1.0/evmos_12.1.0_Darwin_amd64.tar.gz",
-          "darwin/arm64": "https://github.com/evmos/evmos/releases/download/v12.1.0/evmos_12.1.0_Darwin_arm64.tar.gz",
-          "windows/amd64": "https://github.com/evmos/evmos/releases/download/v12.1.0/evmos_12.1.0_Windows_amd64.zip"
+          "linux/amd64": "https://github.com/evmos/evmos/releases/download/v12.1.3/evmos_12.1.3_Linux_amd64.tar.gz",
+          "linux/arm64": "https://github.com/evmos/evmos/releases/download/v12.1.3/evmos_12.1.3_Darwin_arm64.tar.gz",
+          "darwin/amd64": "https://github.com/evmos/evmos/releases/download/v12.1.3/evmos_12.1.3_Darwin_amd64.tar.gz",
+          "darwin/arm64": "https://github.com/evmos/evmos/releases/download/v12.1.3/evmos_12.1.3_Darwin_arm64.tar.gzz",
+          "windows/amd64": "https://github.com/evmos/evmos/releases/download/v12.1.3/evmos_12.1.3_Windows_amd64.zip"
         }
       }
     ]


### PR DESCRIPTION
Upgrade Evmos to v12.1.3 https://github.com/evmos/evmos/releases/tag/v12.1.3