### PR TITLE
Fix breaking typo in Lava Testnet chain.json

### DIFF
--- a/testnets/lavatestnet/chain.json
+++ b/testnets/lavatestnet/chain.json
@@ -158,7 +158,7 @@
     "peers": {
       "seeds": [
         {
-          "id": "3a445bfdbe2dprod-pnet-seed-node.lavanet.xyz:266560c8ee82461633aa3af31bc2b4dc0",
+          "id": "3a445bfdbe2d0c8ee82461633aa3af31bc2b4dc0",
           "address": "prod-pnet-seed-node.lavanet.xyz:26656",
           "provider": "Lava"
         },


### PR DESCRIPTION
On line 161 of `chain.json` on peer seed id was incorrect. This could cause issues with anyone using the Lava testnet entry.