### PR TITLE
Upgrade Jackal to v2.1.0

### DIFF
--- a/jackal/chain.json
+++ b/jackal/chain.json
@@ -47,7 +47,7 @@
     "cosmwasm_enabled": true,
     "versions": [
       {
-        "name": "v1.2.1",
+        "name": "bouncybulldog",
         "recommended_version": "v1.2.1",
         "compatible_versions": [
           "v1.2.1"
@@ -56,33 +56,40 @@
         "binaries": {
           "linux/amd64": "https://github.com/JackalLabs/canine-chain/releases/download/v1.2.1/canined-Linux",
           "darwin/amd64": "https://github.com/JackalLabs/canine-chain/releases/download/v1.2.1/canined-macOS"
-        }
+        },
+        "next_version_name": 
       },
       {
-        "name": "v2.0.0",
-        "height": 2631260,
+        "name": "recovery",
+        "tag": "V2.0.0",
         "proposal": 4,
-        "recommended_version": "v2.0.0",
+        "height": 2631260,
+        "recommended_version": "v2.0.1",
         "compatible_versions": [
-          "v2.0.0"
-        ],
-        "cosmwasm_enabled": true,
-        "binaries": {
-          "linux/amd64": "https://github.com/JackalLabs/canine-chain/releases/download/v2.0.0/canined-Linux",
-          "darwin/amd64": "https://github.com/JackalLabs/canine-chain/releases/download/v2.0.0/canined-macOS"
-        }
-      },
-      {
-        "name": "v2.0.2",
-        "recommended_version": "v2.0.2",
-        "compatible_versions": [
-          "v2.0.2"
+          "v2.0.0", "v2.0.1"
         ],
         "cosmwasm_enabled": true,
         "binaries": {
           "linux/amd64": "https://github.com/JackalLabs/canine-chain/releases/download/v2.0.2/canined-Linux",
           "darwin/amd64": "https://github.com/JackalLabs/canine-chain/releases/download/v2.0.2/canined-macOS"
-        }
+        },
+        "next_version_name": "v210"
+      },
+      {
+        "name": "v210",
+        "tag": "V2.1.0",
+        "proposal": 8,
+        "height": 3503000,
+        "recommended_version": "v2.1.0",
+        "compatible_versions": [
+          "v2.1.0"
+        ],
+        "cosmwasm_enabled": true,
+        "binaries": {
+          "linux/amd64": "https://github.com/JackalLabs/canine-chain/releases/download/v2.1.0/canined-Linux",
+          "darwin/amd64": "https://github.com/JackalLabs/canine-chain/releases/download/v2.1.0/canined-macOS"
+        },
+        "next_version_name": ""
       }
     ]
   },

--- a/jackal/chain.json
+++ b/jackal/chain.json
@@ -57,7 +57,7 @@
           "linux/amd64": "https://github.com/JackalLabs/canine-chain/releases/download/v1.2.1/canined-Linux",
           "darwin/amd64": "https://github.com/JackalLabs/canine-chain/releases/download/v1.2.1/canined-macOS"
         },
-        "next_version_name": 
+        "next_version_name": "recovery"
       },
       {
         "name": "recovery",

--- a/jackal/chain.json
+++ b/jackal/chain.json
@@ -33,13 +33,13 @@
   },
   "codebase": {
     "git_repo": "https://github.com/JackalLabs/canine-chain",
-    "recommended_version": "v2.0.2",
+    "recommended_version": "v2.1.0",
     "compatible_versions": [
-      "v2.0.2"
+      "v2.1.0"
     ],
     "binaries": {
-      "linux/amd64": "https://github.com/JackalLabs/canine-chain/releases/download/v2.0.2/canined-Linux",
-      "darwin/amd64": "https://github.com/JackalLabs/canine-chain/releases/download/v2.0.2/canined-macOS"
+      "linux/amd64": "https://github.com/JackalLabs/canine-chain/releases/download/v2.1.0/canined-Linux",
+      "darwin/amd64": "https://github.com/JackalLabs/canine-chain/releases/download/v2.1.0/canined-macOS"
     },
     "genesis": {
       "genesis_url": "https://cdn.discordapp.com/attachments/1002389406650466405/1034968352591986859/updated_genesis2.json"
@@ -61,7 +61,7 @@
       },
       {
         "name": "recovery",
-        "tag": "V2.0.0",
+        "tag": "V2.0.1",
         "proposal": 4,
         "height": 2631260,
         "recommended_version": "v2.0.1",


### PR DESCRIPTION
Prop 8
Height 3503000
Source: https://ping.pub/jackal/gov/8
Est Upgrade Date July 11

This PR also fixes upgrade names for previous versions