### PR TITLE
Remove API-providers: mms.team & starsquid.io from 3 chains

### DIFF
--- a/gitopia/chain.json
+++ b/gitopia/chain.json
@@ -358,10 +358,6 @@
         "provider": "kjnodes"
       },
       {
-        "address": "https://rpc-gitopia.mms.team",
-        "provider": "MMS"
-      },
-      {
         "address": "https://rpc.gitopia.sgtstake.com",
         "provider": "SGTstake"
       },
@@ -496,10 +492,6 @@
         "provider": "kjnodes"
       },
       {
-        "address": "https://api-gitopia.mms.team",
-        "provider": "MMS"
-      },
-      {
         "address": "https://api.gitopia.sgtstake.com/",
         "provider": "SGTstake"
       },
@@ -624,10 +616,6 @@
       {
         "address": "gitopia.grpc.kjnodes.com:14190",
         "provider": "kjnodes"
-      },
-      {
-        "address": "grpc-gitopia.mms.team:443",
-        "provider": "MMS"
       },
       {
         "address": "grpc.gitopia.roomit.xyz:443",

--- a/lumnetwork/chain.json
+++ b/lumnetwork/chain.json
@@ -254,10 +254,6 @@
         "provider": "Lavender.Five Nodes 🐝"
       },
       {
-        "address": "https://api-lum.starsquid.io",
-        "provider": "Starsquid"
-      },
-      {
         "address": "https://lum-api.ibs.team",
         "provider": "Inter Blockchain Services"
       },

--- a/teritori/chain.json
+++ b/teritori/chain.json
@@ -163,10 +163,6 @@
         "provider": "Inter Blockchain Services"
       },
       {
-        "address": "https://rpc-teritori.mms.team/",
-        "provider": "MMS"
-      },
-      {
         "address": "https://teritori.rpc.kjnodes.com",
         "provider": "kjnodes"
       },
@@ -229,10 +225,6 @@
         "provider": "Inter Blockchain Services"
       },
       {
-        "address": "https://api-teritori.mms.team/",
-        "provider": "MMS"
-      },
-      {
         "address": "https://teritori.api.kjnodes.com",
         "provider": "kjnodes"
       },
@@ -285,10 +277,6 @@
       {
         "address": "teritori-grpc.brocha.in:443",
         "provider": "Brochain"
-      },
-      {
-        "address": "grpc-teritori.mms.team:443",
-        "provider": "MMS"
       },
       {
         "address": "teritori-grpc.polkachu.com:15990",


### PR DESCRIPTION
08 Nov 11:10:10 ~ API_ERROR CHAIN_ID at lumnetwork: https://api-lum.starsquid.io/cosmos/base/tendermint/v1beta1/blocks/latest (returns bitsong-2b but must be lum-network-1)
08 Nov 12:00:42 ~ API_ERROR CHAIN_ID at teritori: https://api-teritori.mms.team/cosmos/base/tendermint/v1beta1/blocks/latest (returns kaiyo-1 but must be teritori-1)
08 Nov 12:21:39 ~ API_ERROR CHAIN_ID at gitopia: https://api-gitopia.mms.team/cosmos/base/tendermint/v1beta1/blocks/latest (returns archway-1 but must be gitopia)

Today the same output...