### PR TITLE
Upgrade Migaloo to v2.2.5

### DIFF
--- a/migaloo/chain.json
+++ b/migaloo/chain.json
@@ -37,9 +37,9 @@
   },
   "codebase": {
     "git_repo": "https://github.com/White-Whale-Defi-Platform/migaloo-chain",
-    "recommended_version": "v2.0.6",
+    "recommended_version": "v2.2.5",
     "compatible_versions": [
-      "v2.0.6"
+      "v2.2.5"
     ],
     "cosmos_sdk_version": "0.47.3",
     "ibc_go_version": "7.2.0",
@@ -66,13 +66,15 @@
         },
         "cosmwasm_version": "0.28",
         "cosmwasm_enabled": true,
-        "next_version_name": "Alliance Upgrade"
+        "next_version_name": "v2.2.5"
       },
       {
-        "name": "Alliance Upgrade",
-        "recommended_version": "v2.0.6",
+        "name": "v2.2.5",
+        "proposal": 10,
+        "height": 2342302,
+        "recommended_version": "v2.2.5",
         "compatible_versions": [
-          "v2.0.6"
+          "v2.2.5"
         ],
         "cosmos_sdk_version": "0.47.3",
         "ibc_go_version": "7.2.0",

--- a/migaloo/chain.json
+++ b/migaloo/chain.json
@@ -82,7 +82,7 @@
         },
         "cosmwasm_version": "0.28",
         "cosmwasm_enabled": true,
-        "next_version_name": "Alliance Upgrade"
+        "next_version_name": ""
       }
     ]
   },

--- a/migaloo/chain.json
+++ b/migaloo/chain.json
@@ -37,9 +37,9 @@
   },
   "codebase": {
     "git_repo": "https://github.com/White-Whale-Defi-Platform/migaloo-chain",
-    "recommended_version": "v2.2.5",
+    "recommended_version": "v2.2.6",
     "compatible_versions": [
-      "v2.2.5"
+      "v2.2.6"
     ],
     "cosmos_sdk_version": "0.47.3",
     "ibc_go_version": "7.2.0",
@@ -72,9 +72,9 @@
         "name": "v2.2.5",
         "proposal": 10,
         "height": 2342302,
-        "recommended_version": "v2.2.5",
+        "recommended_version": "v2.2.6",
         "compatible_versions": [
-          "v2.2.5"
+          "v2.2.6"
         ],
         "cosmos_sdk_version": "0.47.3",
         "ibc_go_version": "7.2.0",

--- a/migaloo/chain.json
+++ b/migaloo/chain.json
@@ -37,14 +37,15 @@
   },
   "codebase": {
     "git_repo": "https://github.com/White-Whale-Defi-Platform/migaloo-chain",
-    "recommended_version": "v2.0.5",
+    "recommended_version": "v2.0.6",
     "compatible_versions": [
-      "v2.0.0", "v2.0.4", "v2.0.5"
+      "v2.0.6"
     ],
-    "cosmos_sdk_version": "0.45",
+    "cosmos_sdk_version": "0.47.3",
+    "ibc_go_version": "7.2.0",
     "consensus": {
-      "type": "tendermint",
-      "version": "0.34"
+      "type": "cometbft",
+      "version": "0.37.2"
     },
     "cosmwasm_version": "0.28",
     "cosmwasm_enabled": true,
@@ -64,7 +65,24 @@
           "version": "0.34"
         },
         "cosmwasm_version": "0.28",
-        "cosmwasm_enabled": true
+        "cosmwasm_enabled": true,
+        "next_version_name": "Alliance Upgrade"
+      },
+      {
+        "name": "Alliance Upgrade",
+        "recommended_version": "v2.0.6",
+        "compatible_versions": [
+          "v2.0.6"
+        ],
+        "cosmos_sdk_version": "0.47.3",
+        "ibc_go_version": "7.2.0",
+        "consensus": {
+          "type": "cometbft",
+          "version": "0.37.2"
+        },
+        "cosmwasm_version": "0.28",
+        "cosmwasm_enabled": true,
+        "next_version_name": "Alliance Upgrade"
       }
     ]
   },


### PR DESCRIPTION
Prop 9
Height 2311215
https://explorer.silknodes.io/migaloo/gov/9

Estimated Upgrade Time 7/17/2023, 3:30:50 PM EST

Added ibc go version, changed consensus to cometbft