### PR TITLE
Composable v6.3.1 patch

### DIFF
--- a/composable/chain.json
+++ b/composable/chain.json
@@ -33,9 +33,9 @@
   },
   "codebase": {
     "git_repo": "https://github.com/notional-labs/composable-centauri",
-    "recommended_version": "v5.1.0",
+    "recommended_version": "v6.3.1",
     "compatible_versions": [
-      "v5.1.0"
+      "v6.3.1"
     ],
     "genesis": {
       "genesis_url": "https://raw.githubusercontent.com/notional-labs/composable-networks/main/mainnet/genesis.json"
@@ -135,10 +135,10 @@
       },
       {
         "name": "v6",
-        "tag": "v6.3.0",
-        "recommended_version": "v6.3.0",
+        "tag": "v6.3.1",
+        "recommended_version": "v6.3.1",
         "compatible_versions": [
-          "v6.3.0"
+          "v6.3.1"
         ],
         "cosmos_sdk_version": "v0.47.5",
         "ibc_go_version": "v7.3.1",


### PR DESCRIPTION
Chain halt on upgrade, previous version removed as it is *not* compatible. 

https://github.com/notional-labs/composable-centauri/releases/tag/v6.3.1