### PR TITLE
Fix PUNDIX Assetlist

### DIFF
--- a/pundix/assetlist.json
+++ b/pundix/assetlist.json
@@ -6,7 +6,7 @@
       "description": "Pundi X Token",
       "denom_units": [
         {
-          "denom": "ibc/55367b7b6572631b78a93c66ef9fdfce87cde372cc4ed7848da78c1eb1dcdd78",
+          "denom": "ibc/55367B7B6572631B78A93C66EF9FDFCE87CDE372CC4ED7848DA78C1EB1DCDD78",
           "exponent": 0
         },
         {
@@ -14,7 +14,7 @@
           "exponent": 18
         }
       ],
-      "base": "ibc/55367b7b6572631b78a93c66ef9fdfce87cde372cc4ed7848da78c1eb1dcdd78",
+      "base": "ibc/55367B7B6572631B78A93C66EF9FDFCE87CDE372CC4ED7848DA78C1EB1DCDD78",
       "name": "Pundi X Token",
       "display": "PUNDIX",
       "symbol": "PUNDIX",


### PR DESCRIPTION
Fix PundiX's assetlist so that ibc denoms are all uppercase, as in: ibc/55367B7B6572631B78A93C66EF9FDFCE87CDE372CC4ED7848DA78C1EB1DCDD78