### PR TITLE
fix: remove a redundant asset record in terra2

### DIFF
--- a/terra2/assetlist.json
+++ b/terra2/assetlist.json
@@ -697,28 +697,6 @@
       ]
     },
     {
-      "description": "Liquidity token, NFT, HARVEST FOR VALUE",
-      "type_asset": "cw20",
-      "address": "terra10se906awphtccf4vd83m0ulpmpt9v4msuakmpy0pwvmtxmup3kdq25rayn",
-      "denom_units": [
-        {
-          "denom": "cw20:terra10se906awphtccf4vd83m0ulpmpt9v4msuakmpy0pwvmtxmup3kdq25rayn",
-          "exponent": 0
-        },
-        {
-          "denom": "xxx",
-          "exponent": 10
-        }
-      ],
-      "base": "cw20:terra10se906awphtccf4vd83m0ulpmpt9v4msuakmpy0pwvmtxmup3kdq25rayn",
-      "name": "TheOnlyOne",
-      "display": "xxx",
-      "symbol": "xxx",
-      "logo_URIs": {
-        "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/terra2/images/xxx.png"
-      }
-    },
-    {
       "description": "useless meme coin",
       "type_asset": "cw20",
       "address": "terra1cl273523kmr2uwjhhznq54je69mted2u3ljffm8kp2ap4z3drdksftwqun",


### PR DESCRIPTION
This PR aims to remove a redundant record of `terra10se906awphtccf4vd83m0ulpmpt9v4msuakmpy0pwvmtxmup3kdq25rayn` that probably mistakenly added in #3506 

Legacy record: https://github.com/cosmos/chain-registry/blob/4aa7a0632390ed0b1a875b88dce6866bddfb0857/terra2/assetlist.json#L306-L332

The duplicated one: https://github.com/cosmos/chain-registry/blob/4aa7a0632390ed0b1a875b88dce6866bddfb0857/terra2/assetlist.json#L699-L720