### PR TITLE
Update fees for many Chains

### DIFF
--- a/akash/chain.json
+++ b/akash/chain.json
@@ -14,7 +14,10 @@
     "fee_tokens": [
       {
         "denom": "uakt",
-        "fixed_min_gas_price": 0
+        "fixed_min_gas_price": 0,
+        "low_gas_price": 0.00025,
+        "average_gas_price": 0.0025,
+        "high_gas_price": 0.025
       }
     ]
   },

--- a/bandchain/chain.json
+++ b/bandchain/chain.json
@@ -13,7 +13,10 @@
   "fees": {
     "fee_tokens": [
       {
-        "denom": "uband"
+        "denom": "uband",
+        "low_gas_price": 0.0025,
+        "average_gas_price": 0.003,
+        "high_gas_price": 0.005
       }
     ]
   },

--- a/carbon/chain.json
+++ b/carbon/chain.json
@@ -17,7 +17,7 @@
     "fee_tokens": [
       {
         "denom": "swth",
-        "fixed_min_gas_price": 100000000,
+        "fixed_min_gas_price": 1,
         "low_gas_price": 1,
         "average_gas_price": 1,
         "high_gas_price": 1,

--- a/doravota/chain.json
+++ b/doravota/chain.json
@@ -14,7 +14,10 @@
     "fee_tokens": [
       {
         "denom": "peaka",
-        "fixed_min_gas_price": 100000000000
+        "fixed_min_gas_price": 100000000000,
+        "low_gas_price": 100000000000,
+        "average_gas_price": 100000000000,
+        "high_gas_price": 100000000000
       }
     ]
   },

--- a/impacthub/chain.json
+++ b/impacthub/chain.json
@@ -20,8 +20,8 @@
         "denom": "uixo",
         "fixed_min_gas_price": 0.025,
         "low_gas_price": 0.025,
-        "average_gas_price": 0.4,
-        "high_gas_price": 0.1
+        "average_gas_price": 0.025,
+        "high_gas_price": 0.04
       }
     ]
   },

--- a/konstellation/chain.json
+++ b/konstellation/chain.json
@@ -36,7 +36,10 @@
     "fee_tokens": [
       {
         "denom": "udarc",
-        "fixed_min_gas_price": 0
+        "fixed_min_gas_price": 0,
+        "low_gas_price": 0.0001,
+    		"average_gas_price": 0.001,
+    		"high_gas_price": 0.01
       }
     ]
   },

--- a/testnets/cosmoshubtestnet/chain.json
+++ b/testnets/cosmoshubtestnet/chain.json
@@ -16,7 +16,10 @@
     "fee_tokens": [
       {
         "denom": "uatom",
-        "fixed_min_gas_price": 0.0025
+        "fixed_min_gas_price": 0.0025,
+        "low_gas_price": 0.01,
+        "average_gas_price": 0.025,
+        "high_gas_price": 0.03
       }
     ]
   },

--- a/testnets/persistencetestnet/chain.json
+++ b/testnets/persistencetestnet/chain.json
@@ -17,7 +17,10 @@
     "fee_tokens": [
       {
         "denom": "uxprt",
-        "fixed_min_gas_price": 0
+        "fixed_min_gas_price": 0,
+        "low_gas_price": 0.05,
+        "average_gas_price": 0.125,
+        "high_gas_price": 0.2
       }
     ]
   },

--- a/testnets/persistencetestnet2/chain.json
+++ b/testnets/persistencetestnet2/chain.json
@@ -17,7 +17,10 @@
     "fee_tokens": [
       {
         "denom": "uxprt",
-        "fixed_min_gas_price": 0
+        "fixed_min_gas_price": 0,
+        "low_gas_price": 0.05,
+        "average_gas_price": 0.125,
+        "high_gas_price": 0.2
       }
     ]
   },


### PR DESCRIPTION
Update fees for many Chains

  'akash', (done, pulled from Leap -- pending PR)
  'impacthub', (done, pulled from Leap and Keplr--pending PR--they just needed the fees reordered)
  'bandchain', (done, pulled from Keplr -- pending PR)
  'konstellation', (done, pulled from Leap -- pending PR)
  'carbon', (fixed--pending PR)
  'doravota', (done, pulled from Keplr -- pending PR)
  'cosmoshubtestnet', (done, pulled from Keplr -- pending PR)
  'persistencetestnet2' (done, pulled from Keplr -- pending PR)