### PR TITLE
Add Observatory to explorers list

### DIFF
--- a/agoric/chain.json
+++ b/agoric/chain.json
@@ -253,6 +253,10 @@
       "kind": "Stakeflow",
       "url": "https://stakeflow.io/agoric",
       "account_page": "https://stakeflow.io/agoric/accounts/${accountAddress}"
+    },
+    {
+      "kind": "observatory",
+      "url": "https://observatory.zone/agoric"
     }
   ],
   "images": [

--- a/akash/chain.json
+++ b/akash/chain.json
@@ -368,6 +368,10 @@
       "kind": "ValidatorNode",
       "url": "https://explorer.validatornode.com/akash-network",
       "tx_page": "https://explorer.validatornode.com/akash-network/tx/${txHash}"
+    },
+    {
+      "kind": "observatory",
+      "url": "https://observatory.zone/akash-network"
     }
   ],
   "images": [

--- a/axelar/chain.json
+++ b/axelar/chain.json
@@ -384,6 +384,10 @@
       "kind": "Stakeflow",
       "url": "https://stakeflow.io/axelar",
       "account_page": "https://stakeflow.io/axelar/accounts/${accountAddress}"
+    },
+    {
+      "kind": "observatory",
+      "url": "https://observatory.zone/axelar"
     }
   ],
   "images": [

--- a/chain4energy/chain.json
+++ b/chain4energy/chain.json
@@ -621,6 +621,10 @@
       "kind": "ScanRun",
       "url": "https://scanrun.io/c4e",
       "tx_page": "https://scanrun.io/c4e/transactions/${txHash}"
+    },
+    {
+      "kind": "observatory",
+      "url": "https://observatory.zone/chain4energy"
     }
   ],
   "images": [

--- a/cosmoshub/chain.json
+++ b/cosmoshub/chain.json
@@ -628,6 +628,10 @@
       "kind": "Stakeflow",
       "url": "https://stakeflow.io/cosmos",
       "account_page": "https://stakeflow.io/cosmos/accounts/${accountAddress}"
+    },
+    {
+      "kind": "observatory",
+      "url": "https://observatory.zone/cosmos-hub"
     }
   ],
   "images": [

--- a/crescent/chain.json
+++ b/crescent/chain.json
@@ -296,6 +296,10 @@
       "kind": "Stakeflow",
       "url": "https://stakeflow.io/crescent",
       "account_page": "https://stakeflow.io/crescent/accounts/${accountAddress}"
+    },
+    {
+      "kind": "observatory",
+      "url": "https://observatory.zone/crescent"
     }
   ],
   "images": [

--- a/evmos/chain.json
+++ b/evmos/chain.json
@@ -642,6 +642,10 @@
       "kind": "Stakeflow",
       "url": "https://stakeflow.io/evmos",
       "account_page": "https://stakeflow.io/evmos/accounts/${accountAddress}"
+    },
+    {
+      "kind": "observatory",
+      "url": "https://observatory.zone/evmos"
     }
   ],
   "images": [

--- a/gravitybridge/chain.json
+++ b/gravitybridge/chain.json
@@ -320,6 +320,10 @@
       "kind": "Stakeflow",
       "url": "https://stakeflow.io/gravity-bridge",
       "account_page": "https://stakeflow.io/gravity-bridge/accounts/${accountAddress}"
+    },
+    {
+      "kind": "observatory",
+      "url": "https://observatory.zone/gravity-bridge"
     }
   ],
   "images": [

--- a/injective/chain.json
+++ b/injective/chain.json
@@ -402,6 +402,10 @@
       "kind": "Stakeflow",
       "url": "https://stakeflow.io/injective",
       "account_page": "https://stakeflow.io/injective/accounts/${accountAddress}"
+    },
+    {
+      "kind": "observatory",
+      "url": "https://observatory.zone/injective"
     }
   ],
   "images": [

--- a/juno/chain.json
+++ b/juno/chain.json
@@ -536,6 +536,10 @@
       "kind": "Stakeflow",
       "url": "https://stakeflow.io/juno",
       "account_page": "https://stakeflow.io/juno/accounts/${accountAddress}"
+    },
+    {
+      "kind": "observatory",
+      "url": "https://observatory.zone/juno-network"
     }
   ],
   "images": [

--- a/kujira/chain.json
+++ b/kujira/chain.json
@@ -361,6 +361,10 @@
       "url": "https://atomscan.com/kujira",
       "tx_page": "https://atomscan.com/kujira/transactions/${txHash}",
       "account_page": "https://atomscan.com/kujira/accounts/${accountAddress}"
+    },
+    {
+      "kind": "observatory",
+      "url": "https://observatory.zone/kujira"
     }
   ],
   "logo_URIs": {

--- a/mars/chain.json
+++ b/mars/chain.json
@@ -300,6 +300,10 @@
       "url": "https://ping.pub/mars",
       "tx_page": "https://ping.pub/mars/tx/${txHash}",
       "account_page": "https://ping.pub/mars/account/${accountAddress}"
+    },
+    {
+      "kind": "observatory",
+      "url": "https://observatory.zone/mars-hub"
     }
   ],
   "logo_URIs": {

--- a/migaloo/chain.json
+++ b/migaloo/chain.json
@@ -261,6 +261,10 @@
       "url": "https://atomscan.com/migaloo",
       "tx_page": "https://atomscan.com/migaloo/transactions/${txHash}",
       "account_page": "https://atomscan.com/migaloo/accounts/${accountAddress}"
+    },
+    {
+      "kind": "observatory",
+      "url": "https://observatory.zone/migaloo"
     }
   ],
   "images": [

--- a/osmosis/chain.json
+++ b/osmosis/chain.json
@@ -710,6 +710,10 @@
       "kind": "Stakeflow",
       "url": "https://stakeflow.io/osmosis",
       "account_page": "https://stakeflow.io/osmosis/accounts/${accountAddress}"
+    },
+    {
+      "kind": "observatory",
+      "url": "https://observatory.zone/osmosis"
     }
   ],
   "keywords": [

--- a/persistence/chain.json
+++ b/persistence/chain.json
@@ -400,6 +400,10 @@
       "kind": "Stakeflow",
       "url": "https://stakeflow.io/persistence",
       "account_page": "https://stakeflow.io/persistence/accounts/${accountAddress}"
+    },
+    {
+      "kind": "observatory",
+      "url": "https://observatory.zone/persistence"
     }
   ],
   "images": [

--- a/quicksilver/chain.json
+++ b/quicksilver/chain.json
@@ -492,6 +492,10 @@
       "kind": "AM Solutions Explorers",
       "url": "https://explorer.theamsolutions.info/quicksilver-main/staking",
       "tx_page": "https://explorer.theamsolutions.info/quicksilver-main/tx/${txHash}"
+    },
+    {
+      "kind": "observatory",
+      "url": "https://observatory.zone/quicksilver"
     }
   ],
   "images": [

--- a/regen/chain.json
+++ b/regen/chain.json
@@ -238,6 +238,10 @@
       "url": "https://atomscan.com/regen-network",
       "tx_page": "https://atomscan.com/regen-network/transactions/${txHash}",
       "account_page": "https://atomscan.com/regen-network/accounts/${accountAddress}"
+    },
+    {
+      "kind": "observatory",
+      "url": "https://observatory.zone/regen"
     }
   ],
   "logo_URIs": {

--- a/secretnetwork/chain.json
+++ b/secretnetwork/chain.json
@@ -300,6 +300,10 @@
       "url": "https://atomscan.com/secret-network",
       "tx_page": "https://atomscan.com/secret-network/transactions/${txHash}",
       "account_page": "https://atomscan.com/secret-network/accounts/${accountAddress}"
+    },
+    {
+      "kind": "observatory",
+      "url": "https://observatory.zone/secret-network"
     }
   ],
   "images": [

--- a/sommelier/chain.json
+++ b/sommelier/chain.json
@@ -232,6 +232,10 @@
       "url": "https://atomscan.com/sommelier",
       "tx_page": "https://atomscan.com/sommelier/transactions/${txHash}",
       "account_page": "https://atomscan.com/sommelier/accounts/${accountAddress}"
+    },
+    {
+      "kind": "observatory",
+      "url": "https://observatory.zone/sommelier"
     }
   ],
   "images": [

--- a/stargaze/chain.json
+++ b/stargaze/chain.json
@@ -361,6 +361,10 @@
       "url": "https://starscan.net/",
       "tx_page": "https://starscan.net/stargaze-1/tx/${txHash}",
       "account_page": "https://starscan.net/stargaze-1/address/${accountAddress}"
+    },
+    {
+      "kind": "observatory",
+      "url": "https://observatory.zone/stargaze"
     }
   ],
   "images": [

--- a/umee/chain.json
+++ b/umee/chain.json
@@ -616,6 +616,10 @@
       "url": "https://explorer.stake-take.com/umee",
       "tx_page": "https://explorer.stake-take.com/umee/transactions/${txHash}",
       "account_page": "https://explorer.stake-take.com/umee/account/${accountAddress}"
+    },
+    {
+      "kind": "observatory",
+      "url": "https://observatory.zone/umee"
     }
   ],
   "images": [


### PR DESCRIPTION
[Observatory](https://observatory.zone/) is not a typical chain explorer where you would be able to browse accounts or transactions. But it provides some insightful data especially about the state of decentralization of individual chains that cannot be found anywhere else.

Many foundations and validators in the Cosmos ecosystem already use Observatory to make informed decisions on how to improve their chains. We would like to add Observatory to `chain-registry` so even more users will become aware of it and will make use of this data.