### PR TITLE
Upgrade Composable to v3.2.0

### DIFF
--- a/composable/chain.json
+++ b/composable/chain.json
@@ -84,7 +84,24 @@
         "proposal": 3,
         "binaries": {
           "linux/amd64": "https://github.com/notional-labs/composable-centauri/releases/download/v3.1.2/centaurid"
-        }
+        },
+        "next_version_name": "reward"
+        {
+        "name": "reward",
+        "tag": "v3.2.0",
+        "recommended_version": "v3.2.0",
+        "compatible_versions": [
+          "v3.2.0"
+        ],
+        "cosmos_sdk_version": "v0.47.3",
+        "ibc_go_version": "v7.0.0",
+        "consensus": {
+          "type": "cometbft",
+          "version": "0.37.1"
+        },
+        "height": 420000,
+        "proposal": 4,
+        "next_version_name": ""
       }
     ]
   },

--- a/composable/chain.json
+++ b/composable/chain.json
@@ -33,15 +33,10 @@
   },
   "codebase": {
     "git_repo": "https://github.com/notional-labs/composable-centauri",
-    "recommended_version": "v3.1.2",
+    "recommended_version": "v3.2.0",
     "compatible_versions": [
-      "v3.1.0",
-      "v3.1.1",
-      "v3.1.2"
+      "v3.2.0"
     ],
-    "binaries": {
-      "linux/amd64": "https://github.com/notional-labs/composable-centauri/releases/download/v3.1.2/centaurid"
-    },
     "genesis": {
       "genesis_url": "https://raw.githubusercontent.com/notional-labs/composable-networks/main/mainnet/genesis.json"
     },
@@ -86,7 +81,8 @@
           "linux/amd64": "https://github.com/notional-labs/composable-centauri/releases/download/v3.1.2/centaurid"
         },
         "next_version_name": "reward"
-        {
+      },  
+      {
         "name": "reward",
         "tag": "v3.2.0",
         "recommended_version": "v3.2.0",

--- a/composable/chain.json
+++ b/composable/chain.json
@@ -33,9 +33,9 @@
   },
   "codebase": {
     "git_repo": "https://github.com/notional-labs/composable-centauri",
-    "recommended_version": "v3.2.0",
+    "recommended_version": "v3.2.1",
     "compatible_versions": [
-      "v3.2.0"
+      "v3.2.1"
     ],
     "genesis": {
       "genesis_url": "https://raw.githubusercontent.com/notional-labs/composable-networks/main/mainnet/genesis.json"
@@ -84,10 +84,10 @@
       },  
       {
         "name": "reward",
-        "tag": "v3.2.0",
-        "recommended_version": "v3.2.0",
+        "tag": "v3.2.1",
+        "recommended_version": "v3.2.1",
         "compatible_versions": [
-          "v3.2.0"
+          "v3.2.1"
         ],
         "cosmos_sdk_version": "v0.47.3",
         "ibc_go_version": "v7.0.0",

--- a/composable/chain.json
+++ b/composable/chain.json
@@ -33,9 +33,9 @@
   },
   "codebase": {
     "git_repo": "https://github.com/notional-labs/composable-centauri",
-    "recommended_version": "v3.2.1",
+    "recommended_version": "v3.2.2",
     "compatible_versions": [
-      "v3.2.1"
+      "v3.2.2"
     ],
     "genesis": {
       "genesis_url": "https://raw.githubusercontent.com/notional-labs/composable-networks/main/mainnet/genesis.json"
@@ -84,10 +84,10 @@
       },  
       {
         "name": "reward",
-        "tag": "v3.2.1",
-        "recommended_version": "v3.2.1",
+        "tag": "v3.2.2",
+        "recommended_version": "v3.2.2",
         "compatible_versions": [
-          "v3.2.1"
+          "v3.2.2"
         ],
         "cosmos_sdk_version": "v0.47.3",
         "ibc_go_version": "v7.0.0",


### PR DESCRIPTION
Prop 4
Height 420000
https://explorers.l0vd.com/composable-mainnet/gov/4 Upgrade time est 2023-07-03 19:52:03 EST

Prop is mistaken in its title (3.1.0), this upgrade is for 3.2.0. Please refer to upgrade description in proposal and this release tag: https://github.com/notional-labs/composable-centauri/releases/tag/v3.2.0