### PR TITLE
Patch Comdex to v13.4.0

### DIFF
--- a/comdex/chain.json
+++ b/comdex/chain.json
@@ -28,12 +28,12 @@
   },
   "codebase": {
     "git_repo": "https://github.com/comdex-official/comdex",
-    "recommended_version": "v13.3.0",
+    "recommended_version": "v13.4.0",
     "compatible_versions": [
-      "v13.3.0"
+      "v13.4.0"
     ],
     "binaries": {
-      "linux/amd64": "https://github.com/comdex-official/comdex/releases/download/v13.3.0/comdex-linux-amd64.tar.gz"
+      "linux/amd64": "https://github.com/comdex-official/comdex/releases/download/v13.4.0/comdex-linux-amd64.tar.gz"
     },
     "cosmos_sdk_version": "v0.47.5",
     "consensus": {

--- a/comdex/chain.json
+++ b/comdex/chain.json
@@ -79,12 +79,12 @@
         "name": "v13.3.0",
         "proposal": 216,
         "height": 10981900,
-        "recommended_version": "v13.3.0",
+        "recommended_version": "v13.4.0",
         "compatible_versions": [
-          "v13.3.0"
+          "v13.4.0"
         ],
         "binaries": {
-          "linux/amd64": "https://github.com/comdex-official/comdex/releases/download/v13.3.0/comdex-linux-amd64.tar.gz"
+          "linux/amd64": "https://github.com/comdex-official/comdex/releases/download/v13.4.0/comdex-linux-amd64.tar.gz"
         },
         "cosmos_sdk_version": "v0.47.5",
         "consensus": {


### PR DESCRIPTION
Removed v13.3.0 as it is no longer compatible due to halt height upgrade for v13.4.0.