### PR TITLE
Re-add FUND logo_URIs

### DIFF
--- a/unification/assetlist.json
+++ b/unification/assetlist.json
@@ -24,6 +24,10 @@
           "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/unification/images/fund.png"
         }
       ],
+      "logo_URIs": {
+        "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/unification/images/fund.svg",
+        "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/unification/images/fund.png"
+      },
       "coingecko_id": "unification"
     }
   ]


### PR DESCRIPTION
Re-add FUND logo_URIs
They switched to images, which is preferred, but the legacy property logo_URIs should be maintained