### PR TITLE
Fix cheqd to 1.4.4 for Barberry

### DIFF
--- a/cheqd/chain.json
+++ b/cheqd/chain.json
@@ -30,17 +30,18 @@
   },
   "codebase": {
     "git_repo": "https://github.com/cheqd/cheqd-node",
-    "recommended_version": "v1.4.0",
+    "recommended_version": "v1.4.4",
     "compatible_versions": [
       "v1.2.5",
       "v1.3.0",
-      "v1.4.0"
+      "v1.4.0",
+      "v1.4.4"
     ],
     "binaries": {
-      "linux/amd64": "https://github.com/cheqd/cheqd-node/releases/download/v1.4.0/cheqd-noded-1.4.0-linux-amd64.tar.gz",
-      "linux/arm64": "https://github.com/cheqd/cheqd-node/releases/download/v1.4.0/cheqd-noded-1.4.0-linux-arm64.tar.gz",
-      "darwin/amd64": "https://github.com/cheqd/cheqd-node/releases/download/v1.4.0/cheqd-noded-1.4.0-darwin-amd64.tar.gz",
-      "darwin/arm64": "https://github.com/cheqd/cheqd-node/releases/download/v1.4.0/cheqd-noded-1.4.0-darwin-arm64.tar.gz"
+      "linux/amd64": "https://github.com/cheqd/cheqd-node/releases/download/v1.4.4/cheqd-noded-1.4.4-linux-amd64.tar.gz",
+      "linux/arm64": "https://github.com/cheqd/cheqd-node/releases/download/v1.4.4/cheqd-noded-1.4.4-linux-arm64.tar.gz",
+      "darwin/amd64": "https://github.com/cheqd/cheqd-node/releases/download/v1.4.4/cheqd-noded-1.4.4-darwin-amd64.tar.gz",
+      "darwin/arm64": "https://github.com/cheqd/cheqd-node/releases/download/v1.4.4/cheqd-noded-1.4.4-darwin-arm64.tar.gz"
     },
     "cosmos_sdk_version": "0.46.10",
     "consensus": {
@@ -52,12 +53,13 @@
     },
     "versions": [
       {
-        "name": "v1.4.0",
-        "recommended_version": "v1.4.0",
+        "name": "v1",
+        "recommended_version": "v1.4.4",
         "compatible_versions": [
           "v1.2.5",
           "v1.3.0",
-          "v1.4.0"
+          "v1.4.0",
+          "v1.4.4"
         ],
         "cosmos_sdk_version": "0.46.10",
         "consensus": {


### PR DESCRIPTION
Barberry https://github.com/cheqd/cheqd-node/releases/tag/v1.4.4

In addition I changed the version name for this series to "v1" to match the upgrade name and folder name for Cosmovisor.