### PR TITLE
Upgrade Aura to v0.4.5

### DIFF
--- a/aura/chain.json
+++ b/aura/chain.json
@@ -26,9 +26,9 @@
   },
   "codebase": {
     "git_repo": "https://github.com/aura-nw/aura",
-    "recommended_version": "aura_v0.4.4",
+    "recommended_version": "aura_v0.4.5",
     "compatible_versions": [
-      "aura_v0.4.4"
+      "aura_v0.4.5"
     ],
     "genesis": {
       "genesis_url": "https://raw.githubusercontent.com/aura-nw/mainnet-artifacts/main/xstaxy-1/genesis.json"
@@ -40,6 +40,17 @@
         "compatible_versions": [
           "aura_v0.4.4"
         ]
+        "next_version_name": "v0.4.5
+      },
+      {
+        "name": "v0.4.5",
+        "proposal": 4,
+        "height": 1292226,
+        "recommended_version": "aura_v0.4.5",
+        "compatible_versions": [
+          "aura_v0.4.5"
+        ],
+        "next_version_name": ""
       }
     ]
   },

--- a/aura/chain.json
+++ b/aura/chain.json
@@ -40,7 +40,7 @@
         "compatible_versions": [
           "aura_v0.4.4"
         ]
-        "next_version_name": "v0.4.5
+        "next_version_name": "v0.4.5"
       },
       {
         "name": "v0.4.5",

--- a/aura/chain.json
+++ b/aura/chain.json
@@ -39,7 +39,7 @@
         "recommended_version": "aura_v0.4.4",
         "compatible_versions": [
           "aura_v0.4.4"
-        ]
+        ],
         "next_version_name": "v0.4.5"
       },
       {


### PR DESCRIPTION
est time: `2023 June 12th, 12pm UTC`