### PR TITLE
Patch Carbon to v2.27.3

### DIFF
--- a/carbon/chain.json
+++ b/carbon/chain.json
@@ -246,13 +246,13 @@
   },
   "codebase": {
     "git_repo": "https://github.com/Switcheo/carbon-bootstrap",
-    "recommended_version": "v2.27.0",
+    "recommended_version": "v2.27.3",
     "compatible_versions": [
-      "v2.27.0"
+      "v2.27.3"
     ],
     "binaries": {
-      "linux/amd64": "https://github.com/Switcheo/carbon-bootstrap/releases/download/v2.27.0/carbond2.27.0-mainnet.linux-amd64.tar.gz",
-      "linux/arm64": "https://github.com/Switcheo/carbon-bootstrap/releases/download/v2.27.0/carbond2.27.0-mainnet.linux-arm64.tar.gz"
+      "linux/amd64": "https://github.com/Switcheo/carbon-bootstrap/releases/download/v2.27.3/carbond2.27.3-mainnet.linux-amd64.tar.gz",
+      "linux/arm64": "https://github.com/Switcheo/carbon-bootstrap/releases/download/v2.27.3/carbond2.27.3-mainnet.linux-arm64.tar.gz"
     },
     "genesis": {
       "genesis_url": "https://github.com/Switcheo/carbon-bootstrap/raw/master/carbon-1/genesis.json"
@@ -306,13 +306,13 @@
         "name": "v2.27.0",
         "proposal": 307,
         "height": 44688221,
-        "recommended_version": "v2.27.0",
+        "recommended_version": "v2.27.3",
         "compatible_versions": [
-          "v2.27.0"
+          "v2.27.3"
         ],
         "binaries": {
-          "linux/amd64": "https://github.com/Switcheo/carbon-bootstrap/releases/download/v2.27.0/carbond2.27.0-mainnet.linux-amd64.tar.gz",
-          "linux/arm64": "https://github.com/Switcheo/carbon-bootstrap/releases/download/v2.27.0/carbond2.27.0-mainnet.linux-arm64.tar.gz"
+          "linux/amd64": "https://github.com/Switcheo/carbon-bootstrap/releases/download/v2.27.3/carbond2.27.3-mainnet.linux-amd64.tar.gz",
+          "linux/arm64": "https://github.com/Switcheo/carbon-bootstrap/releases/download/v2.27.3/carbond2.27.3-mainnet.linux-arm64.tar.gz"
         }
       }
     ]


### PR DESCRIPTION
Carbon had a chain halt and v2.27.3 is a required patch that has already gone live.

Source:

https://github.com/Switcheo/carbon-bootstrap/blob/master/upgrade/v2.27.3.md