### PR TITLE
updated noble-terra2 ibc paths

### DIFF
--- a/_IBC/noble-terra2.json
+++ b/_IBC/noble-terra2.json
@@ -2,22 +2,22 @@
     "$schema": "../ibc_data.schema.json",
     "chain_1": {
       "chain_name": "noble",
-      "client_id": "07-tendermint-14",
-      "connection_id": "connection-23"
+      "client_id": "07-tendermint-56",
+      "connection_id": "connection-54"
     },
     "chain_2": {
       "chain_name": "terra2",
-      "client_id": "07-tendermint-216",
-      "connection_id": "connection-170"
+      "client_id": "07-tendermint-367",
+      "connection_id": "connection-302"
     },
     "channels": [
       {
         "chain_1": {
-          "channel_id": "channel-9",
+          "channel_id": "channel-30",
           "port_id": "transfer"
         },
         "chain_2": {
-          "channel_id": "channel-151",
+          "channel_id": "channel-253",
           "port_id": "transfer"
         },
         "ordering": "unordered",


### PR DESCRIPTION
current one is dead, so it was decided it is not worth the gov proposal since
1. it was needed fast
2. no funds were transferred using the dead one (only 0.001 luna for test https://dev.mintscan.io/terra/txs/DB861BA7510EE26BA2353A755094B62B394629BD33A82E3BC2C00726D80C64EC?height=5010031)

new one is up
https://dev.mintscan.io/terra/relayers/channel-253/noble/channel-30 