### PR TITLE
Upgrade Bitcanna to v2.0.2 wakeandbake

### DIFF
--- a/bitcanna/chain.json
+++ b/bitcanna/chain.json
@@ -33,21 +33,23 @@
   },
   "codebase": {
     "git_repo": "https://github.com/BitCannaGlobal/bcna",
-    "recommended_version": "v1.7.0",
+    "recommended_version": "v2.0.2",
     "compatible_versions": [
-      "v1.7.0"
+      "v2.0.2"
     ],
     "binaries": {
-      "linux/amd64": "https://github.com/BitCannaGlobal/bcna/releases/download/v1.7.0/bcna_linux_amd64.tar.gz",
-      "darwin/arm64": "https://github.com/BitCannaGlobal/bcna/releases/download/v1.7.0/bcna_darwin_arm64.tar.gz",
-      "darwin/amd64": "https://github.com/BitCannaGlobal/bcna/releases/download/v1.7.0/bcna_darwin_amd64.tar.gz"
+      "linux/amd64": "https://github.com/BitCannaGlobal/bcna/releases/download/v2.0.2/bcna_linux_amd64.tar.gz",
+      "linux/arm64": "https://github.com/BitCannaGlobal/bcna/releases/download/v2.0.2/bcna_linux_arm64.tar.gz",
+      "darwin/arm64": "https://github.com/BitCannaGlobal/bcna/releases/download/v2.0.2/bcna_darwin_arm64.tar.gz"
     },
     "genesis": {
       "genesis_url": "https://raw.githubusercontent.com/BitCannaGlobal/bcna/main/genesis.json"
     },
     "versions": [
       {
-        "name": "v1.6.3",
+        "name": "vigorous-grow-fix",
+        "proposal": 10,
+        "height": 7585420,
         "recommended_version": "v1.6.3",
         "compatible_versions": [
           "v1.6.1",
@@ -58,10 +60,13 @@
           "linux/amd64": "https://github.com/BitCannaGlobal/bcna/releases/download/v1.6.3/bcna_linux_amd64.tar.gz",
           "darwin/arm64": "https://github.com/BitCannaGlobal/bcna/releases/download/v1.6.3/bcna_darwin_arm64.tar.gz",
           "darwin/amd64": "https://github.com/BitCannaGlobal/bcna/releases/download/v1.6.3/bcna_darwin_amd64.tar.gz"
-        }
+        },
+       "next_version_name": "vigorous-grow-huckleberry"
       },
       {
-        "name": "v1.7.0",
+        "name": "vigorous-grow-huckleberry",
+        "proposal": 11,
+        "height": 8771420,
         "recommended_version": "v1.7.0",
         "compatible_versions": [
           "v1.7.0"
@@ -70,6 +75,21 @@
           "linux/amd64": "https://github.com/BitCannaGlobal/bcna/releases/download/v1.7.0/bcna_linux_amd64.tar.gz",
           "darwin/arm64": "https://github.com/BitCannaGlobal/bcna/releases/download/v1.7.0/bcna_darwin_arm64.tar.gz",
           "darwin/amd64": "https://github.com/BitCannaGlobal/bcna/releases/download/v1.7.0/bcna_darwin_amd64.tar.gz"
+        },
+        "next_version_name": "wakeandbake"
+      },
+      {
+        "name": "wakeandbake",
+        "proposal": 12,
+        "height": 9209420,
+        "recommended_version": "v2.0.2",
+        "compatible_versions": [
+          "v2.0.2"
+        ],
+       "binaries": {
+          "linux/amd64": "https://github.com/BitCannaGlobal/bcna/releases/download/v2.0.2/bcna_linux_amd64.tar.gz",
+          "linux/arm64": "https://github.com/BitCannaGlobal/bcna/releases/download/v2.0.2/bcna_linux_arm64.tar.gz",
+          "darwin/arm64": "https://github.com/BitCannaGlobal/bcna/releases/download/v2.0.2/bcna_darwin_arm64.tar.gz"
         }
       }
     ]


### PR DESCRIPTION
Prop 12
Height 9209420
https://www.mintscan.io/bitcanna/proposals/12

Estimated Target Date:
Thu Jun 29 2023 09:15:24 GMT-0400 (Eastern Daylight Time)

This PR also fixes upgrade names, adds props and heights, and next_versions for the previous two versions.

Sources for name fix:
https://www.mintscan.io/bitcanna/proposals/11
https://www.mintscan.io/bitcanna/proposals/10