### PR TITLE
Upgrade Akash to v0.26.2

### DIFF
--- a/akash/chain.json
+++ b/akash/chain.json
@@ -27,13 +27,14 @@
   },
   "codebase": {
     "git_repo": "https://github.com/akash-network/node/",
-    "recommended_version": "v0.26.1",
+    "recommended_version": "v0.26.2",
     "compatible_versions": [
-      "v0.26.1"
+      "v0.26.1",
+      "v0.26.2"
     ],
     "binaries": {
-      "linux/amd64": "https://github.com/akash-network/node/releases/download/v0.26.1/akash_linux_amd64.zip",
-      "linux/arm64": "https://github.com/akash-network/node/releases/download/v0.26.1/akash_linux_arm64.zip"
+      "linux/amd64": "https://github.com/akash-network/node/releases/download/v0.26.2/akash_linux_amd64.zip",
+      "linux/arm64": "https://github.com/akash-network/node/releases/download/v0.26.2/akash_linux_arm64.zip"
     },
     "genesis": {
       "genesis_url": "https://raw.githubusercontent.com/akash-network/net/master/mainnet/genesis.json"
@@ -65,15 +66,16 @@
       },
       {
         "name": "v0.26.0",
-        "recommended_version": "v0.26.1",
+        "recommended_version": "v0.26.2",
         "compatible_versions": [
-          "v0.26.1"
+          "v0.26.1",
+          "v0.26.2"
         ],
         "proposal": 231,
         "height": 12992204,
         "binaries": {
-          "linux/amd64": "https://github.com/akash-network/node/releases/download/v0.26.1/akash_linux_amd64.zip",
-          "linux/arm64": "https://github.com/akash-network/node/releases/download/v0.26.1/akash_linux_arm64.zip"
+          "linux/amd64": "https://github.com/akash-network/node/releases/download/v0.26.2/akash_linux_amd64.zip",
+          "linux/arm64": "https://github.com/akash-network/node/releases/download/v0.26.2/akash_linux_arm64.zip"
         },
         "next_version_name": ""
       }


### PR DESCRIPTION
Non-prop upgrade:

https://github.com/akash-network/node/releases/tag/v0.26.2