### PR TITLE
Upgrade Carbon to v2.28.0

### DIFF
--- a/carbon/chain.json
+++ b/carbon/chain.json
@@ -246,13 +246,13 @@
   },
   "codebase": {
     "git_repo": "https://github.com/Switcheo/carbon-bootstrap",
-    "recommended_version": "v2.27.3",
+    "recommended_version": "v2.28.1",
     "compatible_versions": [
-      "v2.27.3"
+      "v2.28.1"
     ],
     "binaries": {
-      "linux/amd64": "https://github.com/Switcheo/carbon-bootstrap/releases/download/v2.27.3/carbond2.27.3-mainnet.linux-amd64.tar.gz",
-      "linux/arm64": "https://github.com/Switcheo/carbon-bootstrap/releases/download/v2.27.3/carbond2.27.3-mainnet.linux-arm64.tar.gz"
+      "linux/amd64": "https://github.com/Switcheo/carbon-bootstrap/releases/download/v2.28.1/carbond2.28.1-mainnet.linux-amd64.tar.gz",
+      "linux/arm64": "https://github.com/Switcheo/carbon-bootstrap/releases/download/v2.28.1/carbond2.28.1-mainnet.linux-arm64.tar.gz"
     },
     "genesis": {
       "genesis_url": "https://github.com/Switcheo/carbon-bootstrap/raw/master/carbon-1/genesis.json"
@@ -313,7 +313,22 @@
         "binaries": {
           "linux/amd64": "https://github.com/Switcheo/carbon-bootstrap/releases/download/v2.27.3/carbond2.27.3-mainnet.linux-amd64.tar.gz",
           "linux/arm64": "https://github.com/Switcheo/carbon-bootstrap/releases/download/v2.27.3/carbond2.27.3-mainnet.linux-arm64.tar.gz"
-        }
+        },
+        "next_version_name": "v2.28.0"
+      },
+      {
+        "name": "v2.28.0",
+        "proposal": 308,
+        "height": 45469721,
+        "recommended_version": "v2.28.1",
+        "compatible_versions": [
+          "v2.28.1"
+        ],
+        "binaries": {
+          "linux/amd64": "https://github.com/Switcheo/carbon-bootstrap/releases/download/v2.28.1/carbond2.28.1-mainnet.linux-amd64.tar.gz",
+          "linux/arm64": "https://github.com/Switcheo/carbon-bootstrap/releases/download/v2.28.1/carbond2.28.1-mainnet.linux-arm64.tar.gz"
+        },
+        "next_version_name": ""
       }
     ]
   },


### PR DESCRIPTION
This upgrade height has already passed and has been patched to v2.28.1

https://scan.carbon.network/governance/proposal/308?net=main