### PR TITLE
Upgrade Desmos to v5.1.0

### DIFF
--- a/desmos/chain.json
+++ b/desmos/chain.json
@@ -33,15 +33,12 @@
   },
   "codebase": {
     "git_repo": "https://github.com/desmos-labs/desmos",
-    "recommended_version": "v4.8.0",
+    "recommended_version": "v5.1.0",
     "compatible_versions": [
-      "v4.8.0", "v4.8.1"
+      "5.1.0"
     ],
     "binaries": {
-      "linux/amd64": "https://github.com/desmos-labs/desmos/releases/download/v4.8.0/desmos-4.8.0-linux-amd64",
-      "linux/arm64": "https://github.com/desmos-labs/desmos/releases/download/v4.8.0/desmos-4.8.0-linux-arm64",
-      "darwin/amd64": "https://github.com/desmos-labs/desmos/releases/download/v4.8.0/desmos-4.8.0-darwin-amd64",
-      "windows/amd64": "https://github.com/desmos-labs/desmos/releases/download/v4.8.0/desmos-4.8.0-windows-amd64.exe"
+      "linux/amd64": "https://github.com/desmos-labs/desmos/releases/download/v5.1.0/desmos-5.1.0-linux-amd64"
     },
     "genesis": {
       "genesis_url": "https://raw.githubusercontent.com/desmos-labs/mainnet/main/genesis.json"
@@ -49,15 +46,25 @@
     "versions": [
       {
         "name": "v4.8.0",
-        "recommended_version": "v4.8.0",
+        "recommended_version": "v4.8.1",
         "compatible_versions": [
           "v4.8.0", "v4.8.1"
         ],
         "binaries": {
-          "linux/amd64": "https://github.com/desmos-labs/desmos/releases/download/v4.8.0/desmos-4.8.0-linux-amd64",
-          "linux/arm64": "https://github.com/desmos-labs/desmos/releases/download/v4.8.0/desmos-4.8.0-linux-arm64",
-          "darwin/amd64": "https://github.com/desmos-labs/desmos/releases/download/v4.8.0/desmos-4.8.0-darwin-amd64",
-          "windows/amd64": "https://github.com/desmos-labs/desmos/releases/download/v4.8.0/desmos-4.8.0-windows-amd64.exe"
+          "linux/amd64": "https://github.com/desmos-labs/desmos/releases/download/v4.8.1/desmos-4.8.1-linux-amd64"
+        },
+        "next_version_name": "v5.0.0"
+      },
+      {
+        "name": "v5.0.0",
+        "recommended_version": "v5.1.0",
+        "compatible_versions": [
+          "v5.1.0"
+        ],
+        "proposal": 28,
+        "height": 9069645,
+        "binaries": {
+          "linux/amd64": "https://github.com/desmos-labs/desmos/releases/download/v5.1.0/desmos-5.1.0-linux-amd64"
         }
       }
     ]


### PR DESCRIPTION
Pending passing of Prop 28, chain will upgrade to v5.0.0 (using version v5.1.0) at height 9069645. https://www.mintscan.io/desmos/proposals/28

Also fixed recommended version for 4.8.0 to 4.8.1 and changed binaries to reflect this (only linux/amd64 available for pre-built for recommended version).