### PR TITLE
Update Realio Network to v0.8.1

### DIFF
--- a/realio/chain.json
+++ b/realio/chain.json
@@ -4,7 +4,7 @@
     "status": "live",
     "network_type": "mainnet",
     "website": "https://realio.network/",
-    "pretty_name": "Realio",
+    "pretty_name": "Realio Network",
     "chain_id": "realionetwork_3301-1",
     "bech32_prefix": "realio",
     "node_home": "$HOME/.realio-network",
@@ -36,34 +36,46 @@
     },
     "codebase": {
       "git_repo": "https://github.com/realiotech/realio-network",
-      "recommended_version": "v0.8.0-rc4",
+      "recommended_version": "v0.8.1",
       "compatible_versions": [
-        "v0.8.0-rc4"
+        "v0.8.1"
       ],
       "binaries": {
-        "linux/amd64": "https://github.com/realiotech/realio-network/releases/download/v0.8.0-rc4/realio-network_0.8.0-rc4_Linux_x86_64.tar.gz",
-        "linux/arm64": "https://github.com/realiotech/realio-network/releases/download/v0.8.0-rc4/realio-network_0.8.0-rc4_Linux_arm64.tar.gz",
-        "darwin/amd64": "https://github.com/realiotech/realio-network/releases/download/v0.8.0-rc4/realio-network_0.8.0-rc4_Darwin_x86_64.tar.gz",
-        "darwin/arm64": "https://github.com/realiotech/realio-network/releases/download/v0.8.0-rc4/realio-network_0.8.0-rc4_Darwin_arm64.tar.gz",
-        "windows/amd64": "https://github.com/realiotech/realio-network/releases/download/v0.8.0-rc4/realio-network_0.8.0-rc4_Windows_x86_64.zip"
+        "linux/amd64": "https://github.com/realiotech/realio-network/releases/download/v0.8.1/realio-network_0.8.1_Linux_x86_64.tar.gz",
+        "linux/arm64": "https://github.com/realiotech/realio-network/releases/download/v0.8.1/realio-network_0.8.1_Linux_arm64.tar.gz",
+        "darwin/amd64": "https://github.com/realiotech/realio-network/releases/download/v0.8.1/realio-network_0.8.1_Darwin_x86_64.tar.gz",
+        "darwin/arm64": "https://github.com/realiotech/realio-network/releases/download/v0.8.1/realio-network_0.8.1_Darwin_arm64.tar.gz",
+        "windows/amd64": "https://github.com/realiotech/realio-network/releases/download/v0.8.1/realio-network_0.8.1_Windows_x86_64.zip"
       },
+      "cosmos_sdk_version": "0.46",
+      "consensus": {
+        "type": "tendermint",
+        "version": "0.34"
+      },
+      "ibc_go_version": "6.1.1",
       "genesis": {
         "genesis_url": "https://raw.githubusercontent.com/realiotech/mainnet/main/realionetwork_3301-1/genesis.json"
       },
       "versions": [
         {
-          "name": "v0.8.0-rc4",
-          "recommended_version": "v0.8.0-rc4",
+          "name": "v0.8.1",
+          "recommended_version": "v0.8.1",
           "compatible_versions": [
-            "v0.8.0-rc4"
+            "v0.8.1"
           ],
           "binaries": {
-            "linux/amd64": "https://github.com/realiotech/realio-network/releases/download/v0.8.0-rc4/realio-network_0.8.0-rc4_Linux_x86_64.tar.gz",
-            "linux/arm64": "https://github.com/realiotech/realio-network/releases/download/v0.8.0-rc4/realio-network_0.8.0-rc4_Linux_arm64.tar.gz",
-            "darwin/amd64": "https://github.com/realiotech/realio-network/releases/download/v0.8.0-rc4/realio-network_0.8.0-rc4_Darwin_x86_64.tar.gz",
-            "darwin/arm64": "https://github.com/realiotech/realio-network/releases/download/v0.8.0-rc4/realio-network_0.8.0-rc4_Darwin_arm64.tar.gz",
-            "windows/amd64": "https://github.com/realiotech/realio-network/releases/download/v0.8.0-rc4/realio-network_0.8.0-rc4_Windows_x86_64.zip"
-          }
+            "linux/amd64": "https://github.com/realiotech/realio-network/releases/download/v0.8.1/realio-network_0.8.1_Linux_x86_64.tar.gz",
+            "linux/arm64": "https://github.com/realiotech/realio-network/releases/download/v0.8.1/realio-network_0.8.1_Linux_arm64.tar.gz",
+            "darwin/amd64": "https://github.com/realiotech/realio-network/releases/download/v0.8.1/realio-network_0.8.1_Darwin_x86_64.tar.gz",
+            "darwin/arm64": "https://github.com/realiotech/realio-network/releases/download/v0.8.1/realio-network_0.8.1_Darwin_arm64.tar.gz",
+            "windows/amd64": "https://github.com/realiotech/realio-network/releases/download/v0.8.1/realio-network_0.8.1_Windows_x86_64.zip"
+          },
+          "cosmos_sdk_version": "0.46",
+          "consensus": {
+            "type": "tendermint",
+            "version": "0.34"
+          },
+          "ibc_go_version": "6.1.1"
         }
       ]
     },


### PR DESCRIPTION
Update chain version to [v0.8.1](https://github.com/realiotech/realio-network/releases/tag/v0.8.1)
Fix chain pretty name to match entry in [slip-0173](https://github.com/satoshilabs/slips/blob/master/slip-0173.md)
Added info on SDK, tendermint and IBC versions