### PR TITLE
Update EntryPoint fee token to ATOM

### DIFF
--- a/testnets/entrypointtestnet/assetlist.json
+++ b/testnets/entrypointtestnet/assetlist.json
@@ -29,6 +29,27 @@
         "governance",
         "vaults"
       ]
+    },
+    {
+      "description": "The native staking and governance token of the Theta testnet version of the Cosmos Hub, via Osmosis.",
+      "denom_units": [
+        {
+          "denom": "ibc/E774302AE43D5FA03522C42B14823288E7DD1B2F54F85DFD3D6FC3E5FCF54645",
+          "exponent": 0
+        },
+        {
+          "denom": "atom",
+          "exponent": 6
+        }
+      ],
+      "base": "ibc/E774302AE43D5FA03522C42B14823288E7DD1B2F54F85DFD3D6FC3E5FCF54645",
+      "name": "Cosmos",
+      "display": "atom",
+      "symbol": "ATOM",
+      "logo_URIs": {
+        "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/cosmoshub/images/atom.png",
+        "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/cosmoshub/images/atom.svg"
+      }
     }
   ]
 }

--- a/testnets/entrypointtestnet/assetlist.json
+++ b/testnets/entrypointtestnet/assetlist.json
@@ -46,6 +46,20 @@
       "name": "Cosmos",
       "display": "atom",
       "symbol": "ATOM",
+      "traces": [
+        {
+          "type": "ibc",
+          "counterparty": {
+            "chain_name": "osmosis",
+            "base_denom": "ibc/B28CFD38D84A480EF2A03AC575DCB05004D934A603A5A642888847BCDA6340C0",
+            "channel_id": "channel-1543"
+          },
+          "chain": {
+            "channel_id": "channel-0",
+            "path": "transfer/channel-0/transfer/channel-1497/uatom"
+          }
+        }
+      ],
       "logo_URIs": {
         "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/cosmoshub/images/atom.png",
         "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/cosmoshub/images/atom.svg"

--- a/testnets/entrypointtestnet/chain.json
+++ b/testnets/entrypointtestnet/chain.json
@@ -15,11 +15,10 @@
   "fees": {
     "fee_tokens": [
       {
-        "denom": "uentry",
-        "fixed_min_gas_price": 0,
-        "low_gas_price": 0.0,
-        "average_gas_price": 0.0,
-        "high_gas_price": 0.0
+        "denom": "ibc/E774302AE43D5FA03522C42B14823288E7DD1B2F54F85DFD3D6FC3E5FCF54645",
+        "low_gas_price": 0.01,
+        "average_gas_price": 0.01,
+        "high_gas_price": 0.02
       }
     ]
   },


### PR DESCRIPTION
As of #2796 the fee token on the EntryPoint public testnet has been changed to ATOM.

For the record, here's an example of a transaction paid for using ATOM: https://explorer.entrypoint.zone/entrypoint/tx/56D647EE82F479674A8817AC182436C66483CC5F4B5F2D14296130750CEEA332