### PR TITLE
Upgrade Composable to v3.2.1 patch

### DIFF
--- a/composable/chain.json
+++ b/composable/chain.json
@@ -33,11 +33,12 @@
   },
   "codebase": {
     "git_repo": "https://github.com/notional-labs/composable-centauri",
-    "recommended_version": "v3.1.2",
+    "recommended_version": "v3.2.1",
     "compatible_versions": [
       "v3.1.0",
       "v3.1.1",
-      "v3.1.2"
+      "v3.1.2",
+      "v3.2.1"
     ],
     "binaries": {
       "linux/amd64": "https://github.com/notional-labs/composable-centauri/releases/download/v3.1.2/centaurid"
@@ -67,12 +68,13 @@
       },
       {
         "name": "centauri",
-        "tag": "v3.1.0",
-        "recommended_version": "v3.1.2",
+        "tag": "v3.2.1",
+        "recommended_version": "v3.2.1",
         "compatible_versions": [
           "v3.1.0",
           "v3.1.1",
-          "v3.1.2"
+          "v3.1.2",
+          "v3.2.1"
         ],
         "cosmos_sdk_version": "v0.47.3",
         "ibc_go_version": "v7.0.0",


### PR DESCRIPTION
This is for the current "centauri" version. 

Source: https://github.com/notional-labs/composable-centauri/releases/tag/v3.2.1