### PR TITLE
Upgrade Osmosis to 15.2.0

### DIFF
--- a/osmosis/chain.json
+++ b/osmosis/chain.json
@@ -37,14 +37,15 @@
   },
   "codebase": {
     "git_repo": "https://github.com/osmosis-labs/osmosis",
-    "recommended_version": "v15.1.0",
+    "recommended_version": "v15.2.0",
     "compatible_versions": [
+      "v15.2.0",
       "v15.1.0",
       "v15.0.0"
     ],
     "binaries": {
-      "linux/amd64": "https://github.com/osmosis-labs/osmosis/releases/download/v15.1.0/osmosisd-15.1.0-linux-amd64?checksum=sha256:f16f901dfd47426caced8436c507e2950a4e2452b6cc6efc7845ab3b43a5c5d5",
-      "linux/arm64": "https://github.com/osmosis-labs/osmosis/releases/download/v15.1.0/osmosisd-15.1.0-linux-arm64?checksum=sha256:08b20f0753b6b0bafa3a6ca7e4bb6807baf72754dfb69d6db7b1fb2b4b55ffc0"
+      "linux/amd64": "https://github.com/osmosis-labs/osmosis/releases/download/v15.2.0/osmosisd-15.2.0-linux-amd64",
+      "linux/arm64": "https://github.com/osmosis-labs/osmosis/releases/download/v15.2.0/osmosisd-15.2.0-linux-arm64"
     },
     "cosmos_sdk_version": "0.45",
     "consensus": {
@@ -118,10 +119,11 @@
       },
       {
         "name": "v15",
-        "tag": "v15.1.0",
+        "tag": "v15.2.0",
         "height": 8732500,
-        "recommended_version": "v15.1.0",
+        "recommended_version": "v15.2.0",
         "compatible_versions": [
+          "v15.2.0",
           "v15.1.0",
           "v15.0.0"
         ],
@@ -137,8 +139,8 @@
           "ics20-1"
         ],
         "binaries": {
-          "linux/amd64": "https://github.com/osmosis-labs/osmosis/releases/download/v15.1.0/osmosisd-15.1.0-linux-amd64?checksum=sha256:f16f901dfd47426caced8436c507e2950a4e2452b6cc6efc7845ab3b43a5c5d5",
-          "linux/arm64": "https://github.com/osmosis-labs/osmosis/releases/download/v15.1.0/osmosisd-15.1.0-linux-arm64?checksum=sha256:08b20f0753b6b0bafa3a6ca7e4bb6807baf72754dfb69d6db7b1fb2b4b55ffc0"
+          "linux/amd64": "https://github.com/osmosis-labs/osmosis/releases/download/v15.2.0/osmosisd-15.2.0-linux-amd64",
+          "linux/arm64": "https://github.com/osmosis-labs/osmosis/releases/download/v15.2.0/osmosisd-15.2.0-linux-arm64"
         }
       }
     ]


### PR DESCRIPTION
Security patch info: https://github.com/osmosis-labs/osmosis/releases/tag/v15.2.0