### PR TITLE
Add Validatus RPC to chain configuration

### DIFF
--- a/chain4energy/chain.json
+++ b/chain4energy/chain.json
@@ -415,6 +415,10 @@
       {
         "address": "http://209.182.239.169:46657",
         "provider": "SECARD"
+      },
+      {
+        "address": "https://rpc.c4e.validatus.com:443",
+        "provider": "Validatus"
       }
     ],
     "rest": [


### PR DESCRIPTION
This commit includes the addition of our RPC, Validatus, to the C4E chain configuration. The address is 'https://rpc.c4e.validatus.com:443'.