### PR TITLE
Upgrade Tenet to v11.2.0 ("multichain")

### DIFF
--- a/tenet/chain.json
+++ b/tenet/chain.json
@@ -36,16 +36,16 @@
   },
   "codebase": {
     "git_repo": "https://github.com/tenet-org/tenet-mainnet",
-    "recommended_version": "v11.0.6",
+    "recommended_version": "v11.2.0",
     "compatible_versions": [
-      "v11.0.6"
+      "v11.2.0"
     ],
     "binaries": {
-      "linux/amd64": "https://github.com/tenet-org/tenet-mainnet/releases/download/v11.0.6/tenet-mainnet_11.0.6_Linux_amd64.tar.gz",
-      "linux/arm64": "https://github.com/tenet-org/tenet-mainnet/releases/download/v11.0.6/tenet-mainnet_11.0.6_Darwin_arm64.tar.gz",
-      "darwin/amd64": "https://github.com/tenet-org/tenet-mainnet/releases/download/v11.0.6/tenet-mainnet_11.0.6_Darwin_amd64.tar.gz",
-      "darwin/arm64": "https://github.com/tenet-org/tenet-mainnet/releases/download/v11.0.6/tenet-mainnet_11.0.6_Darwin_arm64.tar.gz",
-      "windows/amd64": "https://github.com/tenet-org/tenet-mainnet/releases/download/v11.0.6/tenet-mainnet_11.0.6_Windows_amd64.zip"
+      "linux/amd64": "https://github.com/tenet-org/tenet-mainnet/releases/download/v11.2.0/tenet-mainnet_11.2.0_Linux_amd64.tar.gz",
+      "linux/arm64": "https://github.com/tenet-org/tenet-mainnet/releases/download/v11.2.0/tenet-mainnet_11.2.0_Linux_arm64.tar.gz",
+      "darwin/amd64": "https://github.com/tenet-org/tenet-mainnet/releases/download/v11.2.0/tenet-mainnet_11.2.0_Darwin_amd64.tar.gz",
+      "darwin/arm64": "https://github.com/tenet-org/tenet-mainnet/releases/download/v11.2.0/tenet-mainnet_11.2.0_Darwin_arm64.tar.gz",
+      "windows/amd64": "https://github.com/tenet-org/tenet-mainnet/releases/download/v11.2.0/tenet-mainnet_11.2.0_Windows_amd64.zip"
     },
     "cosmos_sdk_version": "0.46",
     "consensus": {
@@ -75,7 +75,31 @@
           "darwin/amd64": "https://github.com/tenet-org/tenet-mainnet/releases/download/v11.0.6/tenet-mainnet_11.0.6_Darwin_amd64.tar.gz",
           "darwin/arm64": "https://github.com/tenet-org/tenet-mainnet/releases/download/v11.0.6/tenet-mainnet_11.0.6_Darwin_arm64.tar.gz",
           "windows/amd64": "https://github.com/tenet-org/tenet-mainnet/releases/download/v11.0.6/tenet-mainnet_11.0.6_Windows_amd64.zip"
-        }
+        },
+        "next_version_name": "multichain"
+      },
+      {
+        "name": "multichain",
+        "proposal": 2,
+        "height": 2330000,
+        "recommended_version": "v11.2.0",
+        "compatible_versions": [
+          "v11.2.0"
+        ],
+        "cosmos_sdk_version": "0.46",
+        "consensus": {
+          "type": "tendermint",
+          "version": "0.34"
+        },
+        "ibc_go_version": "6.1.0",
+        "binaries": {
+          "linux/amd64": "https://github.com/tenet-org/tenet-mainnet/releases/download/v11.2.0/tenet-mainnet_11.2.0_Linux_amd64.tar.gz",
+          "linux/arm64": "https://github.com/tenet-org/tenet-mainnet/releases/download/v11.2.0/tenet-mainnet_11.2.0_Linux_arm64.tar.gz",
+          "darwin/amd64": "https://github.com/tenet-org/tenet-mainnet/releases/download/v11.2.0/tenet-mainnet_11.2.0_Darwin_amd64.tar.gz",
+          "darwin/arm64": "https://github.com/tenet-org/tenet-mainnet/releases/download/v11.2.0/tenet-mainnet_11.2.0_Darwin_arm64.tar.gz",
+          "windows/amd64": "https://github.com/tenet-org/tenet-mainnet/releases/download/v11.2.0/tenet-mainnet_11.2.0_Windows_amd64.zip"
+        },
+        "next_version_name": ""
       }
     ]
   },


### PR DESCRIPTION
Prop 2
Height 2,330,000
https://tenet.explorers.guru/proposal/2

Upgrade has already taken place so this is good to push through. 