### PR TITLE
Upgrade impacthub to v0.20.1

### DIFF
--- a/impacthub/chain.json
+++ b/impacthub/chain.json
@@ -34,9 +34,9 @@
   },
   "codebase": {
     "git_repo": "https://github.com/ixofoundation/ixo-blockchain",
-    "recommended_version": "v0.20.0",
+    "recommended_version": "v0.20.1",
     "compatible_versions": [
-      "v0.20.0"
+      "v0.20.0", "v0.20.1"
     ],
     "genesis": {
       "genesis_url": "https://github.com/ixofoundation/genesis/raw/bc042e1223d551b22d55c155de06e662ca24d2f2/ixo-5/genesis.json.tar.gz"
@@ -44,9 +44,9 @@
     "versions": [
       {
         "name": "v0.20.0",
-        "recommended_version": "v0.20.0",
+        "recommended_version": "v0.20.1",
         "compatible_versions": [
-          "v0.20.0"
+          "v0.20.0", "v0.20.1"
         ]
       }
     ]


### PR DESCRIPTION
Non-consensus upgrade that fixes state sync issues with v0.20.0. Ok to push this now.

Source: https://github.com/ixofoundation/ixo-blockchain/releases/tag/v0.20.1