### PR TITLE
Add Real Yield Eth from Sommelier to Axelar Asset List

### DIFF
--- a/_non-cosmos/ethereum/assetlist.json
+++ b/_non-cosmos/ethereum/assetlist.json
@@ -726,6 +726,16 @@
       "name": "Binance USD",
       "display": "busd",
       "symbol": "BUSD",
+      "traces": [
+        {
+          "type": "synthetic",
+          "counterparty": {
+            "chain_name": "forex",
+            "base_denom": "USD"
+          },
+          "provider": "Binance"
+        }
+      ],
       "logo_URIs": {
         "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/_non-cosmos/ethereum/images/busd.svg",
         "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/_non-cosmos/ethereum/images/busd.png"
@@ -758,6 +768,39 @@
         "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/_non-cosmos/ethereum/images/pepe.png"
       },
       "coingecko_id": "pepe"
+    },
+    {
+      "description": "Maximize ETH yield through leveraged staking across Aave, Compound and Morpho and liquidity provision of ETH liquid staking tokens on Uniswap V3.",
+      "type_asset": "erc20",
+      "address": "0xb5b29320d2Dde5BA5BAFA1EbcD270052070483ec",
+      "denom_units": [
+        {
+          "denom": "0xb5b29320d2Dde5BA5BAFA1EbcD270052070483ec",
+          "exponent": 0
+        },
+        {
+          "denom": "YieldETH",
+          "exponent": 18
+        }
+      ],
+      "base": "0xb5b29320d2Dde5BA5BAFA1EbcD270052070483ec",
+      "name": "Real Yield ETH",
+      "display": "YieldETH",
+      "symbol": "YieldETH",
+      "traces": [
+        {
+          "type": "liquid-stake",
+          "counterparty": {
+            "chain_name": "ethereum",
+            "base_denom": "wei"
+          },
+          "provider": "Seven Seas & DeFine Logic Labs"
+        }
+      ],
+      "logo_URIs": {
+        "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/_non-cosmos/ethereum/images/yieldeth.svg",
+        "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/_non-cosmos/ethereum/images/yieldeth.png"
+      }
     }
   ]
 }

--- a/axelar/assetlist.json
+++ b/axelar/assetlist.json
@@ -991,6 +991,35 @@
           "provider": "Axelar"
         }  
       ]
+    },
+    {
+      "denom_units": [
+        {
+          "denom": "yieldeth-wei",
+          "exponent": 0,
+          "aliases": [
+            "0xb5b29320d2Dde5BA5BAFA1EbcD270052070483ec"
+          ]
+        },
+        {
+          "denom": "YieldEth",
+          "exponent": 18
+        }
+      ],
+      "base": "wsteth-wei",
+      "name": "Real Yield Eth",
+      "display": "RealYieldETH",
+      "symbol": "YieldEth",
+      "traces": [
+        {
+          "type": "bridge",
+          "counterparty": {
+            "chain_name": "ethereum",
+            "base_denom": "0xb5b29320d2Dde5BA5BAFA1EbcD270052070483ec"
+          },
+          "provider": "Axelar"
+        }  
+      ]
     }
   ]
 }


### PR DESCRIPTION
Axelar Satellite now supports Real Yield Eth from Sommelier being bridged into Cosmos. Provides support inside the Cosmos ecosystem.