### PR TITLE
Update junotestnet-noistestnet.json

### DIFF
--- a/testnets/_IBC/junotestnet-noistestnet.json
+++ b/testnets/_IBC/junotestnet-noistestnet.json
@@ -2,22 +2,22 @@
   "$schema": "../ibc_data.schema.json",
   "chain_1": {
     "chain_name": "junotestnet",
-    "client_id": "07-tendermint-169",
-    "connection_id": "connection-177"
+    "client_id": "07-tendermint-170",
+    "connection_id": "connection-178"
   },
   "chain_2": {
     "chain_name": "noistestnet",
-    "client_id": "07-tendermint-15",
-    "connection_id": "connection-4"
+    "client_id": "07-tendermint-16",
+    "connection_id": "connection-5"
   },
   "channels": [
     {
       "chain_1": {
-        "channel_id": "channel-175",
+        "channel_id": "channel-877",
         "port_id": "transfer"
       },
       "chain_2": {
-        "channel_id": "channel-3",
+        "channel_id": "channel-69",
         "port_id": "transfer"
       },
       "ordering": "unordered",


### PR DESCRIPTION
Old client was expired because of some issues on testnet. Now it's back