### PR TITLE
Upgrade Migaloo to v3.0.4

### DIFF
--- a/migaloo/chain.json
+++ b/migaloo/chain.json
@@ -37,9 +37,9 @@
   },
   "codebase": {
     "git_repo": "https://github.com/White-Whale-Defi-Platform/migaloo-chain",
-    "recommended_version": "v3.0.3",
+    "recommended_version": "v3.0.4",
     "compatible_versions": [
-      "v3.0.3"
+      "v3.0.4"
     ],
     "cosmos_sdk_version": "0.46.15",
     "ibc_go_version": "6.2.0",
@@ -111,9 +111,9 @@
         "name": "v3.0.2",
         "proposal": 19,
         "height": 4128108,
-        "recommended_version": "v3.0.3",
+        "recommended_version": "v3.0.4",
         "compatible_versions": [
-          "v3.0.3"
+          "v3.0.4"
         ],
         "cosmos_sdk_version": "0.46.15",
         "ibc_go_version": "6.2.0",


### PR DESCRIPTION
Previous patch (3.0.3) did not resolve security issue. v3.0.4 is now the correct version.