### PR TITLE
Upgrade Nois to v1.0.4

### DIFF
--- a/nois/chain.json
+++ b/nois/chain.json
@@ -36,16 +36,16 @@
   },
   "codebase": {
     "git_repo": "https://github.com/noislabs/noisd",
-    "recommended_version": "v1.0.0",
+    "recommended_version": "v1.0.4",
     "compatible_versions": [
-      "v1.0.0"
+      "v1.0.0", "v1.0.4"
     ],
-    "cosmos_sdk_version": "0.45",
+    "cosmos_sdk_version": "v0.45.15",
     "consensus": {
-      "type": "tendermint",
-      "version": "0.34"
+      "type": "cometbft",
+      "version": "v0.34.29"
     },
-    "cosmwasm_version": "0.30",
+    "cosmwasm_version": "v0.31.0",
     "cosmwasm_enabled": true,
     "genesis": {
       "name": "v1",
@@ -54,18 +54,18 @@
     "versions": [
       {
         "name": "v1",
-        "tag": "v1.0.0",
+        "tag": "v1.0.4",
         "height": 0,
-        "recommended_version": "v1.0.0",
+        "recommended_version": "v1.0.4",
         "compatible_versions": [
-          "v1.0.0"
+          "v1.0.0", "v1.0.4"
         ],
-        "cosmos_sdk_version": "0.45",
+        "cosmos_sdk_version": "v0.45.15",
         "consensus": {
-          "type": "tendermint",
-          "version": "0.34"
+          "type": "cometbft",
+          "version": "v0.34.29"
         },
-        "cosmwasm_version": "0.30",
+        "cosmwasm_version": "v0.31.0",
         "cosmwasm_enabled": true
       }
     ]


### PR DESCRIPTION
Non-consensus upgrade already live.

https://github.com/noislabs/noisd/releases/tag/v1.0.4