### PR TITLE
Fix Gitopia to 2.1.1 for Barberry

### DIFF
--- a/gitopia/chain.json
+++ b/gitopia/chain.json
@@ -39,15 +39,15 @@
     "genesis": {
       "genesis_url": "https://github.com/gitopia/mainnet/raw/master/genesis.tar.gz"
     },
-    "recommended_version": "v2.0.0",
+    "recommended_version": "v2.1.1",
     "compatible_versions": [
-      "v2.0.0"
+      "v2.0.0", "v2.1.1"
     ],
     "binaries": {
-      "linux/amd64": "https://github.com/gitopia/gitopia/releases/download/v2.0.0/gitopiad_2.0.0_linux_amd64.tar.gz",
-      "linux/arm64": "https://github.com/gitopia/gitopia/releases/download/v2.0.0/gitopiad_2.0.0_linux_arm64.tar.gz",
-      "darwin/amd64": "https://github.com/gitopia/gitopia/releases/download/v2.0.0/gitopiad_2.0.0_darwin_amd64.tar.gz",
-      "darwin/arm64": "https://github.com/gitopia/gitopia/releases/download/v2.0.0/gitopiad_2.0.0_darwin_arm64.tar.gz"
+      "linux/amd64": "https://server.gitopia.com/releases/Gitopia/gitopia/v2.1.1/gitopiad_2.1.1_linux_amd64.tar.gz",
+      "linux/arm64": "https://server.gitopia.com/releases/Gitopia/gitopia/v2.1.1/gitopiad_2.1.1_linux_arm64.tar.gz",
+      "darwin/amd64": "https://server.gitopia.com/releases/Gitopia/gitopia/v2.1.1/gitopiad_2.1.1_darwin_amd64.tar.gz",
+      "darwin/arm64": "https://server.gitopia.com/releases/Gitopia/gitopia/v2.1.1/gitopiad_2.1.1_darwin_arm64.tar.gz"
     },
     "cosmos_sdk_version": "0.46",
     "consensus": {
@@ -61,15 +61,15 @@
     "versions": [
       {
         "name": "v2.0",
-        "recommended_version": "v2.0.0",
+        "recommended_version": "v2.1.1",
         "compatible_versions": [
-          "v2.0.0"
+          "v2.0.0", "v2.1.1"
         ],
         "binaries": {
-          "linux/amd64": "https://github.com/gitopia/gitopia/releases/download/v2.0.0/gitopiad_2.0.0_linux_amd64.tar.gz",
-          "linux/arm64": "https://github.com/gitopia/gitopia/releases/download/v2.0.0/gitopiad_2.0.0_linux_arm64.tar.gz",
-          "darwin/amd64": "https://github.com/gitopia/gitopia/releases/download/v2.0.0/gitopiad_2.0.0_darwin_amd64.tar.gz",
-          "darwin/arm64": "https://github.com/gitopia/gitopia/releases/download/v2.0.0/gitopiad_2.0.0_darwin_arm64.tar.gz"
+         "linux/amd64": "https://server.gitopia.com/releases/Gitopia/gitopia/v2.1.1/gitopiad_2.1.1_linux_amd64.tar.gz",
+         "linux/arm64": "https://server.gitopia.com/releases/Gitopia/gitopia/v2.1.1/gitopiad_2.1.1_linux_arm64.tar.gz",
+         "darwin/amd64": "https://server.gitopia.com/releases/Gitopia/gitopia/v2.1.1/gitopiad_2.1.1_darwin_amd64.tar.gz",
+         "darwin/arm64": "https://server.gitopia.com/releases/Gitopia/gitopia/v2.1.1/gitopiad_2.1.1_darwin_arm64.tar.gz"
         },
         "cosmos_sdk_version": "0.46",
         "consensus": {


### PR DESCRIPTION
Barberry https://gitopia.com/Gitopia/gitopia/releases/tag/v2.1.1