### PR TITLE
Update Provenance chain.json with release 1.17.0

### DIFF
--- a/provenance/chain.json
+++ b/provenance/chain.json
@@ -51,7 +51,7 @@
     ],
     "binaries": {
       "linux/amd64": "https://github.com/provenance-io/provenance/releases/download/v1.17.0/provenance-linux-amd64-v1.17.0.zip"
-    }
+    },
     "genesis": {
       "name": "v1.0.1",
       "genesis_url": "https://raw.githubusercontent.com/provenance-io/mainnet/main/pio-mainnet-1/genesis.json"

--- a/provenance/chain.json
+++ b/provenance/chain.json
@@ -249,6 +249,30 @@
         "binaries": {
           "linux/amd64": "https://github.com/provenance-io/provenance/releases/download/v1.16.0/provenance-linux-amd64-v1.16.0.zip"
         }
+      },
+      {
+        "name": "saffron",
+        "tag": "v1.17.0",
+        "height": 13736000,
+        "recommended_version": "v1.17.0",
+        "compatible_versions": [
+          "v1.17.0"
+        ],
+        "cosmos_sdk_version": "0.46.13",
+        "consensus": {
+          "type": "tendermint",
+          "version": "0.34.29"
+        },
+        "cosmwasm_version": "0.30",
+        "cosmwasm_enabled": true,
+        "ibc_go_version": "6.2.0",
+        "ics_enabled": [
+          "ics20-1",
+          "ics27-1"
+        ],
+        "binaries": {
+          "linux/amd64": "https://github.com/provenance-io/provenance/releases/download/v1.17.0/provenance-linux-amd64-v1.17.0.zip"
+        }
       }
     ]
   },

--- a/provenance/chain.json
+++ b/provenance/chain.json
@@ -33,21 +33,14 @@
   },
   "codebase": {
     "git_repo": "https://github.com/provenance-io/provenance",
-    "recommended_version": "v1.16.0",
+    "recommended_version": "v1.17.0",
     "compatible_versions": [
-      "v1.16.0"
+      "v1.17.0"
     ],
-    "binaries": {
-      "linux/amd64": "https://github.com/provenance-io/provenance/releases/download/v1.16.0/provenance-linux-amd64-v1.16.0.zip"
-    },
-    "genesis": {
-      "name": "v1.0.1",
-      "genesis_url": "https://raw.githubusercontent.com/provenance-io/mainnet/main/pio-mainnet-1/genesis.json"
-    },
     "cosmos_sdk_version": "0.46.13",
     "consensus": {
       "type": "tendermint",
-      "version": "0.34.28"
+      "version": "0.34.29"
     },
     "cosmwasm_version": "0.30",
     "cosmwasm_enabled": true,
@@ -56,6 +49,13 @@
       "ics20-1",
       "ics27-1"
     ],
+    "binaries": {
+      "linux/amd64": "https://github.com/provenance-io/provenance/releases/download/v1.17.0/provenance-linux-amd64-v1.17.0.zip"
+    }
+    "genesis": {
+      "name": "v1.0.1",
+      "genesis_url": "https://raw.githubusercontent.com/provenance-io/mainnet/main/pio-mainnet-1/genesis.json"
+    },
     "versions": [
       {
         "name": "v1.0.1",


### PR DESCRIPTION
Updates Provenance Blockchain list of supported versions with information associated with 1.17.0/saffron upgrade.