### PR TITLE
Add Terra2 v2.6.2 as Compatible Version

### DIFF
--- a/terra2/chain.json
+++ b/terra2/chain.json
@@ -30,13 +30,14 @@
   },
   "codebase": {
     "git_repo": "https://github.com/terra-money/core/",
-    "recommended_version": "v2.6.1",
+    "recommended_version": "v2.6.2",
     "compatible_versions": [
-      "v2.6.1"
+      "v2.6.1",
+      "v2.6.2"
     ],
     "binaries": {
-      "linux/arm64": "https://github.com/terra-money/core/releases/download/v2.6.1/terra_2.6.1_Linux_arm64.tar.gz",
-      "linux/amd64": "https://github.com/terra-money/core/releases/download/v2.6.1/terra_2.6.1_Linux_x86_64.tar.gz"
+      "linux/arm64": "https://github.com/terra-money/core/releases/download/v2.6.2/terra_2.6.2_Linux_arm64.tar.gz",
+      "linux/amd64": "https://github.com/terra-money/core/releases/download/v2.6.2/terra_2.6.2_Linux_x86_64.tar.gz"
     },
     "genesis": {
       "name": "v2.0",
@@ -169,10 +170,11 @@
       },
       {
         "name": "v2.6",
-        "tag": "v2.6.1",
-        "recommended_version": "v2.6.1",
+        "tag": "v2.6.2",
+        "recommended_version": "v2.6.2",
         "compatible_versions": [
-          "v2.6.1"
+          "v2.6.1",
+          "v2.6.2"
         ],
         "proposal": 4792,
         "height": 7722000,
@@ -185,8 +187,8 @@
           "version": "v0.37.2"
         },
         "binaries": {
-          "linux/arm64": "https://github.com/terra-money/core/releases/download/v2.6.1/terra_2.6.1_Linux_arm64.tar.gz",
-          "linux/amd64": "https://github.com/terra-money/core/releases/download/v2.6.1/terra_2.6.1_Linux_x86_64.tar.gz"
+          "linux/arm64": "https://github.com/terra-money/core/releases/download/v2.6.2/terra_2.6.2_Linux_arm64.tar.gz",
+          "linux/amd64": "https://github.com/terra-money/core/releases/download/v2.6.2/terra_2.6.2_Linux_x86_64.tar.gz"
         },
         "next_version_name": ""
       }


### PR DESCRIPTION
https://github.com/terra-money/core/releases/tag/v2.6.2