### PR TITLE
Add Coingecko IDs for Osmosis natives

### DIFF
--- a/osmosis/assetlist.json
+++ b/osmosis/assetlist.json
@@ -83,6 +83,7 @@
       "logo_URIs": {
         "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/osmosis/images/ibcx.svg"
       },
+      "coingecko_id": "ibc-index",
       "images": [
         {
           "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/osmosis/images/ibcx.svg"
@@ -537,6 +538,7 @@
       "logo_URIs": {
         "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/osmosis/images/CDT.svg"
       },
+      "coingecko_id": "collateralized-debt-token",
       "images": [
         {
           "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/osmosis/images/CDT.svg"
@@ -562,6 +564,7 @@
       "logo_URIs": {
         "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/osmosis/images/MBRN.svg"
       },
+      "coingecko_id": "membrane",
       "images": [
         {
           "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/osmosis/images/MBRN.svg"


### PR DESCRIPTION
Added Coingecko IDs for IBCX, MBRN, CDT
This should add external incentive display value for Osmosis' CDT pools