### PR TITLE
IBC Path kujira <> terra2

### DIFF
--- a/_IBC/kujira-terra2.json
+++ b/_IBC/kujira-terra2.json
@@ -1,0 +1,31 @@
+{
+  "$schema": "../ibc_data.schema.json",
+  "chain_1": {
+    "chain_name": "kujira",
+    "client_id": "07-tendermint-5",
+    "connection_id": "connection-3"
+  },
+  "chain_2": {
+    "chain_name": "terra2",
+    "client_id": "07-tendermint-11",
+    "connection_id": "connection-13"
+  },
+  "channels": [
+    {
+      "chain_1": {
+        "channel_id": "channel-10",
+        "port_id": "transfer"
+      },
+      "chain_2": {
+        "channel_id": "channel-5",
+        "port_id": "transfer"
+      },
+      "ordering": "unordered",
+      "version": "ics20-1",
+      "tags": {
+        "status": "live",
+        "preferred": true
+      }
+    }
+  ]
+}


### PR DESCRIPTION
This path has existed for 470 days, but was not included in the chain registry.  I confirmed the clients, connections and channels were open.  