### PR TITLE
Upgrade Carbon to v2.30.0

### DIFF
--- a/carbon/chain.json
+++ b/carbon/chain.json
@@ -246,13 +246,13 @@
   },
   "codebase": {
     "git_repo": "https://github.com/Switcheo/carbon-bootstrap",
-    "recommended_version": "v2.29.0",
+    "recommended_version": "v2.30.0",
     "compatible_versions": [
-      "v2.29.0"
+      "v2.30.0"
     ],
     "binaries": {
-      "linux/amd64": "https://github.com/Switcheo/carbon-bootstrap/releases/download/v2.29.0/carbond2.29.0-mainnet.linux-amd64.tar.gz",
-      "linux/arm64": "https://github.com/Switcheo/carbon-bootstrap/releases/download/v2.29.0/carbond2.29.0-mainnet.linux-arm64.tar.gz"
+      "linux/amd64": "https://github.com/Switcheo/carbon-bootstrap/releases/download/v2.30.0/carbond2.30.0-mainnet.linux-amd64.tar.gz",
+      "linux/arm64": "https://github.com/Switcheo/carbon-bootstrap/releases/download/v2.30.0/carbond2.30.0-mainnet.linux-arm64.tar.gz"
     },
     "genesis": {
       "genesis_url": "https://github.com/Switcheo/carbon-bootstrap/raw/master/carbon-1/genesis.json"
@@ -341,6 +341,20 @@
         "binaries": {
           "linux/amd64": "https://github.com/Switcheo/carbon-bootstrap/releases/download/v2.29.0/carbond2.29.0-mainnet.linux-amd64.tar.gz",
           "linux/arm64": "https://github.com/Switcheo/carbon-bootstrap/releases/download/v2.29.0/carbond2.29.0-mainnet.linux-arm64.tar.gz"
+        },
+        "next_version_name": "v2.30.0"
+      },
+      {
+        "name": "v2.30.0",
+        "proposal": 313,
+        "height": 46228611,
+        "recommended_version": "v2.30.0",
+        "compatible_versions": [
+          "v2.30.0"
+        ],
+        "binaries": {
+          "linux/amd64": "https://github.com/Switcheo/carbon-bootstrap/releases/download/v2.30.0/carbond2.30.0-mainnet.linux-amd64.tar.gz",
+          "linux/arm64": "https://github.com/Switcheo/carbon-bootstrap/releases/download/v2.29.0/carbond2.30.0-mainnet.linux-arm64.tar.gz"
         },
         "next_version_name": ""
       }


### PR DESCRIPTION
https://github.com/Switcheo/carbon-bootstrap/blob/master/upgrade/v2.36.9.md