### PR TITLE
Upgrade Nolus to v0.4.1

### DIFF
--- a/nolus/chain.json
+++ b/nolus/chain.json
@@ -35,18 +35,18 @@
   },
   "codebase": {
     "git_repo": "https://github.com/nolus-protocol/nolus-core",
-    "recommended_version": "v0.4.0",
+    "recommended_version": "v0.4.1",
     "compatible_versions": [
-      "v0.4.0"
+      "v0.4.1"
     ],
     "cosmos_sdk_version": "0.45",
     "consensus": {
-      "type": "tendermint",
-      "version": "0.34"
+      "type": "cometbft",
+      "version": "0.34.27"
     },
     "cosmwasm_version": "0.31",
     "cosmwasm_enabled": true,
-    "ibc_go_version": "4.3.0",
+    "ibc_go_version": "4.3.1",
     "ics_enabled": [
       "ics20-1",
       "ics27-1"
@@ -73,11 +73,43 @@
       },
       {
         "name": "v0.4.0",
+        "proposal": 5,
+        "height": 207300,
         "recommended_version": "v0.4.0",
         "compatible_versions": [
           "v0.4.0"
         ],
-        "proposal": 5
+        "cosmos_sdk_version": "0.45",
+        "cosmwasm_version": "0.31",
+        "cosmwasm_enabled": true,
+        "ibc_go_version": "4.3.0",
+        "ics_enabled": [
+          "ics20-1",
+          "ics27-1"
+        ],
+        "next_version_name": "v0.4.1"
+      },
+      {
+        "name": "v0.4.1",
+        "proposal": 34,
+        "height": 941000,
+        "recommended_version": "v0.4.1",
+        "compatible_versions": [
+          "v0.4.1"
+        ],
+        "cosmos_sdk_version": "0.45",
+        "consensus": {
+         "type": "cometbft",
+         "version": "0.34.27"
+        },
+        "cosmwasm_version": "0.31",
+        "cosmwasm_enabled": true,
+        "ibc_go_version": "4.3.1",
+        "ics_enabled": [
+          "ics20-1",
+          "ics27-1"
+        ],
+        "next_version_name": ""
       }
     ]
   },


### PR DESCRIPTION
Prop 34
Height 941000
https://explorer.nolus.io/pirin-1/gov/34

Est Upgrade Time 2023-07-25 10:18:19 EST

Also fixed up previous version by adding upgrade height.

Also updated consensus to cometbft per 0.4.1's go.mod file