### PR TITLE
Fix Evmos to v12.1.5 for Barberry

### DIFF
--- a/evmos/chain.json
+++ b/evmos/chain.json
@@ -36,19 +36,20 @@
   },
   "codebase": {
     "git_repo": "https://github.com/evmos/evmos",
-    "recommended_version": "v12.1.3",
+    "recommended_version": "v12.1.5",
     "compatible_versions": [
+      "v12.1.5",
       "v12.1.3",
       "v12.1.2",
       "v12.1.1",
       "v12.1.0"
     ],
     "binaries": {
-      "linux/amd64": "https://github.com/evmos/evmos/releases/download/v12.1.3/evmos_12.1.3_Linux_amd64.tar.gz",
-      "linux/arm64": "https://github.com/evmos/evmos/releases/download/v12.1.3/evmos_12.1.3_Darwin_arm64.tar.gz",
-      "darwin/amd64": "https://github.com/evmos/evmos/releases/download/v12.1.3/evmos_12.1.3_Darwin_amd64.tar.gz",
-      "darwin/arm64": "https://github.com/evmos/evmos/releases/download/v12.1.3/evmos_12.1.3_Darwin_arm64.tar.gz",
-      "windows/amd64": "https://github.com/evmos/evmos/releases/download/v12.1.3/evmos_12.1.3_Windows_amd64.zip"
+      "linux/amd64": "https://github.com/evmos/evmos/releases/download/v12.1.5/evmos_12.1.5_Linux_amd64.tar.gz",
+      "linux/arm64": "https://github.com/evmos/evmos/releases/download/v12.1.5/evmos_12.1.5_Linux_arm64.tar.gz",
+      "darwin/amd64": "https://github.com/evmos/evmos/releases/download/v12.1.5/evmos_12.1.5_Darwin_amd64.tar.gz",
+      "darwin/arm64": "https://github.com/evmos/evmos/releases/download/v12.1.5/evmos_12.1.5_Darwin_arm64.tar.gz",
+      "windows/amd64": "https://github.com/evmos/evmos/releases/download/v12.1.5/evmos_12.1.5_Windows_amd64.zip"
     },
     "cosmos_sdk_version": "0.46",
     "consensus": {
@@ -62,8 +63,9 @@
     "versions": [
       {
         "name": "v12",
-        "recommended_version": "v12.1.3",
+        "recommended_version": "v12.1.5",
         "compatible_versions": [
+          "v12.1.5",
           "v12.1.3",
           "v12.1.2",
           "v12.1.1",
@@ -76,11 +78,11 @@
         },
         "ibc_go_version": "6.1.0",
         "binaries": {
-          "linux/amd64": "https://github.com/evmos/evmos/releases/download/v12.1.3/evmos_12.1.3_Linux_amd64.tar.gz",
-          "linux/arm64": "https://github.com/evmos/evmos/releases/download/v12.1.3/evmos_12.1.3_Darwin_arm64.tar.gz",
-          "darwin/amd64": "https://github.com/evmos/evmos/releases/download/v12.1.3/evmos_12.1.3_Darwin_amd64.tar.gz",
-          "darwin/arm64": "https://github.com/evmos/evmos/releases/download/v12.1.3/evmos_12.1.3_Darwin_arm64.tar.gz",
-          "windows/amd64": "https://github.com/evmos/evmos/releases/download/v12.1.3/evmos_12.1.3_Windows_amd64.zip"
+          "linux/amd64": "https://github.com/evmos/evmos/releases/download/v12.1.5/evmos_12.1.5_Linux_amd64.tar.gz",
+          "linux/arm64": "https://github.com/evmos/evmos/releases/download/v12.1.5/evmos_12.1.5_Linux_arm64.tar.gz",
+          "darwin/amd64": "https://github.com/evmos/evmos/releases/download/v12.1.5/evmos_12.1.5_Darwin_amd64.tar.gz",
+          "darwin/arm64": "https://github.com/evmos/evmos/releases/download/v12.1.5/evmos_12.1.5_Darwin_arm64.tar.gz",
+          "windows/amd64": "https://github.com/evmos/evmos/releases/download/v12.1.5/evmos_12.1.5_Windows_amd64.zip"
         }
       }
     ]


### PR DESCRIPTION
Barberry https://github.com/evmos/evmos/releases/tag/v12.1.5