### PR TITLE
Update Provenance registration to reflect current version 1.16.0

### DIFF
--- a/provenance/chain.json
+++ b/provenance/chain.json
@@ -33,13 +33,12 @@
   },
   "codebase": {
     "git_repo": "https://github.com/provenance-io/provenance",
-    "recommended_version": "v1.14.1",
+    "recommended_version": "v1.16.0",
     "compatible_versions": [
-      "v1.14.1",
-      "v1.14.0"
+      "v1.16.0"
     ],
     "binaries": {
-      "linux/amd64": "https://github.com/provenance-io/provenance/releases/download/v1.14.1/provenance-linux-amd64-v1.14.1.zip"
+      "linux/amd64": "https://github.com/provenance-io/provenance/releases/download/v1.16.0/provenance-linux-amd64-v1.16.0.zip"
     },
     "genesis": {
       "genesis_url": "https://raw.githubusercontent.com/provenance-io/mainnet/main/pio-mainnet-1/genesis.json"
@@ -47,15 +46,14 @@
     "cosmwasm_enabled": true,
     "versions": [
       {
-        "name": "v1.14.1",
-        "recommended_version": "v1.14.1",
+        "name": "v1.16.0",
+        "recommended_version": "v1.16.0",
         "compatible_versions": [
-          "v1.14.1",
-          "v1.14.0"
+          "v1.16.0"
         ],
         "cosmwasm_enabled": true,
         "binaries": {
-          "linux/amd64": "https://github.com/provenance-io/provenance/releases/download/v1.14.1/provenance-linux-amd64-v1.14.1.zip"
+          "linux/amd64": "https://github.com/provenance-io/provenance/releases/download/v1.16.0/provenance-linux-amd64-v1.16.0.zip"
         }
       }
     ]
@@ -72,14 +70,9 @@
         "provider": "TAKESHI"
       },
       {
-        "id": "4bd2fb0ae5a123f1db325960836004f980ee09b4",
-        "address": "seed-0.provenance.io:26656",
-        "provider": "figure"
-      },
-      {
-        "id": "048b991204d7aac7209229cbe457f622eed96e5d",
-        "address": "seed-1.provenance.io:26656",
-        "provider": "figure"
+        "id": "40f9493fa7ab4259159240e9a8ba12f90743079b",
+        "address": "seed.provenance.io:26656",
+        "provider": "Figure"
       },
       {
         "id": "ad3386812bb9f2fee4e9da6d9f37547afc948977",
@@ -96,7 +89,7 @@
       },
       {
         "address": "https://rpc.provenance.io/",
-        "provider": "figure"
+        "provider": "Figure"
       },
       {
         "address": "https://rpc-provenance-ia.cosmosia.notional.ventures/",
@@ -114,7 +107,7 @@
       },
       {
         "address": "https://api.provenance.io",
-        "provider": "figure"
+        "provider": "Figure"
       },
       {
         "address": "https://api-provenance-ia.cosmosia.notional.ventures/",
@@ -138,14 +131,9 @@
   },
   "explorers": [
     {
-      "kind": "provenance",
+      "kind": "Provenance",
       "url": "https://explorer.provenance.io",
       "tx_page": "https://explorer.provenance.io/tx/${txHash}"
-    },
-    {
-      "kind": "bigdipper",
-      "url": "https://bigdipper.provenance.io",
-      "tx_page": "https://bigdipper.provenance.io/transactions/${txHash}"
     },
     {
       "kind": "hubble",

--- a/provenance/chain.json
+++ b/provenance/chain.json
@@ -186,6 +186,17 @@
           "v1.14.0",
           "v1.14.1"
         ],
+        "cosmos_sdk_version": "0.46.10",
+        "consensus": {
+          "type": "tendermint",
+          "version": "0.34.26"
+        },
+        "cosmwasm_version": "0.30",
+        "cosmwasm_enabled": true,
+        "ibc_go_version": "6.1.0",
+        "ics_enabled": [
+          "ics20-1"
+        ],
         "binaries": {
           "linux/amd64": "https://github.com/provenance-io/provenance/releases/download/v1.14.1/provenance-linux-amd64-v1.14.1.zip"
         },

--- a/provenance/chain.json
+++ b/provenance/chain.json
@@ -53,8 +53,8 @@
     "cosmwasm_enabled": true,
     "ibc_go_version": "6.2.0",
     "ics_enabled": [
-      "ics20-1"
-      "ics-27"
+      "ics20-1",
+      "ics27-1"
     ],
     "versions": [
       {
@@ -111,7 +111,7 @@
         "height": 2641250,
         "recommended_version": "v1.7.6",
         "compatible_versions": [
-          "v1.7.0"
+          "v1.7.0",
           "v1.7.1",
           "v1.7.2",
           "v1.7.3",
@@ -127,8 +127,8 @@
         "height": 4808400,
         "recommended_version": "v1.8.2",
         "compatible_versions": [
-          "v1.8.0"
-          "v1.8.1"
+          "v1.8.0",
+          "v1.8.1",
           "v1.8.2"
         ],
         "next_version_name": "lava"
@@ -243,8 +243,8 @@
         "cosmwasm_enabled": true,
         "ibc_go_version": "6.2.0",
         "ics_enabled": [
-          "ics20-1"
-          "ics-27"
+          "ics20-1",
+          "ics27-1"
         ],
         "binaries": {
           "linux/amd64": "https://github.com/provenance-io/provenance/releases/download/v1.16.0/provenance-linux-amd64-v1.16.0.zip"

--- a/provenance/chain.json
+++ b/provenance/chain.json
@@ -41,17 +41,200 @@
       "linux/amd64": "https://github.com/provenance-io/provenance/releases/download/v1.16.0/provenance-linux-amd64-v1.16.0.zip"
     },
     "genesis": {
+      "name": "v1.0.1",
       "genesis_url": "https://raw.githubusercontent.com/provenance-io/mainnet/main/pio-mainnet-1/genesis.json"
     },
+    "cosmos_sdk_version": "0.46.13",
+    "consensus": {
+      "type": "tendermint",
+      "version": "0.34.28"
+    },
+    "cosmwasm_version": "0.30",
     "cosmwasm_enabled": true,
+    "ibc_go_version": "6.2.0",
+    "ics_enabled": [
+      "ics20-1"
+      "ics-27"
+    ],
     "versions": [
       {
-        "name": "v1.16.0",
+        "name": "v1.0.1",
+        "tag": "v1.0.1",
+        "height": 0,
+        "next_version_name": "bluetiful"
+      },
+      {
+        "name": "bluetiful",
+        "tag": "v1.3.1",
+        "height": 352000,
+        "recommended_version": "v1.3.1",
+        "compatible_versions": [
+          "v1.3.0",
+          "v1.3.1"
+        ],
+        "next_version_name": "citrine"
+      },
+      {
+        "name": "citrine",
+        "tag": "v1.4.1",
+        "height": 940500,
+        "recommended_version": "v1.4.1",
+        "compatible_versions": [
+          "v1.4.0",
+          "v1.4.1"
+        ],
+        "next_version_name": "desert"
+      },
+      {
+        "name": "desert",
+        "tag": "v1.5.0",
+        "height": 1442070,
+        "recommended_version": "v1.5.0",
+        "compatible_versions": [
+          "v1.5.0"
+        ],
+        "next_version_name": "desert"
+      },
+      {
+        "name": "usdf.c-hotfix",
+        "tag": "v1.6.0",
+        "height": 2000000,
+        "recommended_version": "v1.6.0",
+        "compatible_versions": [
+          "v1.6.0"
+        ],
+        "next_version_name": "feldgrau"
+      },
+      {
+        "name": "feldgrau",
+        "tag": "v1.7.6",
+        "height": 2641250,
+        "recommended_version": "v1.7.6",
+        "compatible_versions": [
+          "v1.7.0"
+          "v1.7.1",
+          "v1.7.2",
+          "v1.7.3",
+          "v1.7.4",
+          "v1.7.5",
+          "v1.7.6"
+        ],
+        "next_version_name": "green"
+      },
+      {
+        "name": "green",
+        "tag": "v1.8.2",
+        "height": 4808400,
+        "recommended_version": "v1.8.2",
+        "compatible_versions": [
+          "v1.8.0"
+          "v1.8.1"
+          "v1.8.2"
+        ],
+        "next_version_name": "lava"
+      },
+      {
+        "name": "lava",
+        "tag": "v1.10.0",
+        "height": 5689885,
+        "recommended_version": "v1.10.0",
+        "compatible_versions": [
+          "v1.10.0"
+        ],
+        "next_version_name": "mango"
+      },
+      {
+        "name": "mango",
+        "tag": "v1.11.1",
+        "height": 6512577,
+        "recommended_version": "v1.11.1",
+        "compatible_versions": [
+          "v1.11.0",
+          "v1.11.1"
+        ],
+        "next_version_name": "neoncarrot"
+      },
+      {
+        "name": "neoncarrot",
+        "tag": "v1.12.2",
+        "height": 7334444,
+        "recommended_version": "v1.12.2",
+        "compatible_versions": [
+          "v1.12.0",
+          "v1.12.1",
+          "v1.12.2"
+        ],
+        "next_version_name": "ochre"
+      },
+      {
+        "name": "ochre",
+        "tag": "v1.13.1",
+        "height": 8485555,
+        "recommended_version": "v1.13.1",
+        "compatible_versions": [
+          "v1.13.0",
+          "v1.13.1"
+        ],
+        "next_version_name": "paua"
+      },
+      {
+        "name": "paua",
+        "tag": "v1.14.1",
+        "height": 9828888,
+        "recommended_version": "v1.14.1",
+        "compatible_versions": [
+          "v1.14.0",
+          "v1.14.1"
+        ],
+        "binaries": {
+          "linux/amd64": "https://github.com/provenance-io/provenance/releases/download/v1.14.1/provenance-linux-amd64-v1.14.1.zip"
+        },
+        "next_version_name": "quicksilver"
+      },
+      {
+        "name": "quicksilver",
+        "tag": "v1.15.2",
+        "height": 11130222,
+        "recommended_version": "v1.15.2",
+        "compatible_versions": [
+          "v1.15.0",
+          "v1.15.1",
+          "v1.15.2"
+        ],
+        "cosmos_sdk_version": "0.46.10",
+        "consensus": {
+          "type": "tendermint",
+          "version": "0.34.26"
+        },
+        "ibc_go_version": "6.1.1",
+        "ics_enabled": [
+          "ics20-1"
+        ],
+        "binaries": {
+          "linux/amd64": "https://github.com/provenance-io/provenance/releases/download/v1.15.2/provenance-linux-amd64-v1.15.2.zip"
+        },
+        "next_version_name": "rust"
+      },
+      {
+        "name": "rust",
+        "tag": "v1.16.0",
+        "height": 11842000,
         "recommended_version": "v1.16.0",
         "compatible_versions": [
           "v1.16.0"
         ],
+        "cosmos_sdk_version": "0.46.13",
+        "consensus": {
+          "type": "tendermint",
+          "version": "0.34.28"
+        },
+        "cosmwasm_version": "0.30",
         "cosmwasm_enabled": true,
+        "ibc_go_version": "6.2.0",
+        "ics_enabled": [
+          "ics20-1"
+          "ics-27"
+        ],
         "binaries": {
           "linux/amd64": "https://github.com/provenance-io/provenance/releases/download/v1.16.0/provenance-linux-amd64-v1.16.0.zip"
         }


### PR DESCRIPTION
House keeping for Provenance chain registry entry:
- Updated recommended versions to match current mainnet (1.16.0).
- Updated Figure seed node address and identifier to match current running instance.
- Removed discontinued BigDipper instance hosted by Provenance