### PR TITLE
Move passage to archive dir

### DIFF
--- a/_archive/passage/passage-1/assetlist.json
+++ b/_archive/passage/passage-1/assetlist.json
@@ -1,6 +1,6 @@
 {
   "$schema": "../assetlist.schema.json",
-  "chain_name": "passage1",
+  "chain_name": "passage",
   "assets": [
     {
       "description": "The native staking and governance token of the Passage chain.",

--- a/_archive/passage/passage-1/chain.json
+++ b/_archive/passage/passage-1/chain.json
@@ -1,6 +1,6 @@
 {
   "$schema": "../chain.schema.json",
-  "chain_name": "passage1",
+  "chain_name": "passage",
   "chain_id": "passage-1",
   "pretty_name": "Passage",
   "status": "killed",


### PR DESCRIPTION
@JeremyParish69 this is what I was trying to communicate in the chat, I figured creating a PR to discuss might make it more clear.



Under `_archive` would be the original chain name, `passage`, then a step down would be the chain-id, `passage-1`. If they continued to use `passage-1`, the chain-id could be incremented: `passage-1_1`, etc... however, that wouldn't be the default behavior

Here's the start of the discussion: https://t.me/c/1888994636/235