### PR TITLE
Update Chihuahua HUAHUA gas prices

### DIFF
--- a/chihuahua/chain.json
+++ b/chihuahua/chain.json
@@ -14,9 +14,9 @@
       {
         "denom": "uhuahua",
         "fixed_min_gas_price": 0,
-        "low_gas_price": 1,
-        "average_gas_price": 5,
-        "high_gas_price": 10
+        "low_gas_price": 100,
+        "average_gas_price": 250,
+        "high_gas_price": 500
       }
     ]
   },


### PR DESCRIPTION
as per the [Keplr Chain Registry](https://github.com/chainapsis/keplr-chain-registry/blob/6db1a67b377562adf435aa6b9c3d005144962bec/cosmos/chihuahua.json#L41) which has 100, 250, and 500.