### PR TITLE
Non-consensus upgrade for Neutron to v1.0.4

### DIFF
--- a/neutron/chain.json
+++ b/neutron/chain.json
@@ -31,8 +31,10 @@
   },
   "codebase": {
     "git_repo": "https://github.com/neutron-org/neutron",
-    "recommended_version": "v1.0.1",
-    "compatible_versions": [],
+    "recommended_version": "v1.0.4",
+    "compatible_versions": [
+      "v1.0.3", "v1.0.4"
+    ],
     "cosmos_sdk_version": "0.45",
     "consensus": {
       "type": "tendermint",
@@ -47,8 +49,10 @@
     "versions": [
       {
         "name": "v1.0.1",
-        "recommended_version": "v1.0.1",
-        "compatible_versions": [],
+        "recommended_version": "v1.0.4",
+        "compatible_versions": [
+          "v1.0.3", "v1.0.4"
+        ],
         "cosmos_sdk_version": "0.45",
         "consensus": {
           "type": "tendermint",


### PR DESCRIPTION
Non-consensus upgrade for validators.

Source:
https://github.com/neutron-org/neutron/releases/tag/v1.0.4

https://github.com/neutron-org/mainnet-assets/tree/main/upgrades/v1.0.4