### PR TITLE
Update rsprovidertestnet with Gaia v14

### DIFF
--- a/testnets/rsprovidertestnet/chain.json
+++ b/testnets/rsprovidertestnet/chain.json
@@ -16,7 +16,7 @@
     "fee_tokens": [
       {
         "denom": "uatom",
-        "fixed_min_gas_price": 0.0025
+        "fixed_min_gas_price": 0.005
       }
     ]
   },
@@ -29,18 +29,18 @@
   },
   "codebase": {
     "git_repo": "https://github.com/cosmos/gaia",
-    "recommended_version": "v13.0.0",
+    "recommended_version": "v14.1.0",
     "compatible_versions": [
-      "v13.0.0-rc0",
-      "v13.0.0"
+      "v14.1.0-rc0",
+      "v14.1.0"
     ],
     "binaries": {
-      "linux/amd64": "https://github.com/cosmos/gaia/releases/download/v13.0.0/gaiad-v13.0.0-linux-amd64",
-      "linux/arm64": "https://github.com/cosmos/gaia/releases/download/v13.0.0/gaiad-v13.0.0-linux-arm64",
-      "darwin/amd64": "https://github.com/cosmos/gaia/releases/download/v13.0.0/gaiad-v13.0.0-darwin-amd64",
-      "darwin/arm64": "https://github.com/cosmos/gaia/releases/download/v13.0.0/gaiad-v13.0.0-darwin-arm64",
-      "windows/amd64": "https://github.com/cosmos/gaia/releases/download/v13.0.0/gaiad-v13.0.0-windows-amd64.exe",
-      "windows/arm64": "https://github.com/cosmos/gaia/releases/download/v13.0.0/gaiad-v13.0.0-windows-arm64.exe"
+      "linux/amd64": "https://github.com/cosmos/gaia/releases/download/v14.1.0/gaiad-v14.1.0-linux-amd64",
+      "linux/arm64": "https://github.com/cosmos/gaia/releases/download/v14.1.0/gaiad-v14.1.0-linux-arm64",
+      "darwin/amd64": "https://github.com/cosmos/gaia/releases/download/v14.1.0/gaiad-v14.1.0-darwin-amd64",
+      "darwin/arm64": "https://github.com/cosmos/gaia/releases/download/v14.1.0/gaiad-v14.1.0-darwin-arm64",
+      "windows/amd64": "https://github.com/cosmos/gaia/releases/download/v14.1.0/gaiad-v14.1.0-windows-amd64.exe",
+      "windows/arm64": "https://github.com/cosmos/gaia/releases/download/v14.1.0/gaiad-v14.1.0-windows-arm64.exe"
     },
     "genesis": {
       "genesis_url": "https://github.com/cosmos/testnets/raw/master/replicated-security/provider/provider-genesis.json"
@@ -76,6 +76,22 @@
           "darwin/arm64": "https://github.com/cosmos/gaia/releases/download/v13.0.0/gaiad-v13.0.0-darwin-arm64",
           "windows/amd64": "https://github.com/cosmos/gaia/releases/download/v13.0.0/gaiad-v13.0.0-windows-amd64.exe",
           "windows/arm64": "https://github.com/cosmos/gaia/releases/download/v13.0.0/gaiad-v13.0.0-windows-arm64.exe"
+        }
+      },
+      {
+        "name": "v14",
+        "recommended_version": "v14.1.0",
+        "compatible_versions": [
+          "v14.1.0-rc0",
+          "v14.1.0"
+        ],
+        "binaries": {
+          "linux/amd64": "https://github.com/cosmos/gaia/releases/download/v14.1.0/gaiad-v14.1.0-linux-amd64",
+          "linux/arm64": "https://github.com/cosmos/gaia/releases/download/v14.1.0/gaiad-v14.1.0-linux-arm64",
+          "darwin/amd64": "https://github.com/cosmos/gaia/releases/download/v14.1.0/gaiad-v14.1.0-darwin-amd64",
+          "darwin/arm64": "https://github.com/cosmos/gaia/releases/download/v14.1.0/gaiad-v14.1.0-darwin-arm64",
+          "windows/amd64": "https://github.com/cosmos/gaia/releases/download/v14.1.0/gaiad-v14.1.0-windows-amd64.exe",
+          "windows/arm64": "https://github.com/cosmos/gaia/releases/download/v14.1.0/gaiad-v14.1.0-windows-arm64.exe"
         }
       }
     ]


### PR DESCRIPTION
The `provider` chain is running Gaia v14 now.
Thanks!