### PR TITLE
Add "ccv" for Stride v12 upgrade

### DIFF
--- a/stride/chain.json
+++ b/stride/chain.json
@@ -47,7 +47,7 @@
     "ibc_go_version": "7.2.0",
     "genesis": {
       "genesis_url": "https://raw.githubusercontent.com/Stride-Labs/testnet/main/mainnet/genesis.json",
-      "ccv_url": "https://raw.githubusercontent.com/Stride-Labs/mainnet/main/ics-instructions/ccv.json"
+      "ics_ccv_url": "https://raw.githubusercontent.com/Stride-Labs/mainnet/main/ics-instructions/ccv.json"
     },
     "versions": [
       {

--- a/stride/chain.json
+++ b/stride/chain.json
@@ -46,7 +46,8 @@
     "cosmwasm_enabled": true,
     "ibc_go_version": "7.2.0",
     "genesis": {
-      "genesis_url": "https://raw.githubusercontent.com/Stride-Labs/testnet/main/mainnet/genesis.json"
+      "genesis_url": "https://raw.githubusercontent.com/Stride-Labs/testnet/main/mainnet/genesis.json",
+      "ccv_url": "https://raw.githubusercontent.com/Stride-Labs/mainnet/main/ics-instructions/ccv.json"
     },
     "versions": [
       {
@@ -113,7 +114,6 @@
           "version": "0.37.2"
         },
         "ibc_go_version": "7.2.0",
-        "ccv": "https://raw.githubusercontent.com/Stride-Labs/mainnet/main/ics-instructions/ccv.json",
         "next_version_name": ""
       }
     ]

--- a/stride/chain.json
+++ b/stride/chain.json
@@ -113,6 +113,7 @@
           "version": "0.37.2"
         },
         "ibc_go_version": "7.2.0",
+        "ccv": "https://raw.githubusercontent.com/Stride-Labs/mainnet/main/ics-instructions/ccv.json",
         "next_version_name": ""
       }
     ]


### PR DESCRIPTION
Adding "ccv" for v12 as it is necessary to have in the stride config folder along with the normal genesis when going from v11 to v12.