### PR TITLE
Remove ECOStake APIs from seitestnet

### DIFF
--- a/testnets/seitestnet/chain.json
+++ b/testnets/seitestnet/chain.json
@@ -51,19 +51,11 @@
   "apis": {
     "rpc": [
       {
-        "address": "https://rpc-sei-test.ecostake.com",
-        "provider": "ecostake"
-      },
-      {
         "address": "https://sei-testnet-rpc.brocha.in",
         "provider": "Brochain"
       }
     ],
     "rest": [
-      {
-        "address": "https://rest-sei-test.ecostake.com",
-        "provider": "ecostake"
-      },
       {
         "address": "https://sei-testnet-rest.brocha.in",
         "provider": "Brochain"


### PR DESCRIPTION
Atlantic-1 is effectively killed although still running with a couple of validators. Removing our APIs