### PR TITLE
Upgrade Gravity Bridge to v1.10.2

### DIFF
--- a/gravitybridge/chain.json
+++ b/gravitybridge/chain.json
@@ -45,12 +45,13 @@
   },
   "codebase": {
     "git_repo": "https://github.com/Gravity-Bridge/Gravity-Bridge",
-    "recommended_version": "v1.10.0",
+    "recommended_version": "v1.10.2",
     "compatible_versions": [
-      "v1.10.0"
+      "v1.10.0",
+      "v1.10.2"
     ],
     "binaries": {
-      "linux/amd64": "https://github.com/Gravity-Bridge/Gravity-Bridge/releases/download/v1.10.0/gravity-linux-amd64"
+      "linux/amd64": "https://github.com/Gravity-Bridge/Gravity-Bridge/releases/download/v1.10.2/gravity-linux-amd64"
     },
     "genesis": {
       "genesis_url": "https://raw.githubusercontent.com/Gravity-Bridge/Gravity-Docs/main/genesis.json"
@@ -87,13 +88,14 @@
       {
         "name": "antares",
         "height": 7440250,
-        "recommended_version": "v1.10.0",
+        "recommended_version": "v1.10.2",
         "proposal": 183,
         "compatible_versions": [
-          "v1.10.0"
+          "v1.10.0",
+          "v1.10.2"
         ],
         "binaries": {
-          "linux/amd64": "https://github.com/Gravity-Bridge/Gravity-Bridge/releases/download/v1.10.0/gravity-linux-amd64"
+          "linux/amd64": "https://github.com/Gravity-Bridge/Gravity-Bridge/releases/download/v1.10.2/gravity-linux-amd64"
         }
       }
     ]


### PR DESCRIPTION
Non-consensus upgrade

https://github.com/Gravity-Bridge/Gravity-Bridge/releases/tag/v1.10.2