### PR TITLE
Fix wstETH base capitalization

### DIFF
--- a/gateway/assetlist.json
+++ b/gateway/assetlist.json
@@ -144,19 +144,14 @@
           "type": "bridge",
           "counterparty": {
             "chain_name": "ethereum",
-            "base_denom": "0x7f39C581F595B53c5cb19bD0b3f8dA6c935E2Ca0"
+            "base_denom": "0x7f39c581f595b53c5cb19bd0b3f8da6c935e2ca0"
           },
           "provider": "Wormhole"
         }
       ],
       "logo_URIs": {
         "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/_non-cosmos/ethereum/images/wsteth.svg"
-      },
-      "images": [
-        {
-          "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/_non-cosmos/ethereum/images/wsteth.svg"
-        }
-      ]
+      }
     },
     {
       "description": "Aptos Coin (Wormhole), APT, factory/wormhole14ejqjyq8um4p3xfqj74yld5waqljf88fz25yxnma0cngspxe3les00fpjx/5wS2fGojbL9RhGEAeQBdkHPUAciYDxjDTMYvdf9aDn2r",

--- a/neutron/assetlist.json
+++ b/neutron/assetlist.json
@@ -198,7 +198,7 @@
           "type": "additional-mintage",
           "counterparty": {
             "chain_name": "ethereum",
-            "base_denom": "0x7f39C581F595B53c5cb19bD0b3f8dA6c935E2Ca0"
+            "base_denom": "0x7f39c581f595b53c5cb19bd0b3f8da6c935e2ca0"
           },
           "provider": "Lido"
         }
@@ -207,7 +207,7 @@
         {
           "image_sync": {
             "chain_name": "ethereum",
-            "base_denom": "0x7f39C581F595B53c5cb19bD0b3f8dA6c935E2Ca0"
+            "base_denom": "0x7f39c581f595b53c5cb19bd0b3f8da6c935e2ca0"
           }
         }
       ]


### PR DESCRIPTION
The image script (and other automation) needs the pointer's base_denom to have the same capitalization as the base property in the original asset definition. for ethereum contracts, different interfaces seem to capitalize the letters differently to each other, leading to this inconsistency we see.

Correcting for NTRN and wormhole, and hopefully the image sync script with pull the images correctly for them now.

Ethereum had:
0x7f39c581f595b53c5cb19bd0b3f8da6c935e2ca0
vs
0x7f39C581F595B53c5cb19bD0b3f8dA6c935E2Ca0
which gateway(wormhole) and neutron had