### PR TITLE
Bug fix for Desmos - upgrade to v6.1.1

### DIFF
--- a/desmos/chain.json
+++ b/desmos/chain.json
@@ -35,7 +35,8 @@
     "git_repo": "https://github.com/desmos-labs/desmos",
     "recommended_version": "v6.1.1",
     "compatible_versions": [
-      "v6.1.0", "6.1.1"
+      "v6.1.0",
+      "v6.1.1"
     ],
     "binaries": {
       "linux/amd64": "https://github.com/desmos-labs/desmos/releases/download/v6.1.1/desmos-6.1.1-linux-amd64"
@@ -85,7 +86,8 @@
         "name": "v6.0.0",
         "recommended_version": "v6.1.1",
         "compatible_versions": [
-          "v6.1.0", "v6.1.1"
+          "v6.1.0",
+          "v6.1.1"
         ],
         "proposal": 32,
         "height": 10213500,

--- a/desmos/chain.json
+++ b/desmos/chain.json
@@ -33,12 +33,12 @@
   },
   "codebase": {
     "git_repo": "https://github.com/desmos-labs/desmos",
-    "recommended_version": "v6.0.0",
+    "recommended_version": "v6.1.1",
     "compatible_versions": [
-      "6.0.0"
+      "v6.1.0", "6.1.1"
     ],
     "binaries": {
-      "linux/amd64": "https://github.com/desmos-labs/desmos/releases/download/v6.0.0/desmos-6.0.0-linux-amd64"
+      "linux/amd64": "https://github.com/desmos-labs/desmos/releases/download/v6.1.1/desmos-6.1.1-linux-amd64"
     },
     "genesis": {
       "genesis_url": "https://raw.githubusercontent.com/desmos-labs/mainnet/main/genesis.json"
@@ -83,14 +83,14 @@
       },
       {
         "name": "v6.0.0",
-        "recommended_version": "v6.1.0",
+        "recommended_version": "v6.1.1",
         "compatible_versions": [
-          "v6.1.0"
+          "v6.1.0", "v6.1.1"
         ],
         "proposal": 32,
         "height": 10213500,
         "binaries": {
-          "linux/amd64": "https://github.com/desmos-labs/desmos/releases/download/v6.1.0/desmos-6.1.0-linux-amd64"
+          "linux/amd64": "https://github.com/desmos-labs/desmos/releases/download/v6.1.1/desmos-6.1.1-linux-amd64"
         },
         "next_version_name": ""
       }


### PR DESCRIPTION
Bug fix

Good to push as this is already live and expected to be run by validators 

Source: https://github.com/desmos-labs/desmos/releases/tag/v6.1.1