### PR TITLE
Add "sei-tendermint" to chain.schema.json

### DIFF
--- a/chain.schema.json
+++ b/chain.schema.json
@@ -218,7 +218,8 @@
               "type": "string",
               "enum": [
                 "tendermint",
-                "cometbft"
+                "cometbft",
+                "sei-tendermint"
               ]
             },
             "version": {
@@ -324,7 +325,8 @@
                     "type": "string",
                     "enum": [
                       "tendermint",
-                      "cometbft"
+                      "cometbft",
+                      "sei-tendermint"
                     ]
                   },
                   "version": {


### PR DESCRIPTION
Sei uses their own forked custom modules for consensus, wasm, ibc, etc., In order to properly list "sei-tendermint" with its proper version for sei, we should add this to the chain schema.