### PR TITLE
Fix ixo testnet Image URLs

### DIFF
--- a/testnets/impacthubtestnet/assetlist.json
+++ b/testnets/impacthubtestnet/assetlist.json
@@ -24,7 +24,7 @@
           "counterparty": {
             "chain_name": "impacthub",
             "base_denom": "uixo"
-          }
+          },
           "provider": "impacthub"
         }
       ]

--- a/testnets/impacthubtestnet/assetlist.json
+++ b/testnets/impacthubtestnet/assetlist.json
@@ -21,8 +21,11 @@
       "traces": [
         {
           "type": "test-mintage",
-          "chain_name": "impacthub",
-          "base_denom": "uixo"
+          "counterparty": {
+            "chain_name": "impacthub",
+            "base_denom": "uixo"
+          }
+          "provider": "impacthub"
         }
       ]
     }

--- a/testnets/impacthubtestnet/assetlist.json
+++ b/testnets/impacthubtestnet/assetlist.json
@@ -18,15 +18,11 @@
       "name": "IXO",
       "display": "ixo",
       "symbol": "IXO",
-      "logo_URIs": {
-        "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/impacthubtestnet/images/ixo.png",
-        "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/impacthubtestnet/images/ixo.svg"
-      },
-      "coingecko_id": "ixo",
-      "images": [
+      "traces": [
         {
-          "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/impacthubtestnet/images/ixo.png",
-          "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/impacthubtestnet/images/ixo.svg"
+          "type": "test-mintage",
+          "chain_name": "impacthub",
+          "base_denom": "uixo"
         }
       ]
     }


### PR DESCRIPTION
Fix ixo testnet Image URLs by removing the image urls and tracing it back to mainnet ixo