### PR TITLE
akash: bump to v0.28.2 for mainnet8

### DIFF
--- a/akash/chain.json
+++ b/akash/chain.json
@@ -27,17 +27,16 @@
   },
   "codebase": {
     "git_repo": "https://github.com/akash-network/node/",
-    "recommended_version": "v0.26.2",
+    "recommended_version": "v0.28.2",
     "compatible_versions": [
-      "v0.26.1",
-      "v0.26.2"
+      "v0.28.2"
     ],
     "binaries": {
-      "linux/amd64": "https://github.com/akash-network/node/releases/download/v0.26.2/akash_linux_amd64.zip",
-      "linux/arm64": "https://github.com/akash-network/node/releases/download/v0.26.2/akash_linux_arm64.zip"
+      "linux/amd64": "https://github.com/akash-network/node/releases/download/v0.28.2/akash_linux_amd64.zip",
+      "linux/arm64": "https://github.com/akash-network/node/releases/download/v0.28.2/akash_linux_arm64.zip"
     },
     "genesis": {
-      "genesis_url": "https://raw.githubusercontent.com/akash-network/net/master/mainnet/genesis.json"
+      "genesis_url": "https://raw.githubusercontent.com/akash-network/net/main/mainnet/genesis.json"
     },
     "versions": [
       {
@@ -76,6 +75,20 @@
         "binaries": {
           "linux/amd64": "https://github.com/akash-network/node/releases/download/v0.26.2/akash_linux_amd64.zip",
           "linux/arm64": "https://github.com/akash-network/node/releases/download/v0.26.2/akash_linux_arm64.zip"
+        },
+        "next_version_name": "v0.28.0"
+      },
+      {
+        "name": "v0.28.0",
+        "recommended_version": "v0.28.2",
+        "compatible_versions": [
+          "v0.28.2"
+        ],
+        "proposal": 237,
+        "height": 13759618,
+        "binaries": {
+          "linux/amd64": "https://github.com/akash-network/node/releases/download/v0.28.2/akash_linux_amd64.zip",
+          "linux/arm64": "https://github.com/akash-network/node/releases/download/v0.28.2/akash_linux_arm64.zip"
         },
         "next_version_name": ""
       }


### PR DESCRIPTION
## merge once mainnet is at 0.28.2 !

the upgrade procedure:
https://docs.akash.network/akash-mainnet8-upgrade/mainnet8-provider-upgrade-procedure


mainnet 0.28.2 is planned on `UTC: Nov 20th 2023, 03:40:35`, as per prop #237 -- upgrade height https://www.mintscan.io/akash/block/13759618
