### PR TITLE
Upgrade Juno to v18.1.0

### DIFF
--- a/juno/chain.json
+++ b/juno/chain.json
@@ -40,12 +40,12 @@
   },
   "codebase": {
     "git_repo": "https://github.com/CosmosContracts/juno",
-    "recommended_version": "v18.0.0",
+    "recommended_version": "v18.1.0",
     "compatible_versions": [
-      "v18.0.0"
+      "v18.1.0"
     ],
     "binaries": {
-      "linux/amd64": "https://github.com/CosmosContracts/juno/releases/download/v18.0.0/junod"
+      "linux/amd64": "https://github.com/CosmosContracts/juno/releases/download/v18.1.0/junod"
     },
     "cosmos_sdk_version": "0.47.5",
     "consensus": {
@@ -171,12 +171,12 @@
         "name": "v18",
         "proposal": 325,
         "height": 12265007,
-        "recommended_version": "v18.0.0",
+        "recommended_version": "v18.1.0",
         "compatible_versions": [
-          "v18.0.0"
+          "v18.1.0"
         ],
         "binaries": {
-          "linux/amd64": "https://github.com/CosmosContracts/juno/releases/download/v18.0.0/junod"
+          "linux/amd64": "https://github.com/CosmosContracts/juno/releases/download/v18.1.0/junod"
         },
         "cosmos_sdk_version": "0.47.5",
         "consensus": {


### PR DESCRIPTION
Remove previous version from compatible versions