### PR TITLE
Update EntryPoint testnet to entrypoint-pubtest-2

### DIFF
--- a/testnets/entrypointtestnet/chain.json
+++ b/testnets/entrypointtestnet/chain.json
@@ -4,7 +4,7 @@
   "status": "live",
   "network_type": "testnet",
   "pretty_name": "EntryPoint Testnet",
-  "chain_id": "entrypoint-pubtest-1",
+  "chain_id": "entrypoint-pubtest-2",
   "bech32_prefix": "entrypoint",
   "daemon_name": "entrypointd",
   "node_home": "$HOME/.entrypointd",
@@ -15,10 +15,10 @@
   "fees": {
     "fee_tokens": [
       {
-        "denom": "ibc/E774302AE43D5FA03522C42B14823288E7DD1B2F54F85DFD3D6FC3E5FCF54645",
-        "low_gas_price": 0.01,
-        "average_gas_price": 0.01,
-        "high_gas_price": 0.02
+        "denom": "uentry",
+        "low_gas_price": 0,
+        "average_gas_price": 0,
+        "high_gas_price": 0
       }
     ]
   },
@@ -31,9 +31,9 @@
   },
   "codebase": {
     "git_repo": "https://github.com/entrypoint-zone/testnets",
-    "recommended_version": "v1.0.0",
+    "recommended_version": "v1.1.1",
     "compatible_versions": [
-      "v1.0.0"
+      "v1.1.1"
     ],
     "cosmos_sdk_version": "0.47.4",
     "consensus": {
@@ -41,14 +41,14 @@
       "version": "0.37.2"
     },
     "genesis": {
-      "genesis_url": "https://github.com/entrypoint-zone/testnets/blob/2c4490fcce0f9f32d579e2581e592f5c320e5c14/entrypoint-pubtest-1/genesis.json"
+      "genesis_url": "https://raw.githubusercontent.com/entrypoint-zone/testnets/2f2bffec8e73db30886bffa67fda1a242a6dc1d1/entrypoint-pubtest-2/genesis.json"
     },
     "versions": [
       {
-        "name": "v1.0.0",
-        "recommended_version": "v1.0.0",
+        "name": "v1.1.1",
+        "recommended_version": "v1.1.1",
         "compatible_versions": [
-          "v1.0.0"
+          "v1.1.1"
         ],
         "cosmos_sdk_version": "0.47.4",
         "consensus": {
@@ -61,13 +61,13 @@
   "apis": {
     "rpc": [
       {
-        "address": "https://testnet-rest.entrypoint.zone",
+        "address": "https://testnet-rpc.entrypoint.zone",
         "provider": "Simply Staking"
       }
     ],
     "rest": [
       {
-        "address": "https://testnet-rpc.entrypoint.zone",
+        "address": "https://testnet-rest.entrypoint.zone",
         "provider": "Simply Staking"
       }
     ]


### PR DESCRIPTION
`entrypoint-pubtest-1` (originally introduced in #2796 and updated in #2838) has been deprecated and has now been replaced with `entrypoint-pubtest-2`. This PR also fixes a typo where the REST and RPC APIs were swapped.