### PR TITLE
Fix incorrect agoric logo uris

### DIFF
--- a/agoric/chain.json
+++ b/agoric/chain.json
@@ -56,8 +56,8 @@
     ]
   },
   "logo_URIs": {
-    "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/acrechain/images/Agoric-logo-color.png",
-    "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/acrechain/images/Agoric-logo-color.svg"
+    "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/agoric/images/Agoric-logo-color.png",
+    "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/agoric/images/Agoric-logo-color.svg"
   },
   "peers": {
     "seeds": [


### PR DESCRIPTION
`acrechain` => `agoric`