### PR TITLE
Fix neutron-osmosis IBC client and connection IDs

### DIFF
--- a/_IBC/neutron-osmosis.json
+++ b/_IBC/neutron-osmosis.json
@@ -2,8 +2,8 @@
     "$schema": "../ibc_data.schema.json",
     "chain_1": {
       "chain_name": "neutron",
-      "client_id": "07-tendermint-18",
-      "connection_id": "connection-7"
+      "client_id": "07-tendermint-19",
+      "connection_id": "connection-18"
     },
     "chain_2": {
       "chain_name": "osmosis",


### PR DESCRIPTION
I noticed that the client and connection IDs on the Neutron side of the Neutron <> Osmosis transfer channels were wrong. This updates them:

client: `07-tendermint-19`
connection: `connection-18`