### PR TITLE
Upgrade Cosmos Hub to v10.0.2

### DIFF
--- a/cosmoshub/chain.json
+++ b/cosmoshub/chain.json
@@ -33,45 +33,21 @@
   },
   "codebase": {
     "git_repo": "https://github.com/cosmos/gaia",
-    "recommended_version": "v10.0.1",
+    "recommended_version": "v10.0.2",
     "compatible_versions": [
-      "v10.0.0", "v10.0.1"
+      "v10.0.0", "v10.0.1", "v10.0.2"
     ],
     "binaries": {
-      "linux/amd64": "https://github.com/cosmos/gaia/releases/download/v10.0.1/gaiad-v10.0.1-linux-amd64",
-      "linux/arm64": "https://github.com/cosmos/gaia/releases/download/v10.0.1/gaiad-v10.0.1-linux-arm64",
-      "darwin/amd64": "https://github.com/cosmos/gaia/releases/download/v10.0.1/gaiad-v10.0.1-darwin-amd64",
-      "darwin/arm64": "https://github.com/cosmos/gaia/releases/download/v10.0.1/gaiad-v10.0.1-darwin-arm64",
-      "windows/amd64": "https://github.com/cosmos/gaia/releases/download/v10.0.1/gaiad-v10.0.1-windows-amd64.exe"
+      "linux/amd64": "https://github.com/cosmos/gaia/releases/download/v10.0.2/gaiad-v10.0.2-linux-amd64",
+      "linux/arm64": "https://github.com/cosmos/gaia/releases/download/v10.0.2/gaiad-v10.0.2-linux-arm64",
+      "darwin/amd64": "https://github.com/cosmos/gaia/releases/download/v10.0.2/gaiad-v10.0.2-darwin-amd64",
+      "darwin/arm64": "https://github.com/cosmos/gaia/releases/download/v10.0.2/gaiad-v10.0.2-darwin-arm64",
+      "windows/amd64": "https://github.com/cosmos/gaia/releases/download/v10.0.2/gaiad-v10.0.2-windows-amd64.exe"
     },
     "genesis": {
       "genesis_url": "https://github.com/cosmos/mainnet/raw/master/genesis/genesis.cosmoshub-4.json.gz"
     },
     "versions": [
-      {
-        "name": "v10",
-        "tag": "v10.0.1",
-        "proposal": 798,
-        "height": 15816200,
-        "recommended_version": "v10.0.1",
-        "compatible_versions": [
-          "v10.0.0", "v10.0.1"
-        ],
-        "cosmos_sdk_version": "v0.45.16-ics",
-        "ibc_go_version": "v4.4.1",
-        "consensus": {
-          "type": "cometbft",
-          "version": "v0.34.28"
-        },
-        "binaries": {
-          "linux/amd64": "https://github.com/cosmos/gaia/releases/download/v10.0.1/gaiad-v10.0.1-linux-amd64?checksum=sha256:fcb8210308223d78bc36f3d4c89e2578dcf784994c052cea97efd61f1672cf72",
-          "linux/arm64": "https://github.com/cosmos/gaia/releases/download/v10.0.1/gaiad-v10.0.1-linux-arm64?checksum=sha256:db9b69cf224b410c669fa4f820192890357534e74d4693a744ef915028567462",
-          "darwin/amd64": "https://github.com/cosmos/gaia/releases/download/v10.0.1/gaiad-v10.0.1-darwin-amd64?checksum=sha256:d0bee3b4b243fe1f88ad3258f4648de3a73787434702bcac6e31ca38f81a283a",
-          "darwin/arm64": "https://github.com/cosmos/gaia/releases/download/v10.0.1/gaiad-v10.0.1-darwin-arm64?checksum=sha256:c8124d66ffa99b51da274656f6c3401b1ec9e165a76f3f01699761672e83a136gaiad-v10.0.1-linux-amd64",
-          "windows/amd64": "https://github.com/cosmos/gaia/releases/download/v10.0.1/gaiad-v10.0.1-windows-amd64.exe?checksum=sha256:c02ab2b8fc347f858db1c33fcacafa2467ca550ed83178aee67331762e876926"
-        },
-        "next_version_name": ""
-      },
       {
         "name": "v9-Lambda",
         "tag": "v9.1.1",
@@ -94,6 +70,30 @@
           "windows/amd64": "https://github.com/cosmos/gaia/releases/download/v9.1.1/gaiad-v9.1.1-windows-amd64.exe?checksum=sha256:db1d82650ed2a0aa9abccb2bb60dca902c4d1444444f6c76a8b6d61d6bc41e08"
         },
         "next_version_name": "v10"
+      },
+       {
+        "name": "v10",
+        "tag": "v10.0.2",
+        "proposal": 798,
+        "height": 15816200,
+        "recommended_version": "v10.0.2",
+        "compatible_versions": [
+          "v10.0.0", "v10.0.1", "v10.0.2"
+        ],
+        "cosmos_sdk_version": "v0.45.16-ics",
+        "ibc_go_version": "v4.4.2",
+        "consensus": {
+          "type": "cometbft",
+          "version": "v0.34.29"
+        },
+        "binaries": {
+          "linux/amd64": "https://github.com/cosmos/gaia/releases/download/v10.0.2/gaiad-v10.0.2-linux-amd64?checksum=sha256:fcb8210308223d78bc36f3d4c89e2578dcf784994c052cea97efd61f1672cf72",
+          "linux/arm64": "https://github.com/cosmos/gaia/releases/download/v10.0.2/gaiad-v10.0.2-linux-arm64?checksum=sha256:db9b69cf224b410c669fa4f820192890357534e74d4693a744ef915028567462",
+          "darwin/amd64": "https://github.com/cosmos/gaia/releases/download/v10.0.2/gaiad-v10.0.2-darwin-amd64?checksum=sha256:d0bee3b4b243fe1f88ad3258f4648de3a73787434702bcac6e31ca38f81a283a",
+          "darwin/arm64": "https://github.com/cosmos/gaia/releases/download/v10.0.2/gaiad-v10.0.2-darwin-arm64?checksum=sha256:c8124d66ffa99b51da274656f6c3401b1ec9e165a76f3f01699761672e83a136gaiad-v10.0.1-linux-amd64",
+          "windows/amd64": "https://github.com/cosmos/gaia/releases/download/v10.0.2/gaiad-v10.0.2-windows-amd64.exe?checksum=sha256:c02ab2b8fc347f858db1c33fcacafa2467ca550ed83178aee67331762e876926"
+        },
+        "next_version_name": ""
       }
     ]
   },


### PR DESCRIPTION
Non-consensus upgrade for v10.0.2. Upgrades versions for Comet BFT and IBC Go.

Source: https://github.com/cosmos/gaia/releases/tag/v10.0.2