### PR TITLE
fix: remove duplicated ibc asset record of osmosis

### DIFF
--- a/osmosis/assetlist.json
+++ b/osmosis/assetlist.json
@@ -569,55 +569,6 @@
       ]
     },
     {
-      "description": "DYDX on Osmosis",
-      "denom_units": [
-        {
-          "denom": "ibc/831F0B1BBB1D08A2B75311892876D71565478C532967545476DF4C2D7492E48C",
-          "exponent": 0,
-          "aliases": [
-            "adydx"
-          ]
-        },
-        {
-          "denom": "dydx",
-          "exponent": 18
-        }
-      ],
-      "type_asset": "ics20",
-      "base": "ibc/831F0B1BBB1D08A2B75311892876D71565478C532967545476DF4C2D7492E48C",
-      "name": "DYDX",
-      "display": "dydx",
-      "symbol": "DYDX",
-      "traces": [
-        {
-          "type": "ibc",
-          "counterparty": {
-            "chain_name": "dydx",
-            "base_denom": "adydx",
-            "channel_id": "channel-3"
-          },
-          "chain": {
-            "channel_id": "channel-6787",
-            "path": "transfer/channel-6787/adydx"
-          }
-        }
-      ],
-      "images": [
-        {
-          "image_sync": {
-            "chain_name": "dydx",
-            "base_denom": "adydx"
-          },
-          "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/dydx/images/dydx.png",
-          "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/dydx/images/dydx.svg"
-        }
-      ],
-      "logo_URIs": {
-        "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/dydx/images/dydx.png",
-        "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/dydx/images/dydx.svg"
-      }
-    },
-    {
       "description": "TIA on Osmosis",
       "denom_units": [
         {


### PR DESCRIPTION
ibc/831F0B1BBB1D08A2B75311892876D71565478C532967545476DF4C2D7492E48C
is duplicated at [L572](https://github.com/cosmos/chain-registry/blob/a11f9a6eb14dc23759ccd601280361d41e8a3517/osmosis/assetlist.json#L572) and [L956](https://github.com/cosmos/chain-registry/blob/a11f9a6eb14dc23759ccd601280361d41e8a3517/osmosis/assetlist.json#L956)
so I removed the old (572), keep the new (956)

Diff:
```text
# L572:
"description": "DYDX on Osmosis",
"name": "DYDX",
```
```text
# L956:
"description": "The native staking token of dYdX Protocol.",
"name": "dYdX",
```