### PR TITLE
Upgrade Evmos to v16.0.1

### DIFF
--- a/evmos/chain.json
+++ b/evmos/chain.json
@@ -36,17 +36,11 @@
   },
   "codebase": {
     "git_repo": "https://github.com/evmos/evmos",
-    "recommended_version": "v16.0.0",
+    "recommended_version": "v16.0.1",
     "compatible_versions": [
-      "v16.0.0"
+      "v16.0.0",
+      "v16.0.1"
     ],
-    "binaries": {
-      "linux/amd64": "https://github.com/evmos/evmos/releases/download/v16.0.0/evmos_16.0.0_Linux_amd64.tar.gz",
-      "linux/arm64": "https://github.com/evmos/evmos/releases/download/v16.0.0/evmos_16.0.0_Linux_arm64.tar.gz",
-      "darwin/amd64": "https://github.com/evmos/evmos/releases/download/v16.0.0/evmos_16.0.0_Darwin_amd64.tar.gz",
-      "darwin/arm64": "https://github.com/evmos/evmos/releases/download/v16.0.0/evmos_16.0.0_Darwin_arm64.tar.gz",
-      "windows/amd64": "https://github.com/evmos/evmos/releases/download/v16.0.0/evmos_16.0.0_Windows_amd64.zip"
-    },
     "cosmos_sdk_version": "v0.47.5-evmos.2",
     "consensus": {
       "type": "cometbft",
@@ -159,12 +153,13 @@
       },
       {
         "name": "v16.0.0",
-        "tag": "v16.0.0",
+        "tag": "v16.0.1",
         "proposal": 265,
         "height": 18295000,
-        "recommended_version": "v16.0.0",
+        "recommended_version": "v16.0.1",
         "compatible_versions": [
-          "v16.0.0"
+          "v16.0.0",
+          "v16.0.1"
         ],
         "cosmos_sdk_version": "v0.47.5-evmos.2",
         "consensus": {
@@ -172,13 +167,6 @@
           "version": "v0.37.3-0.20230920093934-46df7b597e3c"
         },
         "ibc_go_version": "v7.3.1",
-        "binaries": {
-          "linux/amd64": "https://github.com/evmos/evmos/releases/download/v16.0.0/evmos_16.0.0_Linux_amd64.tar.gz",
-          "linux/arm64": "https://github.com/evmos/evmos/releases/download/v16.0.0/evmos_16.0.0_Linux_arm64.tar.gz",
-          "darwin/amd64": "https://github.com/evmos/evmos/releases/download/v16.0.0/evmos_16.0.0_Darwin_amd64.tar.gz",
-          "darwin/arm64": "https://github.com/evmos/evmos/releases/download/v16.0.0/evmos_16.0.0_Darwin_arm64.tar.gz",
-          "windows/amd64": "https://github.com/evmos/evmos/releases/download/v16.0.0/evmos_16.0.0_Windows_amd64.zip"
-        },
         "next_version_name": ""
       }
     ]


### PR DESCRIPTION
Removed binaries are there are no pre-builds for 16.0.1