### PR TITLE
Patch Injective to v1.12.1

### DIFF
--- a/injective/chain.json
+++ b/injective/chain.json
@@ -33,13 +33,14 @@
   },
   "codebase": {
     "git_repo": "https://github.com/InjectiveLabs/injective-chain-releases",
-    "recommended_version": "v1.12.0-1704530206",
+    "recommended_version": "v1.12.1-1705909076",
     "compatible_versions": [
-      "v1.12.0-1704530206"
+      "v1.12.0-1704530206",
+      "v1.12.1-1705909076"
     ],
     "binaries": {
-      "linux/amd64": "https://github.com/InjectiveLabs/injective-chain-releases/releases/download/v1.12.0-1704530206/linux-amd64.zip",
-      "darwin/amd64": "https://github.com/InjectiveLabs/injective-chain-releases/releases/download/v1.12.0-1704530206/darwin-amd64.zip"
+      "linux/amd64": "https://github.com/InjectiveLabs/injective-chain-releases/releases/download/v1.12.1-1705909076/linux-amd64.zip",
+      "darwin/amd64": "https://github.com/InjectiveLabs/injective-chain-releases/releases/download/v1.12.1-1705909076/darwin-amd64.zip"
     },
     "genesis": {
       "genesis_url": "https://raw.githubusercontent.com/InjectiveLabs/mainnet-config/master/10001/genesis.json"
@@ -78,13 +79,14 @@
         "name": "v1.12.0",
         "proposal": 314,
         "height": 57076000,
-        "recommended_version": "v1.12.0-1704530206",
+        "recommended_version": "v1.12.1-1705909076",
         "compatible_versions": [
-          "v1.12.0-1704530206"
+          "v1.12.0-1704530206",
+          "v1.12.1-1705909076"
         ],
         "binaries": {
-          "linux/amd64": "https://github.com/InjectiveLabs/injective-chain-releases/releases/download/v1.12.0-1704530206/linux-amd64.zip",
-          "darwin/amd64": "https://github.com/InjectiveLabs/injective-chain-releases/releases/download/v1.12.0-1704530206/darwin-amd64.zip"
+          "linux/amd64": "https://github.com/InjectiveLabs/injective-chain-releases/releases/download/v1.12.1-1705909076/linux-amd64.zip",
+          "darwin/amd64": "https://github.com/InjectiveLabs/injective-chain-releases/releases/download/v1.12.1-1705909076/darwin-amd64.zip"
         },
         "next_version_name": ""
       }


### PR DESCRIPTION
https://github.com/InjectiveLabs/injective-chain-releases/blob/master/docs/migration/injective-canonical-chain-12-1.md