### PR TITLE
Upgrade Cosmos Hub testnet to v11.0.0

### DIFF
--- a/testnets/cosmoshubtestnet/chain.json
+++ b/testnets/cosmoshubtestnet/chain.json
@@ -46,7 +46,35 @@
     },
     "versions": [
       {
-        "name": "v11.0.0",
+        "name": "v9.0.1",
+        "recommended_version": "v9.0.1",
+        "compatible_versions": [
+          "v9.0.1"
+        ],
+        "binaries": {
+          "linux/amd64": "https://github.com/cosmos/gaia/releases/download/v9.0.1/gaiad-v9.0.1-linux-amd64",
+          "linux/arm64": "https://github.com/cosmos/gaia/releases/download/v9.0.1/gaiad-v9.0.1-linux-arm64",
+          "darwin/amd64": "https://github.com/cosmos/gaia/releases/download/v9.0.1/gaiad-v9.0.1-darwin-amd64",
+          "darwin/arm64": "https://github.com/cosmos/gaia/releases/download/v9.0.1/gaiad-v9.0.1-darwin-arm64",
+          "windows/amd64": "https://github.com/cosmos/gaia/releases/download/v9.0.1/gaiad-v9.0.1-windows-amd64.exe"
+        }
+      },
+      {
+        "name": "v10.0.1",
+        "recommended_version": "v10.0.1",
+        "compatible_versions": [
+          "v10.0.1"
+        ],
+        "binaries": {
+          "linux/amd64": "https://github.com/cosmos/gaia/releases/download/v10.0.1/gaiad-v10.0.1-linux-amd64",
+          "linux/arm64": "https://github.com/cosmos/gaia/releases/download/v10.0.1/gaiad-v10.0.1-linux-arm64",
+          "darwin/amd64": "https://github.com/cosmos/gaia/releases/download/v10.0.1/gaiad-v10.0.1-darwin-amd64",
+          "darwin/arm64": "https://github.com/cosmos/gaia/releases/download/v10.0.1/gaiad-v10.0.1-darwin-arm64",
+          "windows/amd64": "https://github.com/cosmos/gaia/releases/download/v10.0.1/gaiad-v10.0.1-windows-amd64.exe"
+        }
+      },
+      {
+        "name": "v11",
         "recommended_version": "v11.0.0",
         "compatible_versions": [
           "v11.0.0"

--- a/testnets/cosmoshubtestnet/chain.json
+++ b/testnets/cosmoshubtestnet/chain.json
@@ -29,47 +29,35 @@
   },
   "codebase": {
     "git_repo": "https://github.com/cosmos/gaia",
-    "recommended_version": "v10.0.1",
+    "recommended_version": "v11.0.0",
     "compatible_versions": [
-      "v10.0.1"
+      "v11.0.0"
     ],
     "binaries": {
-      "linux/amd64": "https://github.com/cosmos/gaia/releases/download/v10.0.1/gaiad-v10.0.1-linux-amd64",
-      "linux/arm64": "https://github.com/cosmos/gaia/releases/download/v10.0.1/gaiad-v10.0.1-linux-arm64",
-      "darwin/amd64": "https://github.com/cosmos/gaia/releases/download/v10.0.1/gaiad-v10.0.1-darwin-amd64",
-      "darwin/arm64": "https://github.com/cosmos/gaia/releases/download/v10.0.1/gaiad-v10.0.1-darwin-arm64",
-      "windows/amd64": "https://github.com/cosmos/gaia/releases/download/v10.0.1/gaiad-v10.0.1-windows-amd64.exe"
+      "linux/amd64": "https://github.com/cosmos/gaia/releases/download/v11.0.0/gaiad-v11.0.0-linux-amd64",
+      "linux/arm64": "https://github.com/cosmos/gaia/releases/download/v11.0.0/gaiad-v11.0.0-linux-arm64",
+      "darwin/amd64": "https://github.com/cosmos/gaia/releases/download/v11.0.0/gaiad-v11.0.0-darwin-amd64",
+      "darwin/arm64": "https://github.com/cosmos/gaia/releases/download/v11.0.0/gaiad-v11.0.0-darwin-arm64",
+      "windows/amd64": "https://github.com/cosmos/gaia/releases/download/v11.0.0/gaiad-v11.0.0-windows-amd64.exe",
+      "windows/arm64": "https://github.com/cosmos/gaia/releases/download/v11.0.0/gaiad-v11.0.0-windows-arm64.exe"
     },
     "genesis": {
       "genesis_url": "https://github.com/cosmos/testnets/raw/master/public/genesis.json.gz"
     },
     "versions": [
       {
-        "name": "v9.0.1",
-        "recommended_version": "v9.0.1",
+        "name": "v11.0.0",
+        "recommended_version": "v11.0.0",
         "compatible_versions": [
-          "v9.0.1"
+          "v11.0.0"
         ],
         "binaries": {
-          "linux/amd64": "https://github.com/cosmos/gaia/releases/download/v9.0.1/gaiad-v9.0.1-linux-amd64",
-          "linux/arm64": "https://github.com/cosmos/gaia/releases/download/v9.0.1/gaiad-v9.0.1-linux-arm64",
-          "darwin/amd64": "https://github.com/cosmos/gaia/releases/download/v9.0.1/gaiad-v9.0.1-darwin-amd64",
-          "darwin/arm64": "https://github.com/cosmos/gaia/releases/download/v9.0.1/gaiad-v9.0.1-darwin-arm64",
-          "windows/amd64": "https://github.com/cosmos/gaia/releases/download/v9.0.1/gaiad-v9.0.1-windows-amd64.exe"
-        }
-      },
-      {
-        "name": "v10.0.1",
-        "recommended_version": "v10.0.1",
-        "compatible_versions": [
-          "v10.0.1"
-        ],
-        "binaries": {
-          "linux/amd64": "https://github.com/cosmos/gaia/releases/download/v10.0.1/gaiad-v10.0.1-linux-amd64",
-          "linux/arm64": "https://github.com/cosmos/gaia/releases/download/v10.0.1/gaiad-v10.0.1-linux-arm64",
-          "darwin/amd64": "https://github.com/cosmos/gaia/releases/download/v10.0.1/gaiad-v10.0.1-darwin-amd64",
-          "darwin/arm64": "https://github.com/cosmos/gaia/releases/download/v10.0.1/gaiad-v10.0.1-darwin-arm64",
-          "windows/amd64": "https://github.com/cosmos/gaia/releases/download/v10.0.1/gaiad-v10.0.1-windows-amd64.exe"
+          "linux/amd64": "https://github.com/cosmos/gaia/releases/download/v11.0.0/gaiad-v11.0.0-linux-amd64",
+          "linux/arm64": "https://github.com/cosmos/gaia/releases/download/v11.0.0/gaiad-v11.0.0-linux-arm64",
+          "darwin/amd64": "https://github.com/cosmos/gaia/releases/download/v11.0.0/gaiad-v11.0.0-darwin-amd64",
+          "darwin/arm64": "https://github.com/cosmos/gaia/releases/download/v11.0.0/gaiad-v11.0.0-darwin-arm64",
+          "windows/amd64": "https://github.com/cosmos/gaia/releases/download/v11.0.0/gaiad-v11.0.0-windows-amd64.exe",
+          "windows/arm64": "https://github.com/cosmos/gaia/releases/download/v11.0.0/gaiad-v11.0.0-windows-arm64.exe"
         }
       }
     ]


### PR DESCRIPTION
Hi! We have upgraded the Cosmos Hub Public Testnet to Gaia `v11.0.0`:
https://github.com/cosmos/testnets/tree/master/public

- I kept v9 and v10 in the version history array

Thanks!