### PR TITLE
agoric-evmos IBC path

### DIFF
--- a/_IBC/agoric-evmos.json
+++ b/_IBC/agoric-evmos.json
@@ -2,22 +2,22 @@
   "$schema": "../ibc_data.schema.json",
   "chain_1": {
     "chain_name": "agoric",
-    "client_id": "07-tendermint-66",
-    "connection_id": "connection-60"
+    "client_id": "07-tendermint-72",
+    "connection_id": "connection-66"
   },
   "chain_2": {
     "chain_name": "evmos",
-    "client_id": "07-tendermint-110",
-    "connection_id": "connection-65"
+    "client_id": "07-tendermint-116",
+    "connection_id": "connection-70"
   },
   "channels": [
     {
       "chain_1": {
-        "channel_id": "channel-51",
+        "channel_id": "channel-57",
         "port_id": "transfer"
       },
       "chain_2": {
-        "channel_id": "channel-81",
+        "channel_id": "channel-85",
         "port_id": "transfer"
       },
       "ordering": "unordered",


### PR DESCRIPTION
The client for the agoric-evmos path expired: 07-tendermint-66 since the last tx from Agoric side was made more than 21 days ago.

As I was the one created the channels, was the only relayer and only one who have made any transactions on this route, as you can see from the path https://www.mintscan.io/evmos/relayers/channel-81/agoric-3/channel-51 I decided to create another connection instead of resurrecting the old one through a governance proposal.

Only accounts with balance on this route are mine:

```
evmosd q bank balances evmos1jall3efpq0tudtp8lxrjt55yd2mv3la0q5apq2
- amount: "21010"
  denom: ibc/8441A8CC19E3C3B5AF15ABA3C6B7B1F54FA90ADD7AA2B519246E5666024AF086
 (0.021010 BLD)
 - amount: "30000"
  denom: ibc/4E676DD4B46FAF79851CCD4F2970377E7FD1A9E8C1E419403173152ACCCD0C64
 (0.03 IST)
```
 
```
 agd q bank balances agoric1k9fuf4gee3340jguwt2u969m8t5kf4zwx56dsp 
balances:
- amount: "100000000000000000"
  denom: ibc/80D5E86278CE910A7A9653CCA7DEB62C817E07AF9C0C657B43191C43DE60B107
  (0.1 axlUSDC)
- amount: "19911000000000000"
  denom: ibc/FA903A861D5A8CD81BB8F0325F2AF782655770AC10E80D8FAF51647B2B61C95E
 (0.019911 EVMOS)
  
```
We'll daily update the new routes so they won't expire until the community starts using them.