### PR TITLE
Patch Tenet to v11.2.1

### DIFF
--- a/tenet/chain.json
+++ b/tenet/chain.json
@@ -36,16 +36,16 @@
   },
   "codebase": {
     "git_repo": "https://github.com/tenet-org/tenet-mainnet",
-    "recommended_version": "v11.2.0",
+    "recommended_version": "v11.2.1",
     "compatible_versions": [
-      "v11.2.0"
+      "v11.2.1"
     ],
     "binaries": {
-      "linux/amd64": "https://github.com/tenet-org/tenet-mainnet/releases/download/v11.2.0/tenet-mainnet_11.2.0_Linux_amd64.tar.gz",
-      "linux/arm64": "https://github.com/tenet-org/tenet-mainnet/releases/download/v11.2.0/tenet-mainnet_11.2.0_Linux_arm64.tar.gz",
-      "darwin/amd64": "https://github.com/tenet-org/tenet-mainnet/releases/download/v11.2.0/tenet-mainnet_11.2.0_Darwin_amd64.tar.gz",
-      "darwin/arm64": "https://github.com/tenet-org/tenet-mainnet/releases/download/v11.2.0/tenet-mainnet_11.2.0_Darwin_arm64.tar.gz",
-      "windows/amd64": "https://github.com/tenet-org/tenet-mainnet/releases/download/v11.2.0/tenet-mainnet_11.2.0_Windows_amd64.zip"
+      "linux/amd64": "https://github.com/tenet-org/tenet-mainnet/releases/download/v11.2.1/tenet-mainnet_11.2.1_Linux_amd64.tar.gz",
+      "linux/arm64": "https://github.com/tenet-org/tenet-mainnet/releases/download/v11.2.1/tenet-mainnet_11.2.1_Linux_arm64.tar.gz",
+      "darwin/amd64": "https://github.com/tenet-org/tenet-mainnet/releases/download/v11.2.1/tenet-mainnet_11.2.1_Darwin_amd64.tar.gz",
+      "darwin/arm64": "https://github.com/tenet-org/tenet-mainnet/releases/download/v11.2.1/tenet-mainnet_11.2.1_Darwin_arm64.tar.gz",
+      "windows/amd64": "https://github.com/tenet-org/tenet-mainnet/releases/download/v11.2.1/tenet-mainnet_11.2.1_Windows_amd64.zip"
     },
     "cosmos_sdk_version": "0.46",
     "consensus": {
@@ -82,9 +82,9 @@
         "name": "multichain",
         "proposal": 2,
         "height": 2330000,
-        "recommended_version": "v11.2.0",
+        "recommended_version": "v11.2.1",
         "compatible_versions": [
-          "v11.2.0"
+          "v11.2.0", "v11.2.1"
         ],
         "cosmos_sdk_version": "0.46",
         "consensus": {
@@ -93,11 +93,11 @@
         },
         "ibc_go_version": "6.1.0",
         "binaries": {
-          "linux/amd64": "https://github.com/tenet-org/tenet-mainnet/releases/download/v11.2.0/tenet-mainnet_11.2.0_Linux_amd64.tar.gz",
-          "linux/arm64": "https://github.com/tenet-org/tenet-mainnet/releases/download/v11.2.0/tenet-mainnet_11.2.0_Linux_arm64.tar.gz",
-          "darwin/amd64": "https://github.com/tenet-org/tenet-mainnet/releases/download/v11.2.0/tenet-mainnet_11.2.0_Darwin_amd64.tar.gz",
-          "darwin/arm64": "https://github.com/tenet-org/tenet-mainnet/releases/download/v11.2.0/tenet-mainnet_11.2.0_Darwin_arm64.tar.gz",
-          "windows/amd64": "https://github.com/tenet-org/tenet-mainnet/releases/download/v11.2.0/tenet-mainnet_11.2.0_Windows_amd64.zip"
+          "linux/amd64": "https://github.com/tenet-org/tenet-mainnet/releases/download/v11.2.1/tenet-mainnet_11.2.1_Linux_amd64.tar.gz",
+          "linux/arm64": "https://github.com/tenet-org/tenet-mainnet/releases/download/v11.2.1/tenet-mainnet_11.2.1_Linux_arm64.tar.gz",
+          "darwin/amd64": "https://github.com/tenet-org/tenet-mainnet/releases/download/v11.2.1/tenet-mainnet_11.2.1_Darwin_amd64.tar.gz",
+          "darwin/arm64": "https://github.com/tenet-org/tenet-mainnet/releases/download/v11.2.1/tenet-mainnet_11.2.1_Darwin_arm64.tar.gz",
+          "windows/amd64": "https://github.com/tenet-org/tenet-mainnet/releases/download/v11.2.1/tenet-mainnet_11.2.1_Windows_amd64.zip"
         },
         "next_version_name": ""
       }


### PR DESCRIPTION
Alliance module patch. Non-consensus. Already live.

https://github.com/tenet-org/tenet-mainnet/releases/tag/v11.2.1