### PR TITLE
Update Kujira Versions

### DIFF
--- a/kujira/chain.json
+++ b/kujira/chain.json
@@ -33,19 +33,19 @@
   },
   "codebase": {
     "git_repo": "https://github.com/Team-Kujira/core",
-    "recommended_version": "v0.8.4-mainnet",
+    "recommended_version": "v0.8.7",
     "compatible_versions": [
-      "v0.8.4-mainnet"
+      "v0.8.7"
     ],
     "genesis": {
       "genesis_url": "https://github.com/Team-Kujira/networks/raw/master/mainnet/kaiyo-1.json"
     },
     "versions": [
       {
-        "name": "v0.8.4-mainnet",
-        "recommended_version": "v0.8.4-mainnet",
+        "name": "v0.8.4",
+        "recommended_version": "v0.8.7",
         "compatible_versions": [
-          "v0.8.4-mainnet"
+          "v0.8.7"
         ]
       }
     ]


### PR DESCRIPTION
- Cosmovisor folder `name` is `v0.8.4`. It was never `v0.8.4-mainnet`, that was just a hotfix release version.
- `v0.8.7` is the current and only compatible version.