### PR TITLE
fix: update Crescent chain.json for latest version

### DIFF
--- a/crescent/chain.json
+++ b/crescent/chain.json
@@ -46,6 +46,8 @@
     "versions": [
       {
         "name": "v4.2.0",
+        "tag": "v4.2.0",
+        "height": 6915000,
         "recommended_version": "v4.2.0",
         "compatible_versions": [
           "v4.2.0"
@@ -54,6 +56,67 @@
           "linux/amd64": "https://github.com/crescent-network/crescent/releases/download/v4.2.0/crescentd-v4.2.0-linux-amd64",
           "darwin/arm64": "https://github.com/crescent-network/crescent/releases/download/v4.2.0/crescentd-v4.2.0-darwin-arm64"
         }
+      },
+      {
+        "name": "v4.1.1",
+        "tag": "v4.1.1",
+        "height": 6500000,
+        "recommended_version": "v4.1.1",
+        "compatible_versions": [
+          "v4.1.1",
+          "v4.1.0"
+        ]
+      },
+      {
+        "name": "v4",
+        "tag": "v4.0.0",
+        "height": 4415902,
+        "proposal": 35,
+        "recommended_version": "v4.0.0",
+        "compatible_versions": [
+          "v4.0.0"
+        ]
+      },
+      {
+        "name": "v3",
+        "tag": "v3.0.0",
+        "height": 3932000,
+        "proposal": 29,
+        "recommended_version": "v3.0.0",
+        "compatible_versions": [
+          "v3.0.0"
+        ]
+      },
+      {
+        "name": "v2.0.0",
+        "tag": "v2.3.0",
+        "height": 1384100,
+        "proposal": 12,
+        "recommended_version": "v2.3.0",
+        "compatible_versions": [
+          "v2.3.0",
+          "v2.2.0",
+          "v2.1.1",
+          "v2.1.0"
+        ]
+      },
+      {
+        "name": "v1.1.0",
+        "tag": "v1.1.0",
+        "height": 48000,
+        "recommended_version": "1.1.0",
+        "compatible_versions": [
+          "v1.1.0"
+        ]
+      },
+      {
+        "name": "v1.0.0",
+        "tag": "v1.0.0",
+        "height": 0,
+        "recommended_version": "v1.0.0",
+        "compatible_versions": [
+          "v1.0.0"
+        ]
       }
     ]
   },

--- a/crescent/chain.json
+++ b/crescent/chain.json
@@ -32,27 +32,27 @@
   },
   "codebase": {
     "git_repo": "https://github.com/crescent-network/crescent",
-    "recommended_version": "v4.0.0",
+    "recommended_version": "v4.2.0",
     "compatible_versions": [
-      "v4.0.0"
+      "v4.2.0"
     ],
     "binaries": {
-      "linux/amd64": "https://github.com/crescent-network/crescent/releases/download/v2.1.0/crescentd-v2.1.0-linux-amd64",
-      "darwin/amd64": "https://github.com/crescent-network/crescent/releases/download/v2.1.0/crescentd-v2.1.0-darwin-amd64"
+      "linux/amd64": "https://github.com/crescent-network/crescent/releases/download/v4.2.0/crescentd-v4.2.0-linux-amd64",
+      "darwin/arm64": "https://github.com/crescent-network/crescent/releases/download/v4.2.0/crescentd-v4.2.0-darwin-arm64"
     },
     "genesis": {
       "genesis_url": "https://github.com/crescent-network/launch/raw/main/mainnet/crescent-1/genesis.json.tar.gz"
     },
     "versions": [
       {
-        "name": "v4.0.0",
-        "recommended_version": "v4.0.0",
+        "name": "v4.2.0",
+        "recommended_version": "v4.2.0",
         "compatible_versions": [
-          "v4.0.0"
+          "v4.2.0"
         ],
         "binaries": {
-          "linux/amd64": "https://github.com/crescent-network/crescent/releases/download/v2.1.0/crescentd-v2.1.0-linux-amd64",
-          "darwin/amd64": "https://github.com/crescent-network/crescent/releases/download/v2.1.0/crescentd-v2.1.0-darwin-amd64"
+          "linux/amd64": "https://github.com/crescent-network/crescent/releases/download/v4.2.0/crescentd-v4.2.0-linux-amd64",
+          "darwin/arm64": "https://github.com/crescent-network/crescent/releases/download/v4.2.0/crescentd-v4.2.0-darwin-arm64"
         }
       }
     ]

--- a/crescent/chain.json
+++ b/crescent/chain.json
@@ -45,36 +45,34 @@
     },
     "versions": [
       {
-        "name": "v4.2.0",
-        "tag": "v4.2.0",
-        "height": 6915000,
-        "recommended_version": "v4.2.0",
+        "name": "v1",
+        "tag": "v1.0.0",
+        "height": 0,
+        "recommended_version": "v1.0.0",
         "compatible_versions": [
-          "v4.2.0"
-        ],
-        "binaries": {
-          "linux/amd64": "https://github.com/crescent-network/crescent/releases/download/v4.2.0/crescentd-v4.2.0-linux-amd64",
-          "darwin/arm64": "https://github.com/crescent-network/crescent/releases/download/v4.2.0/crescentd-v4.2.0-darwin-arm64"
-        }
-      },
-      {
-        "name": "v4.1.1",
-        "tag": "v4.1.1",
-        "height": 6500000,
-        "recommended_version": "v4.1.1",
-        "compatible_versions": [
-          "v4.1.1",
-          "v4.1.0"
+          "v1.0.0"
         ]
       },
       {
-        "name": "v4",
-        "tag": "v4.0.0",
-        "height": 4415902,
-        "proposal": 35,
-        "recommended_version": "v4.0.0",
+        "name": "v1.1",
+        "tag": "v1.1.0",
+        "height": 48000,
+        "recommended_version": "1.1.0",
         "compatible_versions": [
-          "v4.0.0"
+          "v1.1.0"
+        ]
+      },
+      {
+        "name": "v2",
+        "tag": "v2.3.0",
+        "height": 1384100,
+        "proposal": 12,
+        "recommended_version": "v2.3.0",
+        "compatible_versions": [
+          "v2.3.0",
+          "v2.2.0",
+          "v2.1.1",
+          "v2.1.0"
         ]
       },
       {
@@ -88,35 +86,39 @@
         ]
       },
       {
-        "name": "v2.0.0",
-        "tag": "v2.3.0",
-        "height": 1384100,
-        "proposal": 12,
-        "recommended_version": "v2.3.0",
+        "name": "v4",
+        "tag": "v4.0.0",
+        "height": 4415902,
+        "proposal": 35,
+        "recommended_version": "v4.0.0",
         "compatible_versions": [
-          "v2.3.0",
-          "v2.2.0",
-          "v2.1.1",
-          "v2.1.0"
-        ]
+          "v4.0.0"
+        ],
+        "next_version_name": "v4.1"
       },
       {
-        "name": "v1.1.0",
-        "tag": "v1.1.0",
-        "height": 48000,
-        "recommended_version": "1.1.0",
+        "name": "v4.1",
+        "tag": "v4.1.1",
+        "height": 6500000,
+        "recommended_version": "v4.1.1",
         "compatible_versions": [
-          "v1.1.0"
-        ]
+          "v4.1.1",
+          "v4.1.0"
+        ],
+        "next_version_name": "v4.2"
       },
       {
-        "name": "v1.0.0",
-        "tag": "v1.0.0",
-        "height": 0,
-        "recommended_version": "v1.0.0",
+        "name": "v4.2",
+        "tag": "v4.2.0",
+        "height": 6915000,
+        "recommended_version": "v4.2.0",
         "compatible_versions": [
-          "v1.0.0"
-        ]
+          "v4.2.0"
+        ],
+        "binaries": {
+          "linux/amd64": "https://github.com/crescent-network/crescent/releases/download/v4.2.0/crescentd-v4.2.0-linux-amd64",
+          "darwin/arm64": "https://github.com/crescent-network/crescent/releases/download/v4.2.0/crescentd-v4.2.0-darwin-arm64"
+        }
       }
     ]
   },


### PR DESCRIPTION
update the latest Crescent binary version to [v4.2.0](https://github.com/crescent-network/crescent/releases/tag/v4.2.0)