### PR TITLE
Upgrade Chain4Energy to v1.3.0

### DIFF
--- a/chain4energy/chain.json
+++ b/chain4energy/chain.json
@@ -114,6 +114,28 @@
           "linux/arm64": "https://github.com/chain4energy/c4e-chain/releases/download/v1.2.1/c4ed_v1.2.1_linux_arm64.tar.gz",
           "darwin/amd64": "https://github.com/chain4energy/c4e-chain/releases/download/v1.2.1/c4ed_v1.2.1_darwin_amd64.tar.gz"
         },
+        "next_version_name": "v1.3.0"
+      },
+      {
+        "name": "v1.3.0",
+        "tag": "v1.3.0",
+        "proposal": 7,
+        "height": 6283905,
+        "recommended_version": "v1.3.0",
+        "compatible_versions": [
+          "v1.3.0"
+        ],
+        "cosmos_sdk_version": "v0.46.13",
+        "ibc_go_version": "v5.2.1",
+        "consensus": {
+          "type": "cometbft",
+          "version": "v0.34.28"
+        },
+        "binaries": {
+          "linux/amd64": "https://github.com/chain4energy/c4e-chain/releases/download/v1.3.0/c4ed_v1.3.0_darwin_amd64.tar.gz",
+          "linux/arm64": "https://github.com/chain4energy/c4e-chain/releases/download/v1.3.0/c4ed_v1.3.0_linux_arm64.tar.gz",
+          "darwin/amd64": "https://github.com/chain4energy/c4e-chain/releases/download/v1.3.0/c4ed_v1.3.0_darwin_amd64.tar.gz"
+        },
         "next_version_name": ""
       }
     ]
@@ -177,11 +199,6 @@
         "id": "6b0ffcce9b59b91ceb8eea5d4599e27707e3604a",
         "address": "seeds.stakeup.tech:10210",
         "provider": "StakeUp"
-      },
-      {
-        "id": "03d0aa331240ede8090c1e4ab3e6756563a91204",
-        "address": "193.26.159.34:52656",
-        "provider": "genznodes"
       },
       {
         "id": "6cb7ff21d19f139f4ca5e6e2a336e59d2857aba1",


### PR DESCRIPTION
- remove genznodes seed node