### PR TITLE
Add Lum v1.4.1 upgrade plus 1.4.2 patch

### DIFF
--- a/lumnetwork/chain.json
+++ b/lumnetwork/chain.json
@@ -33,9 +33,10 @@
   },
   "codebase": {
     "git_repo": "https://github.com/lum-network/chain",
-    "recommended_version": "v1.4.0",
+    "recommended_version": "v1.4.2",
     "compatible_versions": [
-      "v1.4.0"
+      "v1.4.1",
+      "v1.4.2"
     ],
     "genesis": {
       "genesis_url": "https://raw.githubusercontent.com/lum-network/mainnet/master/genesis.json"
@@ -56,6 +57,16 @@
         "recommended_version": "v1.4.0",
         "compatible_versions": [
           "v1.4.0"
+        ]
+      },
+      {
+        "name": "v1.4.1",
+        "height": 7740000,
+        "proposal": 64,
+        "recommended_version": "v1.4.2",
+        "compatible_versions": [
+          "v1.4.1",
+          "v1.4.2"
         ]
       }
     ]


### PR DESCRIPTION
Chain upgrade v1.4.1 happened at block 7,740,000 per prop 64. https://www.mintscan.io/lum/proposals/64

Chain is being patched currently and v1.4.2 is the recommended version to use. Chain relaunch expected June 5 10:00 UTC per Discord announcements. 