### PR TITLE
Upgrade cosmoshubtestnet to v10.0.1

### DIFF
--- a/testnets/cosmoshubtestnet/chain.json
+++ b/testnets/cosmoshubtestnet/chain.json
@@ -29,33 +29,33 @@
   },
   "codebase": {
     "git_repo": "https://github.com/cosmos/gaia",
-    "recommended_version": "v9.0.1",
+    "recommended_version": "v10.0.1",
     "compatible_versions": [
-      "v9.0.1"
+      "v10.0.1"
     ],
     "binaries": {
-      "linux/amd64": "https://github.com/cosmos/gaia/releases/download/v9.0.1/gaiad-v9.0.1-linux-amd64",
-      "linux/arm64": "https://github.com/cosmos/gaia/releases/download/v9.0.1/gaiad-v9.0.1-linux-arm64",
-      "darwin/amd64": "https://github.com/cosmos/gaia/releases/download/v9.0.1/gaiad-v9.0.1-darwin-amd64",
-      "darwin/arm64": "https://github.com/cosmos/gaia/releases/download/v9.0.1/gaiad-v9.0.1-darwin-arm64",
-      "windows/amd64": "https://github.com/cosmos/gaia/releases/download/v9.0.1/gaiad-v9.0.1-windows-amd64.exe"
+      "linux/amd64": "https://github.com/cosmos/gaia/releases/download/v10.0.1/gaiad-v10.0.1-linux-amd64",
+      "linux/arm64": "https://github.com/cosmos/gaia/releases/download/v10.0.1/gaiad-v10.0.1-linux-arm64",
+      "darwin/amd64": "https://github.com/cosmos/gaia/releases/download/v10.0.1/gaiad-v10.0.1-darwin-amd64",
+      "darwin/arm64": "https://github.com/cosmos/gaia/releases/download/v10.0.1/gaiad-v10.0.1-darwin-arm64",
+      "windows/amd64": "https://github.com/cosmos/gaia/releases/download/v10.0.1/gaiad-v10.0.1-windows-amd64.exe"
     },
     "genesis": {
       "genesis_url": "https://github.com/cosmos/testnets/raw/master/public/genesis.json.gz"
     },
     "versions": [
       {
-        "name": "v9.0.1",
-        "recommended_version": "v9.0.1",
+        "name": "v10.0.1",
+        "recommended_version": "v10.0.1",
         "compatible_versions": [
-          "v9.0.1"
+          "v10.0.1"
         ],
         "binaries": {
-          "linux/amd64": "https://github.com/cosmos/gaia/releases/download/v9.0.1/gaiad-v9.0.1-linux-amd64",
-          "linux/arm64": "https://github.com/cosmos/gaia/releases/download/v9.0.1/gaiad-v9.0.1-linux-arm64",
-          "darwin/amd64": "https://github.com/cosmos/gaia/releases/download/v9.0.1/gaiad-v9.0.1-darwin-amd64",
-          "darwin/arm64": "https://github.com/cosmos/gaia/releases/download/v9.0.1/gaiad-v9.0.1-darwin-arm64",
-          "windows/amd64": "https://github.com/cosmos/gaia/releases/download/v9.0.1/gaiad-v9.0.1-windows-amd64.exe"
+          "linux/amd64": "https://github.com/cosmos/gaia/releases/download/v10.0.1/gaiad-v10.0.1-linux-amd64",
+          "linux/arm64": "https://github.com/cosmos/gaia/releases/download/v10.0.1/gaiad-v10.0.1-linux-arm64",
+          "darwin/amd64": "https://github.com/cosmos/gaia/releases/download/v10.0.1/gaiad-v10.0.1-darwin-amd64",
+          "darwin/arm64": "https://github.com/cosmos/gaia/releases/download/v10.0.1/gaiad-v10.0.1-darwin-arm64",
+          "windows/amd64": "https://github.com/cosmos/gaia/releases/download/v10.0.1/gaiad-v10.0.1-windows-amd64.exe"
         }
       }
     ]

--- a/testnets/cosmoshubtestnet/chain.json
+++ b/testnets/cosmoshubtestnet/chain.json
@@ -45,6 +45,20 @@
     },
     "versions": [
       {
+        "name": "v9.0.1",
+        "recommended_version": "v9.0.1",
+        "compatible_versions": [
+          "v9.0.1"
+        ],
+        "binaries": {
+          "linux/amd64": "https://github.com/cosmos/gaia/releases/download/v9.0.1/gaiad-v9.0.1-linux-amd64",
+          "linux/arm64": "https://github.com/cosmos/gaia/releases/download/v9.0.1/gaiad-v9.0.1-linux-arm64",
+          "darwin/amd64": "https://github.com/cosmos/gaia/releases/download/v9.0.1/gaiad-v9.0.1-darwin-amd64",
+          "darwin/arm64": "https://github.com/cosmos/gaia/releases/download/v9.0.1/gaiad-v9.0.1-darwin-arm64",
+          "windows/amd64": "https://github.com/cosmos/gaia/releases/download/v9.0.1/gaiad-v9.0.1-windows-amd64.exe"
+        }
+      },
+      {
         "name": "v10.0.1",
         "recommended_version": "v10.0.1",
         "compatible_versions": [


### PR DESCRIPTION
Hi! We have upgraded the Cosmos Hub Public Testnet to Gaia `v10.0.1`:
https://github.com/cosmos/testnets/tree/master/public

Thanks!