### PR TITLE
Upgrade Cosmos Hub Testnet to v12

### DIFF
--- a/testnets/cosmoshubtestnet/chain.json
+++ b/testnets/cosmoshubtestnet/chain.json
@@ -29,17 +29,18 @@
   },
   "codebase": {
     "git_repo": "https://github.com/cosmos/gaia",
-    "recommended_version": "v11.0.0",
+    "recommended_version": "v12.0.0",
     "compatible_versions": [
-      "v11.0.0"
+      "v12.0.0-rc0",
+      "v12.0.0"
     ],
     "binaries": {
-      "linux/amd64": "https://github.com/cosmos/gaia/releases/download/v11.0.0/gaiad-v11.0.0-linux-amd64",
-      "linux/arm64": "https://github.com/cosmos/gaia/releases/download/v11.0.0/gaiad-v11.0.0-linux-arm64",
-      "darwin/amd64": "https://github.com/cosmos/gaia/releases/download/v11.0.0/gaiad-v11.0.0-darwin-amd64",
-      "darwin/arm64": "https://github.com/cosmos/gaia/releases/download/v11.0.0/gaiad-v11.0.0-darwin-arm64",
-      "windows/amd64": "https://github.com/cosmos/gaia/releases/download/v11.0.0/gaiad-v11.0.0-windows-amd64.exe",
-      "windows/arm64": "https://github.com/cosmos/gaia/releases/download/v11.0.0/gaiad-v11.0.0-windows-arm64.exe"
+      "linux/amd64": "https://github.com/cosmos/gaia/releases/download/v12.0.0/gaiad-v12.0.0-linux-amd64",
+      "linux/arm64": "https://github.com/cosmos/gaia/releases/download/v12.0.0/gaiad-v12.0.0-linux-arm64",
+      "darwin/amd64": "https://github.com/cosmos/gaia/releases/download/v12.0.0/gaiad-v12.0.0-darwin-amd64",
+      "darwin/arm64": "https://github.com/cosmos/gaia/releases/download/v12.0.0/gaiad-v12.0.0-darwin-arm64",
+      "windows/amd64": "https://github.com/cosmos/gaia/releases/download/v12.0.0/gaiad-v12.0.0-windows-amd64.exe",
+      "windows/arm64": "https://github.com/cosmos/gaia/releases/download/v12.0.0/gaiad-v12.0.0-windows-arm64.exe"
     },
     "genesis": {
       "genesis_url": "https://github.com/cosmos/testnets/raw/master/public/genesis.json.gz"
@@ -86,6 +87,22 @@
           "darwin/arm64": "https://github.com/cosmos/gaia/releases/download/v11.0.0/gaiad-v11.0.0-darwin-arm64",
           "windows/amd64": "https://github.com/cosmos/gaia/releases/download/v11.0.0/gaiad-v11.0.0-windows-amd64.exe",
           "windows/arm64": "https://github.com/cosmos/gaia/releases/download/v11.0.0/gaiad-v11.0.0-windows-arm64.exe"
+        }
+      },
+      {
+        "name": "v12",
+        "recommended_version": "v12.0.0",
+        "compatible_versions": [
+          "v12.0.0-rc0",
+          "v12.0.0"
+        ],
+        "binaries": {
+          "linux/amd64": "https://github.com/cosmos/gaia/releases/download/v12.0.0/gaiad-v12.0.0-linux-amd64",
+          "linux/arm64": "https://github.com/cosmos/gaia/releases/download/v12.0.0/gaiad-v12.0.0-linux-arm64",
+          "darwin/amd64": "https://github.com/cosmos/gaia/releases/download/v12.0.0/gaiad-v12.0.0-darwin-amd64",
+          "darwin/arm64": "https://github.com/cosmos/gaia/releases/download/v12.0.0/gaiad-v12.0.0-darwin-arm64",
+          "windows/amd64": "https://github.com/cosmos/gaia/releases/download/v12.0.0/gaiad-v12.0.0-windows-amd64.exe",
+          "windows/arm64": "https://github.com/cosmos/gaia/releases/download/v12.0.0/gaiad-v12.0.0-windows-arm64.exe"
         }
       }
     ]


### PR DESCRIPTION
Hi! We have upgraded the Cosmos Hub Public Testnet to v12:
https://github.com/cosmos/testnets/tree/master/public

I added v12 to the version history array.

Thanks!