### PR TITLE
Upgrade Quicksilver to v1.2.16

### DIFF
--- a/quicksilver/chain.json
+++ b/quicksilver/chain.json
@@ -30,12 +30,12 @@
   },
   "codebase": {
     "git_repo": "https://github.com/ingenuity-build/quicksilver",
-    "recommended_version": "v1.2.15",
+    "recommended_version": "v1.2.16",
     "compatible_versions": [
-      "v1.2.15"
+      "v1.2.15", "v1.2.16"
     ],
     "binaries": {
-      "linux/amd64": "https://github.com/ingenuity-build/quicksilver/releases/download/v1.2.15/quicksilverd-v1.2.15-amd64"
+      "linux/amd64": "https://github.com/ingenuity-build/quicksilver/releases/download/v1.2.16/quicksilverd-v1.2.16-amd64"
     },
     "cosmos_sdk_version": "0.46",
     "consensus": {
@@ -110,12 +110,12 @@
         "name": "v1.2.15",
         "proposal": 18,
         "height": 3052279,
-        "recommended_version": "v1.2.15",
+        "recommended_version": "v1.2.16",
         "compatible_versions": [
-          "v1.2.15"
+          "v1.2.15", "v1.2.16"
         ],
         "binaries": {
-          "linux/amd64": "https://github.com/ingenuity-build/quicksilver/releases/download/v1.2.15/quicksilverd-v1.2.15-amd64"
+          "linux/amd64": "https://github.com/ingenuity-build/quicksilver/releases/download/v1.2.16/quicksilverd-v1.2.16-amd64"
         },
         "cosmos_sdk_version": "0.46.14",
         "consensus": {


### PR DESCRIPTION
Non-consensus upgrade

https://github.com/ingenuity-build/quicksilver/releases/tag/v1.2.16