### PR TITLE
Update chain.json for IRIShub v2.0.0

### DIFF
--- a/irisnet/chain.json
+++ b/irisnet/chain.json
@@ -12,9 +12,6 @@
     "secp256k1"
   ],
   "slip44": 118,
-  "alternative_slip44s": [
-    566
-  ],
   "fees": {
     "fee_tokens": [
       {
@@ -52,9 +49,18 @@
       },
       {
         "name": "v1.4.1",
+        "next_version_name": "v2.0.0",
         "recommended_version": "v1.4.1",
         "compatible_versions": [
           "v1.4.1"
+        ]
+      },
+      {
+        "name": "v2.0.0",
+        "next_version_name": "v2.1.0",
+        "recommended_version": "v2.0.3",
+        "compatible_versions": [
+          "v2.0.3"
         ]
       }
     ]


### PR DESCRIPTION
there is no alternative_slip44s in IRIShub mainnet, "slip44": 118 only, since genesis time.