### PR TITLE
Patch Carbon to v2.36.9

### DIFF
--- a/carbon/chain.json
+++ b/carbon/chain.json
@@ -301,13 +301,14 @@
   },
   "codebase": {
     "git_repo": "https://github.com/Switcheo/carbon-bootstrap",
-    "recommended_version": "v2.36.0",
+    "recommended_version": "v2.36.9",
     "compatible_versions": [
-      "v2.36.0"
+      "v2.36.0",
+      "v2.36.9"
     ],
     "binaries": {
-      "linux/amd64": "https://github.com/Switcheo/carbon-bootstrap/releases/download/v2.36.0/carbond2.36.0-mainnet.linux-amd64.tar.gz",
-      "linux/arm64": "https://github.com/Switcheo/carbon-bootstrap/releases/download/v2.36.0/carbond2.36.0-mainnet.linux-arm64.tar.gz"
+      "linux/amd64": "https://github.com/Switcheo/carbon-bootstrap/releases/download/v2.36.9/carbond2.36.9-mainnet.linux-amd64.tar.gz",
+      "linux/arm64": "https://github.com/Switcheo/carbon-bootstrap/releases/download/v2.36.9/carbond2.36.9-mainnet.linux-arm64.tar.gz"
     },
     "genesis": {
       "genesis_url": "https://github.com/Switcheo/carbon-bootstrap/raw/master/carbon-1/genesis.json"
@@ -487,13 +488,14 @@
         "name": "v2.36.0",
         "proposal": 323,
         "height": 49677971,
-        "recommended_version": "v2.36.0",
+        "recommended_version": "v2.36.9",
         "compatible_versions": [
-          "v2.36.0"
+          "v2.36.0",
+          "v2.36.9"
         ],
         "binaries": {
-          "linux/amd64": "https://github.com/Switcheo/carbon-bootstrap/releases/download/v2.36.0/carbond2.36.0-mainnet.linux-amd64.tar.gz",
-          "linux/arm64": "https://github.com/Switcheo/carbon-bootstrap/releases/download/v2.36.0/carbond2.36.0-mainnet.linux-arm64.tar.gz"
+          "linux/amd64": "https://github.com/Switcheo/carbon-bootstrap/releases/download/v2.36.9/carbond2.36.9-mainnet.linux-amd64.tar.gz",
+          "linux/arm64": "https://github.com/Switcheo/carbon-bootstrap/releases/download/v2.36.9/carbond2.36.9-mainnet.linux-arm64.tar.gz"
         },
         "next_version_name": ""
       }


### PR DESCRIPTION
https://github.com/Switcheo/carbon-bootstrap/blob/master/upgrade/v2.36.9.md