### PR TITLE
Update ibc osmosistestnet multipath

### DIFF
--- a/testnets/_IBC/akashtestnet-osmosistestnet.json
+++ b/testnets/_IBC/akashtestnet-osmosistestnet.json
@@ -2,22 +2,22 @@
   "$schema": "../ibc_data.schema.json",
   "chain_1": {
     "chain_name": "akashtestnet",
-    "client_id": "07-tendermint-1",
-    "connection_id": "connection-1"
+    "client_id": "07-tendermint-5",
+    "connection_id": "connection-5"
   },
   "chain_2": {
     "chain_name": "osmosistestnet",
-    "client_id": "07-tendermint-646",
-    "connection_id": "connection-585"
+    "client_id": "07-tendermint-1188",
+    "connection_id": "connection-1091"
   },
   "channels": [
     {
       "chain_1": {
-        "channel_id": "channel-1",
+        "channel_id": "channel-5",
         "port_id": "transfer"
       },
       "chain_2": {
-        "channel_id": "channel-1208",
+        "channel_id": "channel-3930",
         "port_id": "transfer"
       },
       "ordering": "unordered",

--- a/testnets/_IBC/cosmoshubtestnet-osmosistestnet.json
+++ b/testnets/_IBC/cosmoshubtestnet-osmosistestnet.json
@@ -2,22 +2,22 @@
   "$schema": "../ibc_data.schema.json",
   "chain_1": {
     "chain_name": "cosmoshubtestnet",
-    "client_id": "07-tendermint-2356",
-    "connection_id": "connection-2693"
+    "client_id": "07-tendermint-2504",
+    "connection_id": "connection-2866"
   },
   "chain_2": {
     "chain_name": "osmosistestnet",
-    "client_id": "07-tendermint-893",
-    "connection_id": "connection-797"
+    "client_id": "07-tendermint-1187",
+    "connection_id": "connection-1087"
   },
   "channels": [
     {
       "chain_1": {
-        "channel_id": "channel-3108",
+        "channel_id": "channel-3259",
         "port_id": "transfer"
       },
       "chain_2": {
-        "channel_id": "channel-1497",
+        "channel_id": "channel-3928",
         "port_id": "transfer"
       },
       "ordering": "unordered",

--- a/testnets/_IBC/injectivetestnet-osmosistestnet.json
+++ b/testnets/_IBC/injectivetestnet-osmosistestnet.json
@@ -1,0 +1,32 @@
+{
+    "$schema": "../ibc_data.schema.json",
+    "chain_1": {
+      "chain_name": "injectivetestnet",
+      "client_id": "07-tendermint-188",
+      "connection_id": "connection-179"
+    },
+    "chain_2": {
+      "chain_name": "osmosistestnet",
+      "client_id": "07-tendermint-1192",
+      "connection_id": "connection-1096"
+    },
+    "channels": [
+      {
+        "chain_1": {
+          "channel_id": "channel-128",
+          "port_id": "transfer"
+        },
+        "chain_2": {
+          "channel_id": "channel-3934",
+          "port_id": "transfer"
+        },
+        "ordering": "unordered",
+        "version": "ics20-1",
+        "tags": {
+          "status": "live",
+          "preferred": true,
+          "dex": "osmosis"
+        }
+      }
+    ]
+  }

--- a/testnets/_IBC/neutrontestnet-osmosistestnet.json
+++ b/testnets/_IBC/neutrontestnet-osmosistestnet.json
@@ -1,0 +1,31 @@
+{
+    "$schema": "../ibc_data.schema.json",
+    "chain_1": {
+      "chain_name": "neutrontestnet",
+      "client_id": "07-tendermint-131",
+      "connection_id": "connection-122"
+    },
+    "chain_2": {
+      "chain_name": "osmosistestnet",
+      "client_id": "07-tendermint-1190",
+      "connection_id": "connection-1093"
+    },
+    "channels": [
+      {
+        "chain_1": {
+          "channel_id": "channel-195",
+          "port_id": "transfer"
+        },
+        "chain_2": {
+          "channel_id": "channel-3932",
+          "port_id": "transfer"
+        },
+        "ordering": "unordered",
+        "version": "ics20-1",
+        "tags": {
+          "status": "live",
+          "preferred": true
+        }
+      }
+    ]
+  }

--- a/testnets/_IBC/osmosistestnet-stargazetestnet.json
+++ b/testnets/_IBC/osmosistestnet-stargazetestnet.json
@@ -1,0 +1,32 @@
+{
+    "$schema": "../ibc_data.schema.json",
+    "chain_1": {
+      "chain_name": "osmosistestnet",
+      "client_id": "07-tendermint-1189",
+      "connection_id": "connection-1092"
+    },
+    "chain_2": {
+      "chain_name": "stargazetestnet",
+      "client_id": "07-tendermint-586",
+      "connection_id": "connection-598"
+    },
+    "channels": [
+      {
+        "chain_1": {
+          "channel_id": "channel-3931",
+          "port_id": "transfer"
+        },
+        "chain_2": {
+          "channel_id": "channel-591",
+          "port_id": "transfer"
+        },
+        "ordering": "unordered",
+        "version": "ics20-1",
+        "tags": {
+          "status": "live",
+          "preferred": true,
+          "dex": "osmosis"
+        }
+      }
+    ]
+  }


### PR DESCRIPTION
new paths created due to consensus param update & client expiration:

- osmosistestnet `osmo-test-5` new `unbonding_period`: 24h
- new paths created for `akashtestnet-osmosistestnet` and `cosmoshubtestnet-osmosistestnet` (clients expired)
- new paths created for `injectivetestnet-osmosistestnet`, `neutrontestnet-osmosistestnet` and `osmosistestnet-stargazetestnet`

CryptoCrew has upgraded their testnet relayer service level by adding redundant relayer instances for all supported channels.