### PR TITLE
Fix Nomic stakenet from 'develop' to 'main'

### DIFF
--- a/nomic/chain.json
+++ b/nomic/chain.json
@@ -21,11 +21,10 @@
     },
     "versions": [
       {
-        "name": "develop",
-        "recommended_version": "develop",
+        "name": "main",
+        "recommended_version": "main",
         "compatible_versions": [
-          "develop",
-          "v3"
+          "main"
         ]
       }
     ]


### PR DESCRIPTION
Nomic stakenet no longer runs off the develop branch, which is now used for testnet. Stakenet is now on the main branch.