### PR TITLE
Add gas prices to passage chain

### DIFF
--- a/passage/chain.json
+++ b/passage/chain.json
@@ -18,7 +18,10 @@
     "fee_tokens": [
       {
         "denom": "upasg",
-        "fixed_min_gas_price": 0
+        "fixed_min_gas_price": 0,
+        "low_gas_price": 0.001,
+        "average_gas_price": 0.0025,
+        "high_gas_price": 0.01
       }
     ]
   },


### PR DESCRIPTION
To integrate Passage network on Osmosis UI at least one of the fee token must be defined. This PR adds low, average and high gas prices.