### PR TITLE
Modify coreum-osmosis IBC information

### DIFF
--- a/_IBC/coreum-osmosis.json
+++ b/_IBC/coreum-osmosis.json
@@ -2,22 +2,22 @@
     "$schema": "../ibc_data.schema.json",
     "chain_1": {
       "chain_name": "coreum",
-      "client_id": "07-tendermint-1",
-      "connection_id": "connection-0"
+      "client_id": "07-tendermint-3",
+      "connection_id": "connection-3"
     },
     "chain_2": {
       "chain_name": "osmosis",
-      "client_id": "07-tendermint-2924",
-      "connection_id": "connection-2422"
+      "client_id": "07-tendermint-2929",
+      "connection_id": "connection-2426"
     },
     "channels": [
       {
         "chain_1": {
-          "channel_id": "channel-0",
+          "channel_id": "channel-2",
           "port_id": "transfer"
         },
         "chain_2": {
-          "channel_id": "channel-2169",
+          "channel_id": "channel-2188",
           "port_id": "transfer"
         },
         "ordering": "unordered",


### PR DESCRIPTION
After discussion with Osmosis team, a new IBC client was created raising the trust treshhold to 2/3 for better security.
We created a new client and new connection so we need to modify this information.