### PR TITLE
Upgrade BitCanna to v2.0.3

### DIFF
--- a/bitcanna/chain.json
+++ b/bitcanna/chain.json
@@ -33,14 +33,14 @@
   },
   "codebase": {
     "git_repo": "https://github.com/BitCannaGlobal/bcna",
-    "recommended_version": "v2.0.2",
+    "recommended_version": "v2.0.3",
     "compatible_versions": [
-      "v2.0.2"
+      "v2.0.2", "v2.0.3"
     ],
     "binaries": {
-      "linux/amd64": "https://github.com/BitCannaGlobal/bcna/releases/download/v2.0.2/bcna_linux_amd64.tar.gz",
-      "linux/arm64": "https://github.com/BitCannaGlobal/bcna/releases/download/v2.0.2/bcna_linux_arm64.tar.gz",
-      "darwin/arm64": "https://github.com/BitCannaGlobal/bcna/releases/download/v2.0.2/bcna_darwin_arm64.tar.gz"
+      "linux/amd64": "https://github.com/BitCannaGlobal/bcna/releases/download/v2.0.3/bcna_linux_amd64.tar.gz",
+      "linux/arm64": "https://github.com/BitCannaGlobal/bcna/releases/download/v2.0.3/bcna_linux_arm64.tar.gz",
+      "darwin/arm64": "https://github.com/BitCannaGlobal/bcna/releases/download/v2.0.3/bcna_darwin_arm64.tar.gz"
     },
     "genesis": {
       "genesis_url": "https://raw.githubusercontent.com/BitCannaGlobal/bcna/main/genesis.json"
@@ -82,14 +82,14 @@
         "name": "wakeandbake",
         "proposal": 12,
         "height": 9209420,
-        "recommended_version": "v2.0.2",
+        "recommended_version": "v2.0.3",
         "compatible_versions": [
-          "v2.0.2"
+          "v2.0.2", "v2.0.3"
         ],
        "binaries": {
-          "linux/amd64": "https://github.com/BitCannaGlobal/bcna/releases/download/v2.0.2/bcna_linux_amd64.tar.gz",
-          "linux/arm64": "https://github.com/BitCannaGlobal/bcna/releases/download/v2.0.2/bcna_linux_arm64.tar.gz",
-          "darwin/arm64": "https://github.com/BitCannaGlobal/bcna/releases/download/v2.0.2/bcna_darwin_arm64.tar.gz"
+          "linux/amd64": "https://github.com/BitCannaGlobal/bcna/releases/download/v2.0.3/bcna_linux_amd64.tar.gz",
+          "linux/arm64": "https://github.com/BitCannaGlobal/bcna/releases/download/v2.0.3/bcna_linux_arm64.tar.gz",
+          "darwin/arm64": "https://github.com/BitCannaGlobal/bcna/releases/download/v2.0.3/bcna_darwin_arm64.tar.gz"
         }
       }
     ]


### PR DESCRIPTION
Non-consensus upgrade for "wakeandbake", added to recommended and compatible versions. Updated binaries to v2.0.3. 

https://github.com/BitCannaGlobal/bcna/releases/tag/v2.0.3