### PR TITLE
Neutron testnet: remove broken RPC endpoints, add Polkachu's

### DIFF
--- a/testnets/neutrontestnet/chain.json
+++ b/testnets/neutrontestnet/chain.json
@@ -85,12 +85,8 @@
         "provider": "Neutron"
       },
       {
-        "address": "https://rpc.pion.remedy.tm.p2p.org",
-        "provider": "P2P.ORG"
-      },
-      {
-        "address": "https://rpc.baryon-sentry-01.rs-testnet.polypore.xyz",
-        "provider": "Hypha"
+        "address": "https://neutron-testnet-rpc.polkachu.com/",
+        "provider": "Polkachu"
       }
     ],
     "rest": [


### PR DESCRIPTION
Two of the current RPC endpoints don't resolve:

<img width="953" alt="Screen Shot 2023-05-30 at 9 56 10 AM" src="https://github.com/cosmos/chain-registry/assets/1042667/9430e5be-474f-4927-bf81-b0cb3b9bef86">

<img width="953" alt="Screen Shot 2023-05-30 at 9 56 03 AM" src="https://github.com/cosmos/chain-registry/assets/1042667/561d67ab-3c1e-44f3-8f0c-c6ce2fb240b1">

Added Polkachu's testnet RPC, too, which does resolve.

https://neutron-testnet-rpc.polkachu.com/status