### PR TITLE
Upgrade Passage to v2.0.1

### DIFF
--- a/passage/chain.json
+++ b/passage/chain.json
@@ -31,9 +31,9 @@
   },
   "codebase": {
     "git_repo": "https://github.com/envadiv/Passage3D",
-    "recommended_version": "v2.0.0",
+    "recommended_version": "v2.0.1",
     "compatible_versions": [
-      "v2.0.0"
+      "v2.0.1"
     ],
     "genesis": {
       "genesis_url": "https://raw.githubusercontent.com/envadiv/mainnet/main/passage-2/genesis.json"
@@ -41,9 +41,9 @@
     "versions": [
       {
         "name": "v2.0.0",
-        "recommended_version": "v2.0.0",
+        "recommended_version": "v2.0.1",
         "compatible_versions": [
-          "v2.0.0"
+          "v2.0.1"
         ],
         "cosmos_sdk_version": "v0.45.16",
         "ibc_go_version": "v4.4.2",


### PR DESCRIPTION
Non-consensus upgrade, validators urged to upgrade asap.

https://github.com/envadiv/Passage3D/releases/tag/v2.0.1