### PR TITLE
Upgrade Canto to v7.0.0

### DIFF
--- a/canto/chain.json
+++ b/canto/chain.json
@@ -30,9 +30,9 @@
   },
   "codebase": {
     "git_repo": "https://github.com/Canto-Network/Canto",
-    "recommended_version": "v6.0.0",
+    "recommended_version": "v7.0.0",
     "compatible_versions": [
-      "v6.0.0"
+      "v7.0.0"
     ],
     "genesis": {
       "genesis_url": "https://raw.githubusercontent.com/Canto-Network/Canto/genesis/Networks/Mainnet/genesis.json"
@@ -52,6 +52,16 @@
         "compatible_versions": [
           "v6.0.0"
         ],
+        "next_version_name": "v7.0.0"
+      },
+      {
+        "name": "v7.0.0",
+        "recommended_version": "v7.0.0",
+        "compatible_versions": [
+          "v7.0.0"
+        ],
+        "proposal": 113,
+        "height": 6055770,
         "next_version_name": ""
       }
     ]


### PR DESCRIPTION
Prop 113
Height 6055770

Upgrade height is already passed and this is live.

https://dev.mintscan.io/canto/proposals/113
https://dev.mintscan.io/canto/blocks/6055770