### PR TITLE
fix: kujira assetlist display

### DIFF
--- a/kujira/assetlist.json
+++ b/kujira/assetlist.json
@@ -44,7 +44,7 @@
       ],
       "base": "factory/kujira1qk00h5atutpsv900x202pxx42npjr9thg58dnqpa72f2p7m2luase444a7/uusk",
       "name": "USK",
-      "display": "USK",
+      "display": "usk",
       "symbol": "USK",
       "coingecko_id": "usk",
       "logo_URIs": {
@@ -124,7 +124,7 @@
       ],
       "base": "factory/kujira1643jxg8wasy5cfcn7xm8rd742yeazcksqlg4d7/umnta",
       "name": "MNTA",
-      "display": "MNTA",
+      "display": "mnta",
       "symbol": "MNTA",
       "coingecko_id": "mantadao",
       "logo_URIs": {
@@ -146,7 +146,7 @@
           "exponent": 0
         },
         {
-          "denom": "qcKUJI",
+          "denom": "qcMNTA",
           "exponent": 6
         }
       ],


### PR DESCRIPTION
Fix the `display` to be the same as in `denom_units`.