### PR TITLE
Upgrade Injective to v1.11.5

### DIFF
--- a/injective/chain.json
+++ b/injective/chain.json
@@ -33,15 +33,15 @@
   },
   "codebase": {
     "git_repo": "https://github.com/InjectiveLabs/injective-chain-releases",
-    "recommended_version": "v1.11.4-1686608669",
+    "recommended_version": "v1.11.5-1687535916",
     "compatible_versions": [
       "v1.11", 
       "v1.11.3-1686246472",
-      "v1.11.4-1686608669"
+      "v1.11.4-1686608669",
+      "v1.11.5-1687535916"
     ],
     "binaries": {
-      "linux/amd64": "https://github.com/InjectiveLabs/injective-chain-releases/releases/download/v1.11.4-1686608669/linux-amd64.zip",
-      "darwin/amd64": "https://github.com/InjectiveLabs/injective-chain-releases/releases/download/v1.11.4-1686608669/darwin-amd64.zip"
+      "linux/amd64": "https://github.com/InjectiveLabs/injective-chain-releases/releases/download/v1.11.5-1687535916/linux-amd64.zip"
     },
     "genesis": {
       "genesis_url": "https://raw.githubusercontent.com/InjectiveLabs/mainnet-config/master/10001/genesis.json"
@@ -63,15 +63,15 @@
         "name": "v1.11",
         "proposal": 231,
         "height": 34775000,
-        "recommended_version": "v1.11.4-1686608669",
+        "recommended_version": "v1.11.5-1687535916",
         "compatible_versions": [
           "v1.11", 
           "v1.11.3-1686246472",
-          "v1.11.4-1686608669"
+          "v1.11.4-1686608669",
+          "v1.11.5-1687535916"
         ],
         "binaries": {
-          "linux/amd64": "https://github.com/InjectiveLabs/injective-chain-releases/releases/download/v1.11.4-1686608669/linux-amd64.zip",
-          "darwin/amd64": "https://github.com/InjectiveLabs/injective-chain-releases/releases/download/v1.11.4-1686608669/darwin-amd64.zip"
+          "linux/amd64": "https://github.com/InjectiveLabs/injective-chain-releases/releases/download/v1.11.5-1687535916/linux-amd64.zip"
         }
       }
     ]


### PR DESCRIPTION
Patch upgrade for chain halt
https://github.com/InjectiveLabs/injective-chain-releases/releases/tag/v1.11.5-1687535916