### PR TITLE
Upgrade Lum Network to v1.4.5

### DIFF
--- a/lumnetwork/chain.json
+++ b/lumnetwork/chain.json
@@ -33,10 +33,9 @@
   },
   "codebase": {
     "git_repo": "https://github.com/lum-network/chain",
-    "recommended_version": "v1.4.2",
+    "recommended_version": "v1.4.5",
     "compatible_versions": [
-      "v1.4.1",
-      "v1.4.2"
+      "v1.4.5"
     ],
     "genesis": {
       "genesis_url": "https://raw.githubusercontent.com/lum-network/mainnet/master/genesis.json"
@@ -57,7 +56,8 @@
         "recommended_version": "v1.4.0",
         "compatible_versions": [
           "v1.4.0"
-        ]
+        ],
+        "next_version_name": "v1.4.1"
       },
       {
         "name": "v1.4.1",
@@ -67,7 +67,19 @@
         "compatible_versions": [
           "v1.4.1",
           "v1.4.2"
-        ]
+        ],
+        "next_version_name": "v1.4.5"
+      },
+      {
+        "name": "v1.4.5",
+        "height": 7950600,
+        "proposal": 71,
+        "recommended_version": "v1.4.2",
+        "compatible_versions": [
+          "v1.4.1",
+          "v1.4.2"
+        ],
+        "next_version_name": "v1.4.5"
       }
     ]
   },

--- a/lumnetwork/chain.json
+++ b/lumnetwork/chain.json
@@ -77,8 +77,7 @@
         "recommended_version": "v1.4.5",
         "compatible_versions": [
           "v1.4.5"
-        ],
-        "next_version_name": "v1.4.5"
+        ]
       }
     ]
   },

--- a/lumnetwork/chain.json
+++ b/lumnetwork/chain.json
@@ -74,10 +74,9 @@
         "name": "v1.4.5",
         "height": 7950600,
         "proposal": 71,
-        "recommended_version": "v1.4.2",
+        "recommended_version": "v1.4.5",
         "compatible_versions": [
-          "v1.4.1",
-          "v1.4.2"
+          "v1.4.5"
         ],
         "next_version_name": "v1.4.5"
       }


### PR DESCRIPTION
Pending Prop 71 the network will upgrade to v1.4.5 at height 7,950,600 estimated to be on June 15th.

https://www.mintscan.io/lum/proposals/71
https://www.mintscan.io/lum/blocks/7950600
