### PR TITLE
Remove autostake.com from source chain

### DIFF
--- a/source/chain.json
+++ b/source/chain.json
@@ -135,10 +135,6 @@
         "provider": "MoonBridge"
       },
       {
-        "address": "https://carbon-mainnet-rpc.autostake.com:443",
-        "provider": "AutoStake 🛡️ Slash Protected"
-      },
-      {
         "address": "https://source.rpc.m.stavr.tech",
         "provider": "🔥STAVR🔥"
       },
@@ -181,10 +177,6 @@
         "provider": "Nodeist"
       },
       {
-        "address": "https://carbon-mainnet-lcd.autostake.com:443",
-        "provider": "AutoStake 🛡️ Slash Protected"
-      },
-      {
         "address": "https://source.api.m.stavr.tech",
         "provider": "🔥STAVR🔥"
       },
@@ -217,10 +209,6 @@
       {
         "address": "source-mainnet-grpc.itrocket.net:32090",
         "provider": "ITRocket"
-      },
-      {
-        "address": "carbon-mainnet-grpc.autostake.com:443",
-        "provider": "AutoStake 🛡️ Slash Protected"
       },
       {
         "address": "http://source.grpc.m.stavr.tech:9590",


### PR DESCRIPTION
05 Dec 15:37:05 ~ API_ERROR CHAIN_ID at source: https://carbon-mainnet-lcd.autostake.com:443/cosmos/base/tendermint/v1beta1/blocks/latest (returns carbon-1 but must be source-1)