### PR TITLE
Update Osmosis assetlist.json for USDC.axl and USDC native from Noble

### DIFF
--- a/osmosis/assetlist.json
+++ b/osmosis/assetlist.json
@@ -437,7 +437,7 @@
       ]
     },
     {
-      "description": "Tether USDt on Osmosis",
+      "description": "Tether USDT on Osmosis",
       "denom_units": [
         {
           "denom": "ibc/4ABBEF4C8926DDDB320AE5188CFD63267ABBCEFC0583E4AE05D6E5AA2401DDAB",

--- a/osmosis/assetlist.json
+++ b/osmosis/assetlist.json
@@ -450,9 +450,9 @@
       ],
       "type_asset": "ics20",
       "base": "ibc/4ABBEF4C8926DDDB320AE5188CFD63267ABBCEFC0583E4AE05D6E5AA2401DDAB",
-      "name": "Tether USDt",
+      "name": "Tether USDT",
       "display": "usdt",
-      "symbol": "USDt",
+      "symbol": "USDT",
       "traces": [
         {
           "type": "ibc",

--- a/osmosis/assetlist.json
+++ b/osmosis/assetlist.json
@@ -134,7 +134,7 @@
       "base": "ibc/D189335C6E4A68B513C10AB227BF1C1D38C746766278BA3EEB4FB14124F1D858",
       "name": "USD Coin",
       "display": "usdc",
-      "symbol": "USDC",
+      "symbol": "USDC.axl",
       "traces": [
         {
           "type": "ibc",
@@ -153,6 +153,48 @@
         {
           "image_sync": {
             "chain_name": "axelar",
+            "base_denom": "uusdc"
+          }
+        }
+      ]
+    },
+    {
+      "denom_units": [
+        {
+          "denom": "ibc/498A0751C798A0D9A389AA3691123DADA57DAA4FE165D5C75894505B876BA6E4",
+          "exponent": 0,
+          "aliases": [
+            "uusdc"
+          ]
+        },
+        {
+          "denom": "usdc",
+          "exponent": 6
+        }
+      ],
+      "type_asset": "ics20",
+      "base": "ibc/498A0751C798A0D9A389AA3691123DADA57DAA4FE165D5C75894505B876BA6E4",
+      "name": "USD Coin",
+      "display": "usdc",
+      "symbol": "USDC",
+      "traces": [
+        {
+          "type": "ibc",
+          "counterparty": {
+            "chain_name": "noble",
+            "base_denom": "uusdc",
+            "channel_id": "channel-1"
+          },
+          "chain": {
+            "channel_id": "channel-750",
+            "path": "transfer/channel-750/uusdc"
+          }
+        }
+      ],
+      "images": [
+        {
+          "image_sync": {
+            "chain_name": "noble",
             "base_denom": "uusdc"
           }
         }

--- a/osmosis/assetlist.json
+++ b/osmosis/assetlist.json
@@ -132,7 +132,7 @@
       ],
       "type_asset": "ics20",
       "base": "ibc/D189335C6E4A68B513C10AB227BF1C1D38C746766278BA3EEB4FB14124F1D858",
-      "name": "USD Coin",
+      "name": "Axelar USD Coin",
       "display": "usdc",
       "symbol": "USDC.axl",
       "traces": [
@@ -174,7 +174,7 @@
       ],
       "type_asset": "ics20",
       "base": "ibc/498A0751C798A0D9A389AA3691123DADA57DAA4FE165D5C75894505B876BA6E4",
-      "name": "USD Coin",
+      "name": "Noble USD Coin",
       "display": "usdc",
       "symbol": "USDC",
       "traces": [


### PR DESCRIPTION
Update the USDC symbol for Axelar USDc from "USDC" to "USDC.axl" on Osmosis.
Add Noble USDC as symbol "USDC" with the correct IBC/hash and channel ids for Osmosis and counterparty chain.
Update Kava USDt symbol to uppercase T as "USDT".