### PR TITLE
Add Versions schema + Osmosis versions

### DIFF
--- a/chain.schema.json
+++ b/chain.schema.json
@@ -298,6 +298,10 @@
                 "type": "number",
                 "description": "Proposal that will officially signal community acceptance of the upgrade."
               },
+              "previous_version_name": {
+                "type": "string",
+                "description": "[Optional] Name of the previous version"
+              },
               "next_version_name": {
                 "type": "string",
                 "description": "[Optional] Name of the following version"

--- a/osmosis/versions.json
+++ b/osmosis/versions.json
@@ -1,0 +1,162 @@
+{
+  "$schema": "../chain.schema.json",
+  "chain_name": "osmosis",
+  "versions": [
+    {
+      "name": "v3",
+      "tag": "v3.1.0",
+      "height": 0,
+      "binaries": {
+        "darwin/amd64": "https://github.com/osmosis-labs/osmosis/releases/download/v3.1.0/osmosisd-3.1.0-darwin-amd64?checksum=sha256:a532f25ae754d2573f6a3c91ba59496ddb9f6766ccf6f69f408f6e1597144a74",
+        "linux/amd64": "https://github.com/osmosis-labs/osmosis/releases/download/v3.1.0/osmosisd-3.1.0-linux-amd64?checksum=sha256:6a73d75e9c75ea402c13edc8c5c4ed08e26c5d8e517d540a9ca8b7e7afa67f79",
+        "linux/arm64": "https://github.com/osmosis-labs/osmosis/releases/download/v3.1.0/osmosisd-3.1.0-linux-arm64?checksum=sha256:893f8a9786ae76d4217260201cd94ab67010f68d98b9676a9b31c0a5e68d1eae"
+      },
+      "next_version_name": "v4"
+    },
+    {
+      "name": "v4",
+      "tag": "v4.2.0",
+      "height": 1314500,
+      "binaries": {
+        "darwin/amd64": "https://github.com/osmosis-labs/osmosis/releases/download/v4.2.0/osmosisd-4.2.0-darwin-amd64?checksum=sha256:eee08350b223dd06a2aa16aab44aa51eb116f6267924ee1e788ca28fb54fe02d",
+        "linux/amd64": "https://github.com/osmosis-labs/osmosis/releases/download/v4.2.0/osmosisd-4.2.0-linux-amd64?checksum=sha256:a11c61a737983d176f23ce83fa5ff985000ce8d5107d738ee6fa7d59b8dd3053",
+        "linux/arm64": "https://github.com/osmosis-labs/osmosis/releases/download/v4.2.0/osmosisd-4.2.0-linux-arm64?checksum=sha256:41260be15e874fbc6cc49757d9fe3d4e459634729e2b745923e508e9cb26f837"
+      },
+      "previous_version_name": "v3",
+      "next_version_name": "v5"
+    },
+    {
+      "name": "v5",
+      "tag": "v6.4.0",
+      "height": 2383300,
+      "binaries": {
+        "darwin/amd64": "https://github.com/osmosis-labs/osmosis/releases/download/v6.4.0/osmosisd-6.4.0-darwin-amd64?checksum=sha256:735c7828b0bc311381f4c18081fa648f849df03aeccf173425cc52a634e3c7d8",
+        "linux/amd64": "https://github.com/osmosis-labs/osmosis/releases/download/v6.4.0/osmosisd-6.4.0-linux-amd64?checksum=sha256:e4017da5d1a0a3b37b4f6936ba7ef16f39972ae25f95feae43e506f14933cf94",
+        "linux/arm64": "https://github.com/osmosis-labs/osmosis/releases/download/v6.4.0/osmosisd-6.4.0-linux-arm64?checksum=sha256:a101bb3feb0419293a3ecee17d732a312bf9e864a829905ed509c65b5944040b"
+      },
+      "previous_version_name": "v4",
+      "next_version_name": "v7"
+    },
+    {
+      "name": "v7",
+      "tag": "v8.0.0",
+      "height": 3401000,
+      "binaries": {
+        "linux/amd64": "https://github.com/osmosis-labs/osmosis/releases/download/v8.0.0/osmosisd-8.0.0-linux-amd64?checksum=sha256:4559ffe7d1e83b1519c2d45a709d35a89b51f8b35f8bba3b58aef92e667e254c"
+      },
+      "previous_version_name": "v5",
+      "next_version_name": "v9"
+    },
+    {
+      "name": "v9",
+      "tag": "v10.1.1",
+      "height": 4707300,
+      "binaries": {
+        "linux/amd64": "https://github.com/osmosis-labs/osmosis/releases/download/v10.1.1/osmosisd-10.1.1-linux-amd64?checksum=sha256:aeae58f8b0be86d5e6e3aec1a8774eab4947207c88c7d4f309c46da98f6694e8",
+        "linux/arm64": "https://github.com/osmosis-labs/osmosis/releases/download/v10.1.1/osmosisd-10.1.1-linux-arm64?checksum=sha256:d2c672ffa9782687f91d8d03bd23fdf8bd2fbe8b79c9cfcf8e9d302a1238a12c"
+      },
+      "previous_version_name": "v7",
+      "next_version_name": "v11"
+    },
+    {
+      "name": "v11",
+      "tag": "v11.0.1",
+      "height": 5432450,
+      "binaries": {
+        "linux/amd64": "https://github.com/osmosis-labs/osmosis/releases/download/v11.0.1/osmosisd-11.0.1-linux-amd64?checksum=sha256:41b8fd2345a5e5b77ee5ed9b9ec5370d94bd1b1aa0d4ac2ac0ab02ee98ddd0d8",
+        "linux/arm64": "https://github.com/osmosis-labs/osmosis/releases/download/v11.0.1/osmosisd-11.0.1-linux-arm64?checksum=sha256:267776170495ecaa831238ea8994f8790a379663c9ae47a2e93e5beceafd8e1d"
+      },
+      "previous_version_name": "v9",
+      "next_version_name": "v12"
+    },
+    {
+      "name": "v12",
+      "tag": "v12.3.0",
+      "height": 6246000,
+      "binaries": {
+        "linux/amd64": "https://github.com/osmosis-labs/osmosis/releases/download/v12.3.0/osmosisd-12.3.0-linux-amd64?checksum=sha256:958210c919d13c281896fa9773c323c5534f0fa46d74807154f737609a00db70",
+        "linux/arm64": "https://github.com/osmosis-labs/osmosis/releases/download/v12.3.0/osmosisd-12.3.0-linux-arm64?checksum=sha256:a931618c8a839c30e5cecfd2a88055cda1d68cc68557fe3303fe14e2de3bef8f"
+      },
+      "previous_version_name": "v11",
+      "next_version_name": "v13"
+    },
+    {
+      "name": "v13",
+      "tag": "v13.1.2",
+      "height": 7241500,
+      "binaries": {
+        "linux/amd64": "https://github.com/osmosis-labs/osmosis/releases/download/v13.1.2/osmosisd-13.1.2-linux-amd64?checksum=sha256:67ed53046667c72ec6bfe962bcb4d6b122610876b3adf75fb7820ce52c34872d",
+        "linux/arm64": "https://github.com/osmosis-labs/osmosis/releases/download/v13.1.2/osmosisd-13.1.2-linux-arm64?checksum=sha256:ad35c2a8d55852fa28187a55bdeb983494c07923f2a8a9f4479fb044d8d62bd9"
+      },
+      "previous_version_name": "v12",
+      "next_version_name": "v14"
+    },
+    {
+      "name": "v14",
+      "tag": "v14.0.1",
+      "height": 7937500,
+      "binaries": {
+        "linux/amd64": "https://github.com/osmosis-labs/osmosis/releases/download/v14.0.1/osmosisd-14.0.1-linux-amd64?checksum=sha256:2cc4172bcf000f0f06b30b16864d875a8de2ee12df994a593dfd52a506851bce",
+        "linux/arm64": "https://github.com/osmosis-labs/osmosis/releases/download/v14.0.1/osmosisd-14.0.1-linux-arm64?checksum=sha256:9a44c17d239c8d9afd19d0ff0bd14ca883fb9e9fbf69aff18c2607ffa6bff378"
+      },
+      "previous_version_name": "v13",
+      "next_version_name": "v15"
+    },
+    {
+      "name": "v15",
+      "tag": "v15.2.0",
+      "height": 8732500,
+      "recommended_version": "v15.2.0",
+      "compatible_versions": [
+        "v15.2.0",
+        "v15.1.2",
+        "v15.0.0"
+      ],
+      "cosmos_sdk_version": "0.46.10",
+      "consensus": {
+        "type": "tendermint",
+        "version": "0.34.24"
+      },
+      "cosmwasm_version": "0.30",
+      "cosmwasm_enabled": true,
+      "ibc_go_version": "4.3.1",
+      "ics_enabled": [
+        "ics20-1"
+      ],
+      "binaries": {
+        "linux/amd64": "https://github.com/osmosis-labs/osmosis/releases/download/v15.2.0/osmosisd-15.2.0-linux-amd64?checksum=sha256:3aab2f2668cb5a713d5770e46a777ef01c433753378702d9ae941aa2d1ee5618",
+        "linux/arm64": "https://github.com/osmosis-labs/osmosis/releases/download/v15.2.0/osmosisd-15.2.0-linux-arm64?checksum=sha256:e158d30707a0ea51482237f99676223e81ce5a353966a5c83791d2662a930f35"
+      },
+      "previous_version_name": "v14",
+      "next_version_name": "v16"
+    },
+    {
+      "name": "v16",
+      "tag": "v16.1.1",
+      "height": 10517000,
+      "recommended_version": "v16.1.1",
+      "compatible_versions": [
+        "v16.1.0",
+        "v16.1.1"
+      ],
+      "cosmos_sdk_version": "osmosis-labs/cosmos-sdk@0.45.0-rc1.0.20230703010110-ed4eb883f2a6",
+      "consensus": {
+        "type": "tendermint",
+        "version": "informalsystems/tendermint@0.34.24"
+      },
+      "cosmwasm_version": "osmosis-labs/wasmd@0.31.0-osmo-v16",
+      "cosmwasm_enabled": true,
+      "ibc_go_version": "4.3.1",
+      "ics_enabled": [
+        "ics20-1"
+      ],
+      "binaries": {
+        "linux/arm64": "https://github.com/osmosis-labs/osmosis/releases/download/v16.1.1/osmosisd-16.1.1-linux-arm64?checksum=sha256:b96ff1f4c9b4abecb1b38998b1a1f891cfed2cc8078ab64914b151183c0c199b",
+        "darwin/arm64": "https://github.com/osmosis-labs/osmosis/releases/download/v16.1.1/osmosisd-16.1.1-darwin-arm64?checksum=sha256:c743da4d3632a2bc3ea0ce784bbd13383492a4a34d53295eb2c96987bacf8e8c",
+        "darwin/amd64": "https://github.com/osmosis-labs/osmosis/releases/download/v16.1.1/osmosisd-16.1.1-darwin-amd64?checksum=sha256:d856ebda9c31f052d10a78443967a93374f2033292f0afdb6434b82b4ed79790",
+        "linux/amd64": "https://github.com/osmosis-labs/osmosis/releases/download/v16.1.1/osmosisd-16.1.1-linux-amd64?checksum=sha256:f838618633c1d42f593dc33d26b25842f5900961e987fc08570bb81a062e311d"
+      },
+      "previous_version_name": "v15"
+    }
+  ]
+}

--- a/versions.schema.json
+++ b/versions.schema.json
@@ -1,0 +1,145 @@
+{
+  "$id": "https://sikka.tech/chain.schema.json",
+  "$schema": "https://json-schema.org/draft-07/schema",
+  "title": "Cosmos Chain",
+  "description": "Cosmos Chain Versions.json is a metadata file that contains information about a cosmos sdk based chain's current and historical versions.",
+  "type": "object",
+  "required": [
+    "chain_name",
+    "versions"
+  ],
+  "properties": {
+    "$schema": {
+      "type": "string",
+      "pattern": "^(\\.\\./)+chain\\.schema\\.json$"
+    },
+    "chain_name": {
+      "type": "string",
+      "pattern": "[a-z0-9]+"
+    },
+    "versions": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "name"
+        ],
+        "properties": {
+          "name": {
+            "type": "string",
+            "description": "Official Upgrade Name"
+          },
+          "tag": {
+            "type": "string",
+            "description": "Git Upgrade Tag"
+          },
+          "height": {
+            "type": "number",
+            "description": "Block Height"
+          },
+          "proposal": {
+            "type": "number",
+            "description": "Proposal that will officially signal community acceptance of the upgrade."
+          },
+          "previous_version_name": {
+            "type": "string",
+            "description": "[Optional] Name of the previous version"
+          },
+          "next_version_name": {
+            "type": "string",
+            "description": "[Optional] Name of the following version"
+          },
+          "recommended_version": {
+            "type": "string"
+          },
+          "compatible_versions": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "cosmos_sdk_version": {
+            "type": "string"
+          },
+          "consensus": {
+            "type": "object",
+            "required": [
+              "type"
+            ],
+            "properties": {
+              "type": {
+                "type": "string",
+                "enum": [
+                  "tendermint",
+                  "cometbft"
+                ]
+              },
+              "version": {
+                "type": "string"
+              }
+            },
+            "additionalProperties": false
+          },
+          "cosmwasm_version": {
+            "type": "string"
+          },
+          "cosmwasm_enabled": {
+            "type": "boolean"
+          },
+          "cosmwasm_path": {
+            "type": "string",
+            "description": "Relative path to the cosmwasm directory. ex. $HOME/.juno/data/wasm",
+            "pattern": "^\\$HOME.*$"
+          },
+          "ibc_go_version": {
+            "type": "string"
+          },
+          "ics_enabled": {
+            "type": "array",
+            "description": "List of IBC apps (usually corresponding to a ICS standard) which have been enabled on the network.",
+            "items": {
+              "type": "string",
+              "description": "IBC app or ICS standard.",
+              "enum": [
+                "ics20-1",
+                "ics27-1",
+                "mauth"
+              ]
+            }
+          },
+          "binaries": {
+            "type": "object",
+            "properties": {
+              "linux/amd64": {
+                "type": "string",
+                "format": "uri"
+              },
+              "linux/arm64": {
+                "type": "string",
+                "format": "uri"
+              },
+              "darwin/amd64": {
+                "type": "string",
+                "format": "uri"
+              },
+              "darwin/arm64": {
+                "type": "string",
+                "format": "uri"
+              },
+              "windows/amd64": {
+                "type": "string",
+                "format": "uri"
+              },
+              "windows/arm64": {
+                "type": "string",
+                "format": "uri"
+              }
+            },
+            "additionalProperties": false
+          }
+        },
+        "additionalProperties": false
+      }
+    }
+  }
+}


### PR DESCRIPTION
The idea is that the chain.json file only needs the current version data--not the historical version data.

The Osmosis versions file is just an example until automation can manage the synchronicity between that file and the chain.json file. Once automation is set up, we'll be able to enter future version data that will only be included if and when the referenced block height and proposal passes. It will also be nice if new version data can be added to either 'versions.json' or 'chain.json', and the other file would be updated appropriately. 