### PR TITLE
Upgrade Comdex to v11.5.0

### DIFF
--- a/comdex/chain.json
+++ b/comdex/chain.json
@@ -28,9 +28,9 @@
   },
   "codebase": {
     "git_repo": "https://github.com/comdex-official/comdex",
-    "recommended_version": "v10.0.0",
+    "recommended_version": "v11.5.0",
     "compatible_versions": [
-      "v10.0.0"
+      "v11.5.0"
     ],
     "cosmwasm_enabled": true,
     "genesis": {
@@ -52,7 +52,19 @@
         "compatible_versions": [
           "v10.0.0"
         ],
-        "cosmwasm_enabled": true
+        "cosmwasm_enabled": true,
+        "next_version_name": "v11.5.0"
+      }
+      ,
+      {
+        "name": "v11.5.0",
+        "height": 8184000,
+        "proposal": 154, 
+        "recommended_version": "v11.5.0",
+        "compatible_versions": [
+          "v11.5.0"
+        ],
+        "cosmwasm_enabled": true,
       }
     ]
   },

--- a/comdex/chain.json
+++ b/comdex/chain.json
@@ -64,7 +64,7 @@
         "compatible_versions": [
           "v11.5.0"
         ],
-        "cosmwasm_enabled": true,
+        "cosmwasm_enabled": true
       }
     ]
   },


### PR DESCRIPTION
Upgrade Comdex to v11.5.0 per Prop 154 at height 8184000. https://www.mintscan.io/comdex/proposals/154

Worth noting v11.4.0 and v11.5.0 were pushed with the same commit, so building with v11.5.0 might result in still installing v11.4.0. Fix here: https://github.com/comdex-official/networks/blob/main/mainnet/15_v11.5.0_Mainet_Upgrade.md#note-if-comdex-version-shows-v1140