### PR TITLE
Upgrade QWOYN to v5.1.0

### DIFF
--- a/qwoyn/chain.json
+++ b/qwoyn/chain.json
@@ -48,7 +48,7 @@
         "tag": "v5.0.2",
         "recommended_version": "v5.0.2",
         "compatible_versions": [
-          "v10.0.0"
+          "v5.0.2"
         ],
         "cosmos_sdk_version": "0.47.3",
         "ibc_go_version": "7.0.1",

--- a/qwoyn/chain.json
+++ b/qwoyn/chain.json
@@ -45,39 +45,40 @@
   },
   "versions": [
     {
-     "tag": "v5.0.2",
-     "recommended_version": "v5.0.2",
-     "compatible_versions": [
-       "v10.0.0"
+      "name": "v5.0.2",
+      "tag": "v5.0.2",
+      "recommended_version": "v5.0.2",
+      "compatible_versions": [
+        "v10.0.0"
       ],
-     "cosmos_sdk_version": "0.47.3",
-     "ibc_go_version": "7.0.1",
-     "consensus": {
-          "type": "cometbft",
-          "version": "v0.37.1"
-     },
-     "binaries": {
-       "linux/amd64": "https://github.com/cosmic-horizon/QWOYN/releases/download/v5.0.2/qwoynd_5.0.2_linux_amd64.zip"
-     },
-     "next_version_name": "v5.1.0"
+      "cosmos_sdk_version": "0.47.3",
+      "ibc_go_version": "7.0.1",
+      "consensus": {
+        "type": "cometbft",
+        "version": "v0.37.1"
+      },
+      "binaries": {
+        "linux/amd64": "https://github.com/cosmic-horizon/QWOYN/releases/download/v5.0.2/qwoynd_5.0.2_linux_amd64.zip"
+      },
+      "next_version_name": "v5.1.0"
     },
     {
-     "name": "v5.1.0",
-     "tag": "v5.1.0",
-     "proposal": 1,
-     "height": 280850,
-     "recommended_version": "v5.1.0",
-     "compatible_versions": [
-       "v5.1.0"
+      "name": "v5.1.0",
+      "tag": "v5.1.0",
+      "proposal": 1,
+      "height": 280850,
+      "recommended_version": "v5.1.0",
+      "compatible_versions": [
+        "v5.1.0"
       ],
-     "cosmos_sdk_version": "0.47.3",
-     "ibc_go_version": "7.0.1",
-     "consensus": {
-          "type": "cometbft",
-          "version": "v0.37.1"
-     },
-     "next_version_name": ""
-   }
+      "cosmos_sdk_version": "0.47.3",
+      "ibc_go_version": "7.0.1",
+      "consensus": {
+        "type": "cometbft",
+        "version": "v0.37.1"
+      },
+      "next_version_name": ""
+    }
   ]
   "peers": {
     "seeds": [

--- a/qwoyn/chain.json
+++ b/qwoyn/chain.json
@@ -29,13 +29,10 @@
   },
   "codebase": {
     "git_repo": "https://github.com/cosmic-horizon/QWOYN",
-    "recommended_version": "v5.0.2",
+    "recommended_version": "v5.1.0",
     "compatible_versions": [
-      "v5.0.2"
+      "v5.1.0"
     ],
-    "binaries": {
-      "linux/amd64": "https://github.com/cosmic-horizon/QWOYN/releases/download/v5.0.2/qwoynd_5.0.2_linux_amd64.zip"
-    },
     "cosmos_sdk_version": "0.47.3",
     "ibc_go_version": "7.0.1",
     "ics_enabled": [
@@ -46,6 +43,42 @@
       "genesis_url": "https://github.com/cosmic-horizon/mainnet/blob/main/genesis.json"
     }
   },
+  "versions": [
+    {
+     "tag": "v5.0.2",
+     "recommended_version": "v5.0.2",
+     "compatible_versions": [
+       "v10.0.0"
+      ],
+     "cosmos_sdk_version": "0.47.3",
+     "ibc_go_version": "7.0.1",
+     "consensus": {
+          "type": "cometbft",
+          "version": "v0.37.1"
+     },
+     "binaries": {
+       "linux/amd64": "https://github.com/cosmic-horizon/QWOYN/releases/download/v5.0.2/qwoynd_5.0.2_linux_amd64.zip"
+     },
+     "next_version_name": "v5.1.0"
+    },
+    {
+     "name": "v5.1.0",
+     "tag": "v5.1.0",
+     "proposal": 1,
+     "height": 280850,
+     "recommended_version": "v5.1.0",
+     "compatible_versions": [
+       "v5.1.0"
+      ],
+     "cosmos_sdk_version": "0.47.3",
+     "ibc_go_version": "7.0.1",
+     "consensus": {
+          "type": "cometbft",
+          "version": "v0.37.1"
+     },
+     "next_version_name": ""
+   }
+  ]
   "peers": {
     "seeds": [
       {
@@ -93,6 +126,10 @@
       {
         "address": "https://qwoyn-rpc-archive.staketab.org:443",
         "provider": "Staketab archive"
+      },
+      {
+        "address": "https://qwoyn-rpc.lavenderfive.com:443",
+        "provider": "Lavender.Five Nodes 🐝"
       }
     ],
     "grpc": [
@@ -107,6 +144,10 @@
       {
         "address": "https://grpc-qwoyn.theamsolutions.info:443",
         "provider": "AM Solutions"
+      },
+      {
+        "address": "https://qwoyn-grpc.lavenderfive.com:443",
+        "provider": "Lavender.Five Nodes 🐝"
       }
     ],
     "rest": [
@@ -121,6 +162,10 @@
       {
         "address": "https://qwoyn-rest-archive.staketab.org",
         "provider": "Staketab archive"
+      },
+      {
+        "address": "https://qwoyn-api.lavenderfive.com",
+        "provider": "Lavender.Five Nodes 🐝"
       }
     ]
   },

--- a/qwoyn/chain.json
+++ b/qwoyn/chain.json
@@ -42,44 +42,43 @@
     "genesis": {
       "genesis_url": "https://github.com/cosmic-horizon/mainnet/blob/main/genesis.json"
     }
-  },
-  "versions": [
-    {
-      "name": "v5.0.2",
-      "tag": "v5.0.2",
-      "recommended_version": "v5.0.2",
-      "compatible_versions": [
-        "v10.0.0"
-      ],
-      "cosmos_sdk_version": "0.47.3",
-      "ibc_go_version": "7.0.1",
-      "consensus": {
+    "versions": [
+      {
+        "name": "v5.0.2",
+        "tag": "v5.0.2",
+        "recommended_version": "v5.0.2",
+        "compatible_versions": [
+          "v10.0.0"
+        ],
+        "cosmos_sdk_version": "0.47.3",
+        "ibc_go_version": "7.0.1",
+        "consensus": {
+          "type": "cometbft",
+          "version": "v0.37.1"
+        },
+        "binaries": {
+          "linux/amd64": "https://github.com/cosmic-horizon/QWOYN/releases/download/v5.0.2/qwoynd_5.0.2_linux_amd64.zip"
+        },
+        "next_version_name": "v5.1.0"
+      },
+      {
+        "name": "v5.1.0",
+        "tag": "v5.1.0",
+        "proposal": 1,
+        "height": 280850,
+        "recommended_version": "v5.1.0",
+        "compatible_versions": [
+          "v5.1.0"
+        ],
+        "cosmos_sdk_version": "0.47.3",
+        "ibc_go_version": "7.0.1",
+        "consensus": {
         "type": "cometbft",
         "version": "v0.37.1"
-      },
-      "binaries": {
-        "linux/amd64": "https://github.com/cosmic-horizon/QWOYN/releases/download/v5.0.2/qwoynd_5.0.2_linux_amd64.zip"
-      },
-      "next_version_name": "v5.1.0"
-    },
-    {
-      "name": "v5.1.0",
-      "tag": "v5.1.0",
-      "proposal": 1,
-      "height": 280850,
-      "recommended_version": "v5.1.0",
-      "compatible_versions": [
-        "v5.1.0"
-      ],
-      "cosmos_sdk_version": "0.47.3",
-      "ibc_go_version": "7.0.1",
-      "consensus": {
-        "type": "cometbft",
-        "version": "v0.37.1"
-      },
-      "next_version_name": ""
-    }
-  ]
+        },
+        "next_version_name": ""
+      }
+    ]
   "peers": {
     "seeds": [
       {

--- a/qwoyn/chain.json
+++ b/qwoyn/chain.json
@@ -78,7 +78,8 @@
         },
         "next_version_name": ""
       }
-    ]
+    ]    
+  },
   "peers": {
     "seeds": [
       {

--- a/qwoyn/chain.json
+++ b/qwoyn/chain.json
@@ -41,7 +41,7 @@
     ],
     "genesis": {
       "genesis_url": "https://github.com/cosmic-horizon/mainnet/blob/main/genesis.json"
-    }
+    },
     "versions": [
       {
         "name": "v5.0.2",


### PR DESCRIPTION
Prop 1
Height 280850

No details for prop at https://explorer.theamsolutions.info/QWOYN-MAIN/gov, please refer to https://commonwealth.im/qwoyn-network/discussion/11774-coho-token-initial-mint-and-internal-lp-integration-qwoyndv510 and https://github.com/cosmic-horizon/QWOYN/releases/tag/v5.1.0. 

Estimated Time: 7/5/2023, 1:54:20 PM EST

This PR also adds APIs for Lavender.Five Nodes