### PR TITLE
Remove non-public starname endpoints

### DIFF
--- a/starname/chain.json
+++ b/starname/chain.json
@@ -80,10 +80,6 @@
         "provider": "Starname"
       },
       {
-        "address": "https://rpc-iov.keplr.app",
-        "provider": "chainapsis"
-      },
-      {
         "address": "https://rpc-starname-ia.cosmosia.notional.ventures/",
         "provider": "Notional"
       },
@@ -96,10 +92,6 @@
       {
         "address": "https://api.starname.cosmos.iov.one",
         "provider": "Starname"
-      },
-      {
-        "address": "https://lcd-iov.keplr.app",
-        "provider": "chainapsis"
       },
       {
         "address": "https://api-starname-ia.cosmosia.notional.ventures/",


### PR DESCRIPTION
Remove non-public starname endpoints from the chain-registry.