### PR TITLE
Remove unregistered Fee assets from Carbon

### DIFF
--- a/carbon/chain.json
+++ b/carbon/chain.json
@@ -126,17 +126,6 @@
         }
       },
       {
-        "denom": "ibc/16065EE5282C5217685C8F084FC44864C25C706AC37356B0D62811D50B96920F",
-        "fixed_min_gas_price": 0,
-        "low_gas_price": 0.0000075,
-        "average_gas_price": 0.0000075,
-        "high_gas_price": 0.0000075,
-        "gas_costs": {
-          "cosmos_send": 100000000,
-          "ibc_transfer": 100000000
-        }
-      },
-      {
         "denom": "ibc/2B58B8C147E8718EECCB3713271DF46DEE8A3A00A27242628604E31C2F370EF5",
         "fixed_min_gas_price": 0,
         "low_gas_price": 0.00005,
@@ -186,17 +175,6 @@
         "low_gas_price": 0.00015,
         "average_gas_price": 0.00015,
         "high_gas_price": 0.00015,
-        "gas_costs": {
-          "cosmos_send": 100000000,
-          "ibc_transfer": 100000000
-        }
-      },
-      {
-        "denom": "ibc/6C349F0EB135C5FA99301758F35B87DB88403D690E5E314AB080401FEE4066E5",
-        "fixed_min_gas_price": 0,
-        "low_gas_price": 0.0000075,
-        "average_gas_price": 0.0000075,
-        "high_gas_price": 0.0000075,
         "gas_costs": {
           "cosmos_send": 100000000,
           "ibc_transfer": 100000000


### PR DESCRIPTION
Remove unregistered Fee assets from Carbon
Not allowed to register fee assets that aren't also registered in its assetlist