### PR TITLE
Update oraichain to v0.41.4

### DIFF
--- a/oraichain/chain.json
+++ b/oraichain/chain.json
@@ -56,18 +56,6 @@
         }
       },
       {
-        "name": "v0.41.3",
-        "height": 12353514,
-        "proposal": 185,
-        "recommended_version": "v0.41.3",
-        "compatible_versions": [
-          "v0.41.3"
-        ],
-        "binaries": {
-          "linux/amd64": "https://orai.s3.us-east-2.amazonaws.com/v0.41.3/oraid"
-        }
-      },
-      {
         "name": "v0.41.4",
         "height": 13567875,
         "proposal": 197,
@@ -77,7 +65,7 @@
           "v0.41.4"
         ],
         "binaries": {
-          "linux/amd64": "https://github.com/oraichain/orai/releases/download/v0.41.4/oraid"
+          "linux/amd64": "https://orai.s3.us-east-2.amazonaws.com/v0.41.4/oraid"
         }
       }
     ]

--- a/oraichain/chain.json
+++ b/oraichain/chain.json
@@ -39,7 +39,7 @@
       "v0.41.4"
     ],
     "binaries": {
-      "linux/amd64": "https://orai.s3.us-east-2.amazonaws.com/v0.41.4/oraid"
+      "linux/amd64": "https://github.com/oraichain/orai/releases/download/v0.41.4/oraid"
     },
     "genesis": {
       "genesis_url": "https://raw.githubusercontent.com/oraichain/oraichain-static-files/master/mainnet-static-files/genesis.json"

--- a/oraichain/chain.json
+++ b/oraichain/chain.json
@@ -33,9 +33,10 @@
   },
   "codebase": {
     "git_repo": "https://github.com/oraichain/orai",
-    "recommended_version": "v0.41.3",
+    "recommended_version": "v0.41.4",
     "compatible_versions": [
-      "v0.41.3"
+      "v0.41.3",
+      "v0.41.4"
     ],
     "binaries": {
       "linux/amd64": "https://orai.s3.us-east-2.amazonaws.com/v0.41.3/oraid"
@@ -64,6 +65,18 @@
         ],
         "binaries": {
           "linux/amd64": "https://orai.s3.us-east-2.amazonaws.com/v0.41.3/oraid"
+        }
+      },
+      {
+        "name": "v0.41.4",
+        "height": 13567875,
+        "proposal": 197,
+        "recommended_version": "v0.41.4",
+        "compatible_versions": [
+          "v0.41.4"
+        ],
+        "binaries": {
+          "linux/amd64": "https://github.com/oraichain/orai/releases/download/v0.41.4/oraid"
         }
       }
     ]

--- a/oraichain/chain.json
+++ b/oraichain/chain.json
@@ -39,7 +39,7 @@
       "v0.41.4"
     ],
     "binaries": {
-      "linux/amd64": "https://orai.s3.us-east-2.amazonaws.com/v0.41.3/oraid"
+      "linux/amd64": "https://orai.s3.us-east-2.amazonaws.com/v0.41.4/oraid"
     },
     "genesis": {
       "genesis_url": "https://raw.githubusercontent.com/oraichain/oraichain-static-files/master/mainnet-static-files/genesis.json"
@@ -73,6 +73,7 @@
         "proposal": 197,
         "recommended_version": "v0.41.4",
         "compatible_versions": [
+          "v0.41.3",
           "v0.41.4"
         ],
         "binaries": {


### PR DESCRIPTION
https://github.com/oraichain/orai/releases/tag/v0.41.4