### PR TITLE
Added callbacks middleware's memo keys to the ICS-20 memo registry

### DIFF
--- a/_memo_keys/ICS20_memo_keys.json
+++ b/_memo_keys/ICS20_memo_keys.json
@@ -57,6 +57,28 @@
           }
         }
       }
+    },
+    {
+      "key": "src_callback",
+      "description": "Passing the IBC SendPacket, AcknowledgementPacket, and TimeoutPacket events to a callback address on the source chain.",
+      "git_repo": "https://github.com/cosmos/ibc-go/tree/main/modules/apps/callbacks",
+      "memo": {
+        "src_callback": {
+          "address": "src-chain-address",
+          "gas_limit": "100000"
+        }
+      }
+    },
+    {
+      "key": "dest_callback",
+      "description": "Passing the IBC ReceivePacket event to a callback address on the destination chain on WriteAcknowledgement step.",
+      "git_repo": "https://github.com/cosmos/ibc-go/tree/main/modules/apps/callbacks",
+      "memo": {
+        "dest_callback": {
+          "address": "dest-chain-address",
+          "gas_limit": "100000"
+        }
+      }
     }
   ]
 }


### PR DESCRIPTION
## Description

A new IBC middleware was [released last week](https://github.com/cosmos/ibc-go/releases/tag/modules%2Fapps%2Fcallbacks%2Fv0.1.0%2Bibc-go-v7.3) in ibc-go, introducing two new memo field keys! This PR adds these keys to the memo registry.