### PR TITLE
Add Chain Images Optional Layout Data

### DIFF
--- a/chain.schema.json
+++ b/chain.schema.json
@@ -444,8 +444,34 @@
             },
             "minProperties": 1,
             "additionalProperties": false
+          },
+          "layout": {
+            "type": "string",
+            "enum": ["logo", "logomark", "logotype"],
+            "description": "logomark == icon only; logotype == text only; logo == icon + text."
+          },
+          "text_position": {
+            "type": "string",
+            "enum": ["top", "bottom", "left", "right"],
+            "description": "Indicates in which position the text is placed, in case the layout is 'icon' type, it's required only in this case."
+          },
+        },
+        "if": {
+          "properties": {
+            "layout": { "const": "logo" }
           }
         },
+        "then": {
+          "required": ["text_position"]
+        },
+        "anyOf": [
+          {
+            "required": ["png"]
+          },
+          {
+            "required": ["svg"]
+          }
+        ],
         "additionalProperties": false
       }
     },

--- a/chain.schema.json
+++ b/chain.schema.json
@@ -452,14 +452,15 @@
           },
           "text_position": {
             "type": "string",
-            "enum": ["top", "bottom", "left", "right"],
+            "enum": ["top", "bottom", "left", "right", "integrated"],
             "description": "Indicates in which position the text is placed, in case the layout is 'icon' type, it's required only in this case."
           }
         },
         "if": {
           "properties": {
             "layout": { "const": "logo" }
-          }
+          },
+          "required": ["layout"]
         },
         "then": {
           "required": ["text_position"]

--- a/chain.schema.json
+++ b/chain.schema.json
@@ -454,7 +454,7 @@
             "type": "string",
             "enum": ["top", "bottom", "left", "right"],
             "description": "Indicates in which position the text is placed, in case the layout is 'icon' type, it's required only in this case."
-          },
+          }
         },
         "if": {
           "properties": {

--- a/osmosis/chain.json
+++ b/osmosis/chain.json
@@ -318,10 +318,13 @@
       "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/osmosis/images/osmosis-chain-logo.png",
       "theme": {
         "primary_color_hex": "#231D4B"
-      }
+      },
+      "layout": "logo",
+      "text_position": "right"
     },
     {
-      "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/osmosis/images/osmo.svg"
+      "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/osmosis/images/osmo.svg",
+      "layout": "logomark"
     }
   ],
   "logo_URIs": {


### PR DESCRIPTION
Add Chain Images Optional Layout Data
layout -> logo (icon + text), logotype (only text), logomark (only icon)
Not added to assetlist since token logo should never have this.

Added the properties to Osmosis' chain.json to serve as an example.