### PR TITLE
Upgrade Carbon to 2.27.0

### DIFF
--- a/carbon/chain.json
+++ b/carbon/chain.json
@@ -246,13 +246,13 @@
   },
   "codebase": {
     "git_repo": "https://github.com/Switcheo/carbon-bootstrap",
-    "recommended_version": "v2.26.3",
+    "recommended_version": "v2.27.0",
     "compatible_versions": [
-      "v2.26.3"
+      "v2.27.0"
     ],
     "binaries": {
-      "linux/amd64": "https://github.com/Switcheo/carbon-bootstrap/releases/download/v2.26.3/carbond2.26.3-mainnet.linux-amd64.tar.gz",
-      "linux/arm64": "https://github.com/Switcheo/carbon-bootstrap/releases/download/v2.26.3/carbond2.26.3-mainnet.linux-arm64.tar.gz"
+      "linux/amd64": "https://github.com/Switcheo/carbon-bootstrap/releases/download/v2.27.0/carbond2.27.0-mainnet.linux-amd64.tar.gz",
+      "linux/arm64": "https://github.com/Switcheo/carbon-bootstrap/releases/download/v2.27.0/carbond2.27.0-mainnet.linux-arm64.tar.gz"
     },
     "genesis": {
       "genesis_url": "https://github.com/Switcheo/carbon-bootstrap/raw/master/carbon-1/genesis.json"
@@ -299,7 +299,22 @@
         "binaries": {
           "linux/amd64": "https://github.com/Switcheo/carbon-bootstrap/releases/download/v2.26.3/carbond2.26.3-mainnet.linux-amd64.tar.gz",
           "linux/arm64": "https://github.com/Switcheo/carbon-bootstrap/releases/download/v2.26.3/carbond2.26.3-mainnet.linux-arm64.tar.gz"
-        }
+        },
+        "next_version_name": "v2.27.0"
+      },
+      {
+        "name": "v2.27.0",
+        "proposal": 307,
+        "height": 44688221,
+        "recommended_version": "v2.27.0",
+        "compatible_versions": [
+          "v2.27.0"
+        ],
+        "binaries": {
+          "linux/amd64": "https://github.com/Switcheo/carbon-bootstrap/releases/download/v2.27.0/carbond2.27.0-mainnet.linux-amd64.tar.gz",
+          "linux/arm64": "https://github.com/Switcheo/carbon-bootstrap/releases/download/v2.27.0/carbond2.27.0-mainnet.linux-arm64.tar.gz"
+        },
+        "next_version_name": ""
       }
     ]
   },


### PR DESCRIPTION
Prop 307
Height 44688221 
https://scan.carbon.network/governance/proposal/307?net=main

The 2.27.0 is still in "pre-release" but the chain is already live with this version, so this is ok to push now.