### PR TITLE
Update minimum ixo gas price

### DIFF
--- a/impacthub/chain.json
+++ b/impacthub/chain.json
@@ -18,10 +18,10 @@
     "fee_tokens": [
       {
         "denom": "uixo",
-        "fixed_min_gas_price": 0.015,
-        "low_gas_price": 0.015,
-        "average_gas_price": 0.025,
-        "high_gas_price": 0.04
+        "fixed_min_gas_price": 0.025,
+        "low_gas_price": 0.025,
+        "average_gas_price": 0.4,
+        "high_gas_price": 0.1
       }
     ]
   },


### PR DESCRIPTION
Found through restake the minimum gas validators tend to allow is `0.025uixo`: https://github.com/eco-stake/restake/blob/master/src/networks.json#L127