### PR TITLE
Upgrade Evmos to v13.0.2

### DIFF
--- a/evmos/chain.json
+++ b/evmos/chain.json
@@ -88,8 +88,8 @@
       {
         "name": "v13.0.2",
         "tag": "v13.0.2",
-        "proposal": 148,
-        "height": 14492000,
+        "proposal": 149,
+        "height": 14538200,
         "recommended_version": "v13.0.2",
         "compatible_versions": [
           "v13.0.2"

--- a/evmos/chain.json
+++ b/evmos/chain.json
@@ -36,20 +36,16 @@
   },
   "codebase": {
     "git_repo": "https://github.com/evmos/evmos",
-    "recommended_version": "v12.1.5",
+    "recommended_version": "v13.0.2",
     "compatible_versions": [
-      "v12.1.5",
-      "v12.1.3",
-      "v12.1.2",
-      "v12.1.1",
-      "v12.1.0"
+      "v13.0.2"
     ],
     "binaries": {
-      "linux/amd64": "https://github.com/evmos/evmos/releases/download/v12.1.5/evmos_12.1.5_Linux_amd64.tar.gz",
-      "linux/arm64": "https://github.com/evmos/evmos/releases/download/v12.1.5/evmos_12.1.5_Linux_arm64.tar.gz",
-      "darwin/amd64": "https://github.com/evmos/evmos/releases/download/v12.1.5/evmos_12.1.5_Darwin_amd64.tar.gz",
-      "darwin/arm64": "https://github.com/evmos/evmos/releases/download/v12.1.5/evmos_12.1.5_Darwin_arm64.tar.gz",
-      "windows/amd64": "https://github.com/evmos/evmos/releases/download/v12.1.5/evmos_12.1.5_Windows_amd64.zip"
+      "linux/amd64": "https://github.com/evmos/evmos/releases/download/v13.0.2/evmos_13.0.2_Linux_amd64.tar.gz",
+      "linux/arm64": "https://github.com/evmos/evmos/releases/download/v13.0.2/evmos_13.0.2_Linux_arm64.tar.gz",
+      "darwin/amd64": "https://github.com/evmos/evmos/releases/download/v13.0.2/evmos_13.0.2_Darwin_amd64.tar.gz",
+      "darwin/arm64": "https://github.com/evmos/evmos/releases/download/v13.0.2/evmos_13.0.2_Darwin_arm64.tar.gz",
+      "windows/amd64": "https://github.com/evmos/evmos/releases/download/v13.0.2/evmos_13.0.2_Windows_amd64.zip"
     },
     "cosmos_sdk_version": "0.46",
     "consensus": {
@@ -63,6 +59,9 @@
     "versions": [
       {
         "name": "v12",
+        "tag": "v12.1.5",
+        "proposal": 137,
+        "height": 12303000,
         "recommended_version": "v12.1.5",
         "compatible_versions": [
           "v12.1.5",
@@ -83,7 +82,32 @@
           "darwin/amd64": "https://github.com/evmos/evmos/releases/download/v12.1.5/evmos_12.1.5_Darwin_amd64.tar.gz",
           "darwin/arm64": "https://github.com/evmos/evmos/releases/download/v12.1.5/evmos_12.1.5_Darwin_arm64.tar.gz",
           "windows/amd64": "https://github.com/evmos/evmos/releases/download/v12.1.5/evmos_12.1.5_Windows_amd64.zip"
-        }
+        },
+        "next_version_name": "v13.0.2"
+      },
+      {
+        "name": "v13.0.2",
+        "tag": "v13.0.2",
+        "proposal": 148,
+        "height": 14492000,
+        "recommended_version": "v13.0.2",
+        "compatible_versions": [
+          "v13.0.2"
+        ],
+        "cosmos_sdk_version": "0.46",
+        "consensus": {
+          "type": "cometbft",
+          "version": "v0.34.29"
+        },
+        "ibc_go_version": "v6.2.0",
+        "binaries": {
+          "linux/amd64": "https://github.com/evmos/evmos/releases/download/v13.0.2/evmos_13.0.2_Linux_amd64.tar.gz",
+          "linux/arm64": "https://github.com/evmos/evmos/releases/download/v13.0.2/evmos_13.0.2_Linux_arm64.tar.gz",
+          "darwin/amd64": "https://github.com/evmos/evmos/releases/download/v13.0.2/evmos_13.0.2_Darwin_amd64.tar.gz",
+          "darwin/arm64": "https://github.com/evmos/evmos/releases/download/v13.0.2/evmos_13.0.2_Darwin_arm64.tar.gz",
+          "windows/amd64": "https://github.com/evmos/evmos/releases/download/v13.0.2/evmos_13.0.2_Windows_amd64.zip"
+        },
+        "next_version_name": ""
       }
     ]
   },


### PR DESCRIPTION
Prop 148
Height 14492000
https://www.mintscan.io/evmos/proposals/149
Wed Jul 12 2023 12:53:29 GMT-0400 (Eastern Daylight Time)

This version also changes to cometbft. Also added prop/height for previous version (v12).