### PR TITLE
Reversion of Gas Prices to Standard Levels on Terra (Phoenix)

### DIFF
--- a/terra2/chain.json
+++ b/terra2/chain.json
@@ -14,10 +14,10 @@
     "fee_tokens": [
       {
         "denom": "uluna",
-        "fixed_min_gas_price": 0.15,
-        "low_gas_price": 0.15,
-        "average_gas_price": 0.15,
-        "high_gas_price": 0.4
+        "fixed_min_gas_price": 0.015,
+        "low_gas_price": 0.015,
+        "average_gas_price": 0.015,
+        "high_gas_price": 0.04
       }
     ]
   },


### PR DESCRIPTION
- [x] Adjusted gas prices to normal levels post high-traffic event on Terra network, in collaboration with validators.