### PR TITLE
fix: :bug: fix bug in JSON schema

### DIFF
--- a/chain.schema.json
+++ b/chain.schema.json
@@ -408,8 +408,7 @@
           }
         },
         "additionalProperties": false
-      },
-      "minItems": 1
+      }
     },
     "logo_URIs": {
       "type": "object",


### PR DESCRIPTION
Removing the `minItems` attribute from the `properties.images` field for fixing a bug in JSON schema.

Closes cosmos/chain-registry#2352.