### PR TITLE
Upgrade Jackal to v3.0.2

### DIFF
--- a/jackal/chain.json
+++ b/jackal/chain.json
@@ -33,13 +33,14 @@
   },
   "codebase": {
     "git_repo": "https://github.com/JackalLabs/canine-chain",
-    "recommended_version": "v3.0.0",
+    "recommended_version": "v3.0.2",
     "compatible_versions": [
-      "v3.0.0"
+      "v3.0.0", 
+      "v3.0.2"
     ],
     "binaries": {
-      "linux/amd64": "https://github.com/JackalLabs/canine-chain/releases/download/v3.0.0/canined-Linux",
-      "darwin/amd64": "https://github.com/JackalLabs/canine-chain/releases/download/v3.0.0/canined-macOS"
+      "linux/amd64": "https://github.com/JackalLabs/canine-chain/releases/download/v3.0.2/canined-Linux",
+      "darwin/amd64": "https://github.com/JackalLabs/canine-chain/releases/download/v3.0.2/canined-macOS"
     },
     "genesis": {
       "genesis_url": "https://cdn.discordapp.com/attachments/1002389406650466405/1034968352591986859/updated_genesis2.json"
@@ -93,18 +94,19 @@
         "next_version_name": "v3"
       },
       {
-        "name": "3",
-        "tag": "V3.0.0",
+        "name": "v3",
+        "tag": "V3.0.2",
         "proposal": 9,
         "height": 4074200,
-        "recommended_version": "v3.0.0",
+        "recommended_version": "v3.0.2",
         "compatible_versions": [
-          "v3.0.0"
+          "v3.0.0",
+          "v3.0.2"
         ],
         "cosmwasm_enabled": true,
         "binaries": {
-          "linux/amd64": "https://github.com/JackalLabs/canine-chain/releases/download/v3.0.0/canined-Linux",
-          "darwin/amd64": "https://github.com/JackalLabs/canine-chain/releases/download/v3.0.0/canined-macOS"
+          "linux/amd64": "https://github.com/JackalLabs/canine-chain/releases/download/v3.0.2/canined-Linux",
+          "darwin/amd64": "https://github.com/JackalLabs/canine-chain/releases/download/v3.0.2/canined-macOS"
         },
         "next_version_name": ""
       }


### PR DESCRIPTION
Non-consensus upgrade

https://github.com/JackalLabs/canine-chain/releases/tag/v3.0.2