### PR TITLE
Fix Terra2 v2.4

### DIFF
--- a/terra2/chain.json
+++ b/terra2/chain.json
@@ -30,13 +30,9 @@
   },
   "codebase": {
     "git_repo": "https://github.com/terra-money/core/",
-    "recommended_version": "v2.3.5",
+    "recommended_version": "v2.4.1",
     "compatible_versions": [
-      "v2.3.0",
-      "v2.3.1",
-      "v2.3.2",
-      "v2.3.4",
-      "v2.3.5"
+      "v2.4.1"
     ],
     "genesis": {
       "name": "v2.0",
@@ -120,25 +116,33 @@
         "cosmwasm_version": "v0.30.0",
         "ibc_go_version": "v6.1.1",
         "consensus": {
-          "type": "cometbft",
+          "type": "tendermint",
           "version": "v0.34.27"
         },
         "binaries": {
           "linux/arm64": "https://github.com/terra-money/core/releases/download/v2.3.5/terra_2.3.5_Linux_arm64.tar.gz?checksum=sha256:93b0c508e16f779b93f0e76629ab247ddaf5fa0db96573405b3b2b11e3eb6859",
           "linux/amd64": "https://github.com/terra-money/core/releases/download/v2.3.5/terra_2.3.5_Linux_x86_64.tar.gz?checksum=sha256:8c3ac7392436b102dcdd63fd275fa73b1e0201e65e420af71954782cee682ac6"
-        }
+        },
+        "next_version_name": "v2.4"
       },
       {
         "name": "v2.4",
-        "tag": "v2.4.0",
+        "tag": "v2.4.1",
+        "proposal": 4737,
+        "height": 5994365,
         "cosmos_sdk_version": "v0.46.11",
         "cosmwasm_enabled": true,
         "cosmwasm_version": "v0.30.0",
         "ibc_go_version": "v6.1.1",
         "consensus": {
-          "type": "cometbft",
+          "type": "tendermint",
           "version": "v0.34.27"
-        }
+        },
+        "binaries": {
+          "linux/arm64": "https://github.com/terra-money/core/releases/download/v2.4.1/terra_2.4.1_Linux_arm64.tar.gz",
+          "linux/amd64": "https://github.com/terra-money/core/releases/download/v2.4.1/terra_2.4.1_Linux_x86_64.tar.gz"
+        },
+        "next_version_name": ""
       }
     ]
   },


### PR DESCRIPTION
Some fixes for Terra2 v2.4:

1.) update codebase to v2.4
2.) add proposal and height
3.) switch back to tendermint from cometbft on 2.4 and 2.3 - nowhere indicated on go.mod or commit history of a change from tendermint to cometbft. 4.) add binaries for v2.4
5.) switch tag to v2.4.1

It seems v2.4 was pushed a litte early initially. The expected upgrade time for v2.4 is July 18 8AM EST.