### PR TITLE
Fix Kyve to 1.2.2 for Barberry

### DIFF
--- a/kyve/chain.json
+++ b/kyve/chain.json
@@ -23,9 +23,9 @@
   },
   "codebase": {
     "git_repo": "https://github.com/KYVENetwork/chain",
-    "recommended_version": "v1.2.1",
+    "recommended_version": "v1.2.2",
     "compatible_versions": [
-      "v1.2.1"
+      "v1.2.1", "v1.2.2"
     ],
     "genesis": {
       "genesis_url": "https://raw.githubusercontent.com/KYVENetwork/networks/main/kyve-1/genesis.json"
@@ -53,9 +53,9 @@
         "name": "v1.2.0",
         "height": 1135000,
         "proposal": 4,
-        "recommended_version": "v1.2.1",
+        "recommended_version": "v1.2.2",
         "compatible_versions": [
-          "v1.2.1"
+          "v1.2.1", "1.2.2"
         ]
       }
     ]


### PR DESCRIPTION
Barberry patch https://github.com/KYVENetwork/chain/releases/tag/v1.2.2