### PR TITLE
feat: add IBC connection for two testnets

### DIFF
--- a/testnets/_IBC/cosmoshubtestnet-celestiatestnet3.json
+++ b/testnets/_IBC/cosmoshubtestnet-celestiatestnet3.json
@@ -1,0 +1,31 @@
+{
+    "$schema": "../ibc_data.schema.json",
+    "chain_1": {
+        "chain_name": "cosmoshubtestnet",
+        "client_id": "07-tendermint-2382",
+        "connection_id": "connection-2727"
+    },
+    "chain_2": {
+        "chain_name": "celestiatestnet3",
+        "client_id": "07-tendermint-0",
+        "connection_id": "connection-0"
+    },
+    "channels": [
+        {
+            "chain_1": {
+                "channel_id": "channel-3152",
+                "port_id": "transfer"
+            },
+            "chain_2": {
+                "channel_id": "channel-0",
+                "port_id": "transfer"
+            },
+            "ordering": "unordered",
+            "version": "ics20-1",
+            "tags": {
+                "status": "live",
+                "preferred": true
+            }
+        }
+    ]
+}


### PR DESCRIPTION
Add an IBC connection between Cosmos hub testnet (`theta-testnet-001`) and Celestia testnet (`mocha-4`). 

## Testing

I verified that I can use this channel via [this tx](https://explorer.theta-testnet.polypore.xyz/transactions/B9ACC78B86DDA84B9B3263B9EC1A7311A12F88B44F65B21B5520866C292A43FF
):
```
$ ./target/release/hermes tx ft-transfer --timeout-seconds 1000 --dst-chain mocha-4 --src-chain theta-testnet-001 --src-port transfer --src-channel channel-3152 --amount 1 --denom uatom
```


Here is the raw output from creating this channel:

```shell
$ ./target/release/hermes create channel --a-chain theta-testnet-001 --a-connection connection-2727 --a-port transfer --b-port transfer
2023-09-16T19:53:09.813815Z  INFO ThreadId(01) using default configuration from '/Users/rootulp/.hermes/config.toml'
2023-09-16T19:53:09.815380Z  INFO ThreadId(01) running Hermes v1.6.0+1c1cf0298-dirty
2023-09-16T19:53:11.056847Z  WARN ThreadId(01) Unsupported tendermint version, will use v0.34 compatibility mode but relaying might not work as desired: unsupported Tendermint version reported by the node: 1.0.0-rc14
2023-09-16T19:53:15.227950Z  INFO ThreadId(01) 🎊  theta-testnet-001 => OpenInitChannel(OpenInit { port_id: transfer, channel_id: channel-3152, connection_id: None, counterparty_port_id: transfer, counterparty_channel_id: None }) at height 0-17936815
2023-09-16T19:53:26.469824Z  INFO ThreadId(01) 🎊  mocha-4 => OpenTryChannel(OpenTry { port_id: transfer, channel_id: channel-0, connection_id: connection-0, counterparty_port_id: transfer, counterparty_channel_id: channel-3152 }) at height 4-78122
2023-09-16T19:53:53.057004Z  INFO ThreadId(01) 🎊  theta-testnet-001 => OpenAckChannel(OpenAck { port_id: transfer, channel_id: channel-3152, connection_id: connection-2727, counterparty_port_id: transfer, counterparty_channel_id: channel-0 }) at height 0-17936822
2023-09-16T19:54:13.450361Z  INFO ThreadId(01) 🎊  mocha-4 => OpenConfirmChannel(OpenConfirm { port_id: transfer, channel_id: channel-0, connection_id: connection-0, counterparty_port_id: transfer, counterparty_channel_id: channel-3152 }) at height 4-78126
2023-09-16T19:54:16.606587Z  INFO ThreadId(01) channel handshake already finished for Channel { ordering: ORDER_UNORDERED, a_side: ChannelSide { chain: BaseChainHandle { chain_id: theta-testnet-001 }, client_id: 07-tendermint-2382, connection_id: connection-2727, port_id: transfer, channel_id: channel-3152, version: None }, b_side: ChannelSide { chain: BaseChainHandle { chain_id: mocha-4 }, client_id: 07-tendermint-0, connection_id: connection-0, port_id: transfer, channel_id: channel-0, version: None }, connection_delay: 0ns }
SUCCESS Channel {
    ordering: Unordered,
    a_side: ChannelSide {
        chain: BaseChainHandle {
            chain_id: ChainId {
                id: "theta-testnet-001",
                version: 0,
            },
            runtime_sender: Sender { .. },
        },
        client_id: ClientId(
            "07-tendermint-2382",
        ),
        connection_id: ConnectionId(
            "connection-2727",
        ),
        port_id: PortId(
            "transfer",
        ),
        channel_id: Some(
            ChannelId(
                "channel-3152",
            ),
        ),
        version: None,
    },
    b_side: ChannelSide {
        chain: BaseChainHandle {
            chain_id: ChainId {
                id: "mocha-4",
                version: 4,
            },
            runtime_sender: Sender { .. },
        },
        client_id: ClientId(
            "07-tendermint-0",
        ),
        connection_id: ConnectionId(
            "connection-0",
        ),
        port_id: PortId(
            "transfer",
        ),
        channel_id: Some(
            ChannelId(
                "channel-0",
            ),
        ),
        version: None,
    },
    connection_delay: 0ns,
}
```