### PR TITLE
Update Chain Fees to Default

### DIFF
--- a/beezee/chain.json
+++ b/beezee/chain.json
@@ -16,7 +16,10 @@
     "fee_tokens": [
       {
         "denom": "ubze",
-        "fixed_min_gas_price": 0
+        "fixed_min_gas_price": 0,
+        "low_gas_price": 0.01,
+        "average_gas_price": 0.025,
+        "high_gas_price": 0.04
       }
     ]
   },

--- a/cerberus/chain.json
+++ b/cerberus/chain.json
@@ -33,7 +33,10 @@
     "fee_tokens": [
       {
         "denom": "ucrbrus",
-        "fixed_min_gas_price": 0
+        "fixed_min_gas_price": 0,
+        "low_gas_price": 0.01,
+        "average_gas_price": 0.025,
+        "high_gas_price": 0.04
       }
     ]
   },

--- a/microtick/chain.json
+++ b/microtick/chain.json
@@ -11,7 +11,10 @@
   "fees": {
     "fee_tokens": [
       {
-        "denom": "utick"
+        "denom": "utick",
+        "low_gas_price": 0.01,
+        "average_gas_price": 0.025,
+        "high_gas_price": 0.04
       }
     ]
   },

--- a/rebus/chain.json
+++ b/rebus/chain.json
@@ -17,7 +17,10 @@
     "fee_tokens": [
       {
         "denom": "arebus",
-        "fixed_min_gas_price": 0
+        "fixed_min_gas_price": 0,
+        "low_gas_price": 0.01,
+        "average_gas_price": 0.025,
+        "high_gas_price": 0.04
       }
     ]
   },

--- a/sommelier/chain.json
+++ b/sommelier/chain.json
@@ -16,7 +16,10 @@
   "fees": {
     "fee_tokens": [
       {
-        "denom": "usomm"
+        "denom": "usomm",
+        "low_gas_price": 0.01,
+        "average_gas_price": 0.025,
+        "high_gas_price": 0.04
       }
     ]
   },


### PR DESCRIPTION
I see the fees for these chains on popular wallets using the default values:
"low_gas_price": 0.01,
        "average_gas_price": 0.025,
        "high_gas_price": 0.04

for sommelier, rebus, beezee, cerberus, microtick