### PR TITLE
Fix Juno v16 to v16.0.2

### DIFF
--- a/juno/chain.json
+++ b/juno/chain.json
@@ -40,9 +40,9 @@
   },
   "codebase": {
     "git_repo": "https://github.com/CosmosContracts/juno",
-    "recommended_version": "v16.0.0",
+    "recommended_version": "v16.0.2",
     "compatible_versions": [
-      "v16.0.0"
+      "v16.0.0", "v16.0.2"
     ],
     "cosmos_sdk_version": "0.47.3",
     "consensus": {
@@ -94,9 +94,9 @@
         "name": "v16",
         "proposal": 311,
         "height": 9481382,
-        "recommended_version": "v16.0.0",
+        "recommended_version": "v16.0.2",
         "compatible_versions": [
-          "v16.0.0"
+          "v16.0.0", "v16.0.2"
         ],
         "next_version_name": ""
       }


### PR DESCRIPTION
Non-consensus upgrade, already live.


https://github.com/CosmosContracts/juno/releases/tag/v16.0.2