### PR TITLE
Upgrade likecoin to v4.1.1

### DIFF
--- a/likecoin/chain.json
+++ b/likecoin/chain.json
@@ -36,18 +36,16 @@
   },
   "codebase": {
     "git_repo": "https://github.com/likecoin/likecoin-chain",
-    "recommended_version": "v4.0.1",
+    "recommended_version": "v4.1.1",
     "compatible_versions": [
-      "v4.0.0",
-      "v4.0.1",
-      "v4.0.2"
+      "v4.1.1"
     ],
     "binaries": {
-      "linux/amd64": "https://github.com/likecoin/likecoin-chain/releases/download/v4.0.1/likecoin-chain_4.0.1_Linux_x86_64.tar.gz",
-      "linux/arm64": "https://github.com/likecoin/likecoin-chain/releases/download/v4.0.1/likecoin-chain_4.0.1_Linux_arm64.tar.gz",
-      "darwin/amd64": "https://github.com/likecoin/likecoin-chain/releases/download/v4.0.1/likecoin-chain_4.0.1_Darwin_x86_64.tar.gz",
-      "darwin/arm64": "https://github.com/likecoin/likecoin-chain/releases/download/v4.0.1/likecoin-chain_4.0.1_Darwin_arm64.tar.gz",
-      "windows/amd64": "https://github.com/likecoin/likecoin-chain/releases/download/v4.0.1/likecoin-chain_4.0.1_Windows_x86_64.zip"
+      "linux/amd64": "https://github.com/likecoin/likecoin-chain/releases/download/v4.1.1/likecoin-chain_4.1.1_Linux_x86_64.tar.gz",
+      "linux/arm64": "https://github.com/likecoin/likecoin-chain/releases/download/v4.1.1/likecoin-chain_4.1.1_Linux_arm64.tar.gz",
+      "darwin/amd64": "https://github.com/likecoin/likecoin-chain/releases/download/v4.1.1/likecoin-chain_4.1.1_Darwin_x86_64.tar.gz",
+      "darwin/arm64": "https://github.com/likecoin/likecoin-chain/releases/download/v4.1.1/likecoin-chain_4.1.1_Darwin_arm64.tar.gz",
+      "windows/amd64": "https://github.com/likecoin/likecoin-chain/releases/download/v4.1.1/likecoin-chain_4.1.1_Windows_x86_64.zip"
     },
     "cosmos_sdk_version": "0.46",
     "consensus": {
@@ -55,7 +53,7 @@
       "version": "0.34"
     },
     "cosmwasm_enabled": false,
-    "ibc_go_version": "5.3.0",
+    "ibc_go_version": "6.2.1",
     "ics_enabled": [
       "ics20-1"
     ],
@@ -157,7 +155,31 @@
           "darwin/amd64": "https://github.com/likecoin/likecoin-chain/releases/download/v4.0.1/likecoin-chain_4.0.1_Darwin_x86_64.tar.gz",
           "darwin/arm64": "https://github.com/likecoin/likecoin-chain/releases/download/v4.0.1/likecoin-chain_4.0.1_Darwin_arm64.tar.gz",
           "windows/amd64": "https://github.com/likecoin/likecoin-chain/releases/download/v4.0.1/likecoin-chain_4.0.1_Windows_x86_64.zip"
-        }
+        },
+        "next_version_name": "v4.1.1"
+      },
+      {
+        "name": "v4.1.1",
+        "tag": "v4.1.1",
+        "height": 12102100,
+        "recommended_version": "v4.1.1",
+        "compatible_versions": [
+          "v4.1.1"
+        ],
+        "cosmos_sdk_version": "0.46",
+        "ibc_go_version": "6.2.1",
+        "consensus": {
+          "type": "tendermint",
+          "version": "0.34"
+        },
+        "binaries": {
+          "linux/amd64": "https://github.com/likecoin/likecoin-chain/releases/download/v4.1.1/likecoin-chain_4.1.1_Linux_x86_64.tar.gz",
+          "linux/arm64": "https://github.com/likecoin/likecoin-chain/releases/download/v4.1.1/likecoin-chain_4.1.1_Linux_arm64.tar.gz",
+          "darwin/amd64": "https://github.com/likecoin/likecoin-chain/releases/download/v4.1.1/likecoin-chain_4.1.1_Darwin_x86_64.tar.gz",
+          "darwin/arm64": "https://github.com/likecoin/likecoin-chain/releases/download/v4.1.1/likecoin-chain_4.1.1_Darwin_arm64.tar.gz",
+          "windows/amd64": "https://github.com/likecoin/likecoin-chain/releases/download/v4.1.1/likecoin-chain_4.1.1_Windows_x86_64.zip"
+        },
+        "next_version_name": ""
       }
     ]
   },
@@ -184,6 +206,16 @@
         "id": "f087d600cf3d34d3bac04a9723a53180619e8445",
         "address": "35.247.83.138:26656",
         "provider": "like.co"
+      },
+      {
+        "id": "20afcd5637b2278efc78c54fd523bd331d1820f2",
+        "address": "78.47.110.110:26656",
+        "provider": "moonbeam"
+      },
+      {
+        "id": "5940f55e0e7e2f1a2c9507bf62fbfd7c6d2f3874",
+        "address": "likechain.oursky.com:26656",
+        "provider": "Oursky"
       }
     ]
   },
@@ -200,6 +232,10 @@
       {
         "address": "https://rpc-likecoin-mainnet.pikaser.net",
         "provider": "PikaSer"
+      },
+      {
+        "address": "http://51.159.223.25:28657",
+        "provider": "Citizen"
       }
     ],
     "rest": [
@@ -217,6 +253,10 @@
       }
     ],
     "grpc": [
+      {
+        "address": "mainnet-node-grpc.like.co:80",
+        "provider": "like.co"
+      },
       {
         "address": "https://likecoin-node.oldcat.io:443/grpc/",
         "provider": "Oldcat"

--- a/testnets/likecointestnet/chain.json
+++ b/testnets/likecointestnet/chain.json
@@ -35,18 +35,16 @@
   },
   "codebase": {
     "git_repo": "https://github.com/likecoin/likecoin-chain",
-    "recommended_version": "v4.0.1",
+    "recommended_version": "v4.1.1",
     "compatible_versions": [
-      "v4.0.0",
-      "v4.0.1",
-      "v4.0.2"
+      "v4.1.1"
     ],
     "binaries": {
-      "linux/amd64": "https://github.com/likecoin/likecoin-chain/releases/download/v4.0.1/likecoin-chain_4.0.1_Linux_x86_64.tar.gz",
-      "linux/arm64": "https://github.com/likecoin/likecoin-chain/releases/download/v4.0.1/likecoin-chain_4.0.1_Linux_arm64.tar.gz",
-      "darwin/amd64": "https://github.com/likecoin/likecoin-chain/releases/download/v4.0.1/likecoin-chain_4.0.1_Darwin_x86_64.tar.gz",
-      "darwin/arm64": "https://github.com/likecoin/likecoin-chain/releases/download/v4.0.1/likecoin-chain_4.0.1_Darwin_arm64.tar.gz",
-      "windows/amd64": "https://github.com/likecoin/likecoin-chain/releases/download/v4.0.1/likecoin-chain_4.0.1_Windows_x86_64.zip"
+      "linux/amd64": "https://github.com/likecoin/likecoin-chain/releases/download/v4.1.1/likecoin-chain_4.1.1_Linux_x86_64.tar.gz",
+      "linux/arm64": "https://github.com/likecoin/likecoin-chain/releases/download/v4.1.1/likecoin-chain_4.1.1_Linux_arm64.tar.gz",
+      "darwin/amd64": "https://github.com/likecoin/likecoin-chain/releases/download/v4.1.1/likecoin-chain_4.1.1_Darwin_x86_64.tar.gz",
+      "darwin/arm64": "https://github.com/likecoin/likecoin-chain/releases/download/v4.1.1/likecoin-chain_4.1.1_Darwin_arm64.tar.gz",
+      "windows/amd64": "https://github.com/likecoin/likecoin-chain/releases/download/v4.1.1/likecoin-chain_4.1.1_Windows_x86_64.zip"
     },
     "cosmos_sdk_version": "0.46",
     "consensus": {
@@ -54,7 +52,7 @@
       "version": "0.34"
     },
     "cosmwasm_enabled": false,
-    "ibc_go_version": "5.3.0",
+    "ibc_go_version": "6.2.1",
     "ics_enabled": [
       "ics20-1"
     ],


### PR DESCRIPTION
LikeCoin chain was upgraded to v4.1.1 at height 12102100

https://www.mintscan.io/likecoin/proposals/77