### PR TITLE
Add Composable Pica image via symlinks (Proposed Solution)

### DIFF
--- a/_non-cosmos/picasso/images/ppica-test.svg
+++ b/_non-cosmos/picasso/images/ppica-test.svg
@@ -1,0 +1,1 @@
+../../../composable/images/pica.svg

--- a/_non-cosmos/picasso/images/ppica.svg
+++ b/_non-cosmos/picasso/images/ppica.svg
@@ -1,0 +1,1 @@
+../../../composable/images/pica.svg

--- a/composable/assetlist.json
+++ b/composable/assetlist.json
@@ -27,7 +27,10 @@
           },
           "provider": "Composable Finance"
         }
-      ]
+      ],
+      "logo_URIs": {
+        "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/composable/images/ppica.svg"
+      },
     },
     {
       "description": "The native staking and governance token of Kusama Relay Chain.",

--- a/composable/images/ppica.svg
+++ b/composable/images/ppica.svg
@@ -1,0 +1,1 @@
+./ppica_origin.svg

--- a/composable/images/ppica_origin.svg
+++ b/composable/images/ppica_origin.svg
@@ -1,0 +1,1 @@
+../../_non-cosmos/picasso/images/ppica.svg


### PR DESCRIPTION
What this PR does is assume that /images/<base_denom>.<extension> is reserved for that asset.
e.g., picasso::ppica's image corresponds to /picasso/images/ppica.svg
This may be accomplished via soft symbolic link, which, in this case, it is.

Then it also assumes that /images/<based_denom>**_origin**.<extension> is reserved for that assets origin (as defined under its 'traces' property).
e.g., composable::ppica's origin image: /composable/images/ppica_origin.svg is an image of /picasso/images/ppica.svg
This is accomplished via soft symbolic links.

It also assumes that if an asset is to take on the image of it's origin (the most recent hop) and update with it, we can use a symlink to point its reserved image name to the origin asset image.
e.g., composable::ppica's image is a symlink that points to composable/images/ppica_origin.svg.

The composable's assetlist.json can now define logo_URIs for PICA as /composable/images/ppica.svg.
But, when we eventually have automation take over such that no user ever has to create a symlink, then defining the logo_URIs.svg as /composable/images/ppica_origin.svg is acceptable, and the automation will update the reference to just ppica (instead of ppica_origin) and create the necessary symlink of ppica to ppica_origin.

To summarize this particular case:

/composable/assetlist.json::ppica.logo_URIs.svg points to:
/composable/images/ppica.svg, which is a symlink to:
/composable/images/ppica_origin.svg, which is a symlink to:
/_non-cosmos/picasso/images/ppica.svg, which is a symlink to:
/composable/images/pica.svg

Benefits:
-if /composable/images/pica.svg is modified, both token logos (Picasso's and Composable's) will be modified.
-if /composable/images/pica.svg is replaced with an image of a different name, we would need to repair picasso pica's logo_URIs reference URI. (and we also would need to update the /picasso/images/ppica.svg symlink--soon to be automated), and both images would be modified together.
-if composable::PICA wants to deviate from Picasso::PICA and use a different image, we can just upload a new image and update it's assetlist.json file (logo__URIs reference)

With automation that updates the symlinks automatically such that no user needs to create a symlink, there should be little to no need for contributors to understand symlinks, and this becomes very powerful and storage-efficient.