### PR TITLE
Update archway testnet to `constantine-3`

### DIFF
--- a/testnets/archwaytestnet/chain.json
+++ b/testnets/archwaytestnet/chain.json
@@ -1,7 +1,7 @@
 {
   "$schema": "../chain.schema.json",
   "chain_name": "archwaytestnet",
-  "chain_id": "constantine-2",
+  "chain_id": "constantine-3",
   "pretty_name": "Archway testnet",
   "status": "live",
   "network_type": "testnet",
@@ -33,22 +33,26 @@
   "apis": {
     "rpc": [
       {
-        "address": "https://rpc.constantine-2.archway.tech",
-        "provider": "Quickapi"
+        "address": "https://rpc.constantine.archway.tech",
+        "provider": "Archway"
+      },
+      {
+        "address": "https://archway-testnet-rpc.polkachu.com",
+        "provider": "Polkachu"
       }
     ],
     "rest": [
       {
-        "address": "https://api.constantine-2.archway.tech",
-        "provider": "Quickapi"
+        "address": "https://api.constantine.archway.tech",
+        "provider": "Archway"
       }
     ]
   },
   "explorers": [
     {
       "kind": "archwayscan",
-      "url": "https://explorer.constantine-2.archway.tech",
-      "tx_page": "https://explorer.constantine-2.archway.tech/transactions/${txHash}"
+      "url": "https://testnet.archway.explorers.guru",
+      "tx_page": "https://testnet.archway.explorers.guru/transaction/${txHash}"
     }
   ]
 }


### PR DESCRIPTION
As we (CronCat) works on deploying to CosmWasm chains, we noticed the Archway testnet is out of date here.

As you can see from [their website](https://docs.archway.io/resources/networks), `constantine-3` is the only one that appears, due to `constantine-2` being outdated.

I've also changed the explorer URL and added Polkachu's testnet RPC node from https://polkachu.com/testnets/archway under "RPC endpoint"