### PR TITLE
Update archway-bitcanna IBC to new client

### DIFF
--- a/_IBC/archway-bitcanna.json
+++ b/_IBC/archway-bitcanna.json
@@ -2,22 +2,22 @@
   "$schema": "../ibc_data.schema.json",
   "chain_1": {
     "chain_name": "archway",
-    "client_id": "07-tendermint-35",
-    "connection_id": "connection-38"
+    "client_id": "07-tendermint-37",
+    "connection_id": "connection-40"
   },
   "chain_2": {
     "chain_name": "bitcanna",
-    "client_id": "07-tendermint-82",
-    "connection_id": "connection-73"
+    "client_id": "07-tendermint-83",
+    "connection_id": "connection-74"
   },
   "channels": [
     {
       "chain_1": {
-        "channel_id": "channel-33",
+        "channel_id": "channel-35",
         "port_id": "transfer"
       },
       "chain_2": {
-        "channel_id": "channel-49",
+        "channel_id": "channel-50",
         "port_id": "transfer"
       },
       "ordering": "unordered",


### PR DESCRIPTION
The previously created client had a misconfiguration, with one of trusting periods being too short. This was picked up before starting to relay transactions, and mitigated by creating a new client, in alignment with the Archway team.

---

`IBC Channel Open Confirm` on [BitCanna Tx 8CAC6901342ACD758AAA1BBEB116FEC9F7DBB199168217C8AB244D7836D30C64](https://explorer.bitcanna.io/transactions/8CAC6901342ACD758AAA1BBEB116FEC9F7DBB199168217C8AB244D7836D30C64).

Updates #2892.