### PR TITLE
fix: Update default CHEQ gas values

### DIFF
--- a/cheqd/chain.json
+++ b/cheqd/chain.json
@@ -15,8 +15,8 @@
       {
         "denom": "ncheq",
         "fixed_min_gas_price": 25,
-        "low_gas_price": 25,
-        "average_gas_price": 50,
+        "low_gas_price": 50,
+        "average_gas_price": 75,
         "high_gas_price": 100
       }
     ]

--- a/testnets/cheqdtestnet/chain.json
+++ b/testnets/cheqdtestnet/chain.json
@@ -14,8 +14,8 @@
       {
         "denom": "ncheq",
         "fixed_min_gas_price": 25,
-        "low_gas_price": 25,
-        "average_gas_price": 50,
+        "low_gas_price": 50,
+        "average_gas_price": 75,
         "high_gas_price": 100
       }
     ]


### PR DESCRIPTION
This updates the recommended low/medium/high gas step values for CHEQ/cheqd network. Many validators run with min-gas 50 (although some go lower), which means in some apps, when selecting the "low" gas value as default, transactions fail.