### PR TITLE
Change root folder for Nolus

### DIFF
--- a/nolus/chain.json
+++ b/nolus/chain.json
@@ -8,7 +8,7 @@
   "chain_id": "pirin-1",
   "bech32_prefix": "nolus",
   "daemon_name": "nolusd",
-  "node_home": "$HOME/.nolusd",
+  "node_home": "$HOME/.nolus",
   "key_algos": [
     "secp256k1"
   ],


### PR DESCRIPTION
Change from $HOME/.nolusd to $HOME/.nolus. 

When running `nolusd init` the directory created is $HOME/.nolus rather than $HOME/.nolusd