### PR TITLE
Fix Injective to v1.11.3-1686246472 for Barberry

### DIFF
--- a/injective/chain.json
+++ b/injective/chain.json
@@ -33,13 +33,13 @@
   },
   "codebase": {
     "git_repo": "https://github.com/InjectiveLabs/injective-chain-releases",
-    "recommended_version": "v1.11",
+    "recommended_version": "v1.11.3-1686246472",
     "compatible_versions": [
-      "v1.11"
+      "v1.11", "v1.11.3-1686246472"
     ],
     "binaries": {
-      "linux/amd64": "https://github.com/InjectiveLabs/injective-chain-releases/releases/download/v1.11.1-1685698280/linux-amd64.zip",
-      "darwin/amd64": "https://github.com/InjectiveLabs/injective-chain-releases/releases/download/v1.11.1-1685698280/darwin-amd64.zip"
+      "linux/amd64": "https://github.com/InjectiveLabs/injective-chain-releases/releases/download/v1.11.3-1686246472/linux-amd64.zip",
+      "darwin/amd64": "https://github.com/InjectiveLabs/injective-chain-releases/releases/download/v1.11.3-1686246472/darwin-amd64.zip"
     },
     "genesis": {
       "genesis_url": "https://raw.githubusercontent.com/InjectiveLabs/mainnet-config/master/10001/genesis.json"
@@ -61,13 +61,13 @@
         "name": "v1.11",
         "proposal": 231,
         "height": 34775000,
-        "recommended_version": "v1.11",
+        "recommended_version": "v1.11.3-1686246472",
         "compatible_versions": [
-          "v1.11"
+          "v1.11", "v1.11.3-1686246472"
         ],
         "binaries": {
-          "linux/amd64": "https://github.com/InjectiveLabs/injective-chain-releases/releases/download/v1.11.1-1685698280/linux-amd64.zip",
-          "darwin/amd64": "https://github.com/InjectiveLabs/injective-chain-releases/releases/download/v1.11.1-1685698280/darwin-amd64.zip"
+          "linux/amd64": "https://github.com/InjectiveLabs/injective-chain-releases/releases/download/v1.11.3-1686246472/linux-amd64.zip",
+          "darwin/amd64": "https://github.com/InjectiveLabs/injective-chain-releases/releases/download/v1.11.3-1686246472/darwin-amd64.zip"
         }
       }
     ]


### PR DESCRIPTION
Barberry https://github.com/InjectiveLabs/injective-chain-releases/releases/tag/v1.11.3-1686246472