### PR TITLE
Update humans chain bech32_prefix

### DIFF
--- a/humans/chain.json
+++ b/humans/chain.json
@@ -6,7 +6,7 @@
   "website": "https://humans.ai/",
   "pretty_name": "humans",
   "chain_id": "humans_1089-1",
-  "bech32_prefix": "humans",
+  "bech32_prefix": "human",
   "node_home": "$HOME/.humansd",
   "daemon_name": "humansd",
   "key_algos": ["ethsecp256k1"],


### PR DESCRIPTION
Example failing query: http://humans-rpc.stakeangle.com:41417/cosmos/bank/v1beta1/balances/humans1a2hs6gh8qg50lcgwmycln3tqg6e4wk427uq6fh

```json
{
  "code": 3,
  "message": "invalid address: invalid Bech32 prefix; expected human, got humans",
  "details": [
  ]
}
```