### PR TITLE
Fabo/change milkTIA base denom to IBC trace

### DIFF
--- a/osmosis/assetlist.json
+++ b/osmosis/assetlist.json
@@ -1053,7 +1053,7 @@
           "type": "liquid-stake",
           "counterparty": {
             "chain_name": "celestia",
-            "base_denom": "utia"
+            "base_denom": "ibc/D79E7D83AB399BFFF93433E54FAA480C191248FC556924A2A8351AE2638B387"
           },
           "provider": "MilkyWay"
         }

--- a/osmosis/assetlist.json
+++ b/osmosis/assetlist.json
@@ -1052,7 +1052,7 @@
         {
           "type": "liquid-stake",
           "counterparty": {
-            "chain_name": "celestia",
+            "chain_name": "osmosis",
             "base_denom": "ibc/D79E7D83AB399BFFF93433E54FAA480C191248FC556924A2A8351AE2638B387"
           },
           "provider": "MilkyWay"


### PR DESCRIPTION
Instead of using the base denom of the token on the native chain we need to provide the base denom of the token on Osmosis