### PR TITLE
Add ICS CCV url to Chain Schema

### DIFF
--- a/chain.schema.json
+++ b/chain.schema.json
@@ -258,6 +258,10 @@
             "genesis_url": {
               "type": "string",
               "format": "uri"
+            },
+            "ics_ccv_url": {
+              "type": "string",
+              "format": "uri"
             }
           },
           "additionalProperties": false


### PR DESCRIPTION
to allow for ICS additions. Goes right below genesis_url