### PR TITLE
Fix Mars to v1.0.2 for Barberry

### DIFF
--- a/mars/chain.json
+++ b/mars/chain.json
@@ -36,9 +36,9 @@
   },
   "codebase": {
     "git_repo": "https://github.com/mars-protocol/hub",
-    "recommended_version": "v1.0.0",
+    "recommended_version": "v1.0.2",
     "compatible_versions": [
-      "v1.0.0"
+      "v1.0.0", "v1.0.2"
     ],
     "cosmos_sdk_version": "0.46.7",
     "consensus": {
@@ -59,9 +59,9 @@
         "name": "v1",
         "tag": "v1.0.0",
         "height": 0,
-        "recommended_version": "v1.0.0",
+        "recommended_version": "v1.0.2",
         "compatible_versions": [
-          "v1.0.0"
+          "v1.0.0", "v1.0.2"
         ],
         "cosmos_sdk_version": "0.46.7",
         "consensus": {


### PR DESCRIPTION
Barberry https://github.com/mars-protocol/hub/releases/tag/v1.0.2