### PR TITLE
Remove Coinbase Cloud validators

### DIFF
--- a/cryptoorgchain/chain.json
+++ b/cryptoorgchain/chain.json
@@ -84,36 +84,6 @@
         "provider": "crypto-org"
       },
       {
-        "id": "8dc1863d1d23cf9ad7cbea215c19bcbe8bf39702",
-        "address": "p2p.baaa7e56-cc71-4ae4-b4b3-c6a9d4a9596a.cryptodotorg.bison.run:26656",
-        "provider": "bison-trails"
-      },
-      {
-        "id": "8a7922f3fb3fb4cfe8cb57281b9d159ca7fd29c6",
-        "address": "p2p.aef59b2a-d77e-4922-817a-d1eea614aef4.cryptodotorg.bison.run:26656",
-        "provider": "bison-trails"
-      },
-      {
-        "id": "494d860a2869b90c458b07d4da890539272785c9",
-        "address": "p2p.fabc23d9-e0a1-4ced-8cd7-eb3efd6d9ef3.cryptodotorg.bison.run:26656",
-        "provider": "bison-trails"
-      },
-      {
-        "id": "dc2540dabadb8302da988c95a3c872191061aed2",
-        "address": "p2p.7d1b53c0-b86b-44c8-8c02-e3b0e88a4bf7.cryptodotorg.herd.run:26656",
-        "provider": "bison-trails"
-      },
-      {
-        "id": "33b15c14f54f71a4a923ac264761eb3209784cf2",
-        "address": "p2p.0d20d4b3-6890-4f00-b9f3-596ad3df6533.cryptodotorg.herd.run:26656",
-        "provider": "bison-trails"
-      },
-      {
-        "id": "d2862ef8f86f9976daa0c6f59455b2b1452dc53b",
-        "address": "p2p.a088961f-5dfd-4007-a15c-3a706d4be2c0.cryptodotorg.herd.run:26656",
-        "provider": "bison-trails"
-      },
-      {
         "id": "e1b058e5cfa2b836ddaa496b10911da62dcf182e",
         "address": "crypto-org-seed-1.allnodes.me:26656",
         "provider": "Allnodes.com ⚡️ Nodes & Staking"
@@ -145,21 +115,6 @@
         "address": "seed-2.crypto.org:26656",
         "provider": "crypto-org"
       },
-      {
-        "id": "8dc1863d1d23cf9ad7cbea215c19bcbe8bf39702",
-        "address": "p2p.baaa7e56-cc71-4ae4-b4b3-c6a9d4a9596a.cryptodotorg.bison.run:26656",
-        "provider": "bison-trails"
-      },
-      {
-        "id": "8a7922f3fb3fb4cfe8cb57281b9d159ca7fd29c6",
-        "address": "p2p.aef59b2a-d77e-4922-817a-d1eea614aef4.cryptodotorg.bison.run:26656",
-        "provider": "bison-trails"
-      },
-      {
-        "id": "d2862ef8f86f9976daa0c6f59455b2b1452dc53b",
-        "address": "p2p.a088961f-5dfd-4007-a15c-3a706d4be2c0.cryptodotorg.herd.run:26656",
-        "provider": "bison-trails"
-      }
     ]
   },
   "apis": {

--- a/cryptoorgchain/chain.json
+++ b/cryptoorgchain/chain.json
@@ -114,7 +114,7 @@
         "id": "2c55809558a4e491e9995962e10c026eb9014655",
         "address": "seed-2.crypto.org:26656",
         "provider": "crypto-org"
-      },
+      }
     ]
   },
   "apis": {


### PR DESCRIPTION
Coinbase Cloud doesn't run crypto.org validators anymore