### PR TITLE
Add "windows/arm64" to schema

### DIFF
--- a/chain.schema.json
+++ b/chain.schema.json
@@ -197,6 +197,10 @@
             "windows/amd64": {
               "type": "string",
               "format": "uri"
+            },
+            "windows/arm64": {
+              "type": "string",
+              "format": "uri"
             }
           },
           "additionalProperties": false
@@ -376,6 +380,10 @@
                     "format": "uri"
                   },
                   "windows/amd64": {
+                    "type": "string",
+                    "format": "uri"
+                  },
+                  "windows/arm64": {
                     "type": "string",
                     "format": "uri"
                   }


### PR DESCRIPTION
Cosmos Hub now offers a windows/arm64 pre-built binary in their chain assets. 