### PR TITLE
Update $COREUM token symbol

### DIFF
--- a/coreum/assetlist.json
+++ b/coreum/assetlist.json
@@ -17,7 +17,7 @@
       "base": "ucore",
       "name": "Coreum",
       "display": "core",
-      "symbol": "CORE",
+      "symbol": "COREUM",
       "logo_URIs": {
         "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/coreum/images/coreum.png",
         "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/coreum/images/coreum.svg"


### PR DESCRIPTION
was $CORE for on-chain referencing before, but team agrees to use $COREUM everywhere