### PR TITLE
Upgrade Composable to v3.1.2

### DIFF
--- a/composable/chain.json
+++ b/composable/chain.json
@@ -33,13 +33,14 @@
   },
   "codebase": {
     "git_repo": "https://github.com/notional-labs/composable-centauri",
-    "recommended_version": "v3.1.1",
+    "recommended_version": "v3.1.2",
     "compatible_versions": [
       "v3.1.0",
-      "v3.1.1"
+      "v3.1.1",
+      "v3.1.2"
     ],
     "binaries": {
-      "linux/amd64": "https://github.com/notional-labs/composable-centauri/releases/download/v3.1.1/centaurid"
+      "linux/amd64": "https://github.com/notional-labs/composable-centauri/releases/download/v3.1.2/centaurid"
     },
     "genesis": {
       "genesis_url": "https://raw.githubusercontent.com/notional-labs/composable-networks/main/mainnet/genesis.json"
@@ -67,10 +68,11 @@
       {
         "name": "centauri",
         "tag": "v3.1.0",
-        "recommended_version": "v3.1.1",
+        "recommended_version": "v3.1.2",
         "compatible_versions": [
           "v3.1.0",
-          "v3.1.1"
+          "v3.1.1",
+          "v3.1.2"
         ],
         "cosmos_sdk_version": "v0.47.3",
         "ibc_go_version": "v7.0.0",
@@ -81,7 +83,7 @@
         "height": 188500,
         "proposal": 3,
         "binaries": {
-          "linux/amd64": "https://github.com/notional-labs/composable-centauri/releases/download/v3.1.1/centaurid"
+          "linux/amd64": "https://github.com/notional-labs/composable-centauri/releases/download/v3.1.2/centaurid"
         }
       }
     ]


### PR DESCRIPTION
Upgrade Composable to v3.1.2. Non-consensus patch. 

https://github.com/notional-labs/composable-centauri/releases/tag/v3.1.2