### PR TITLE
feat(teritori-update-assetlist): Add USD Coin and Secret Network assets

### DIFF
--- a/teritori/assetlist.json
+++ b/teritori/assetlist.json
@@ -179,6 +179,92 @@
           "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/kujira/images/kuji.svg"
         }
       ]
+    },
+    {
+      "description": "USD Coin",
+      "denom_units": [
+          {
+            "denom": "ibc/FE98AAD68F02F03565E9FA39A5E627946699B2B07115889ED812D8BA639576A9",
+            "exponent": 0
+          },
+          {
+            "denom": "usdc",
+            "exponent": 6
+          }
+      ],
+      "type_asset": "ics20",
+      "base": "uusdc",
+      "display": "usdc",
+      "name": "USD Coin",
+      "symbol": "USDC",
+      "coingecko_id": "usd-coin",
+      "traces": [
+        {
+          "type": "ibc",
+          "counterparty": {
+            "chain_name": "noble",
+            "base_denom": "usdc",
+            "channel_id": "channel-54"
+          },
+          "chain": {
+            "channel_id": "channel-62",
+            "path": "transfer/channel-62/uusdc"
+          }
+        }
+      ],
+      "logo_URIs": {
+        "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/noble/images/USDCoin.png",
+        "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/noble/images/USDCoin.svg"
+      },
+      "images": [
+        {
+          "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/noble/images/USDCoin.png",
+          "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/noble/images/USDCoin.svg"
+        }
+      ]
+    },
+    {
+      "description": "The native staking and governance token of the Secret chain.",
+      "denom_units": [
+        {
+          "denom": "ibc/F3F6BDEE1A79664B169D742651107BF4E03FA67E931452E27380B75F5917B7E9",
+          "exponent": 0
+        },
+        {
+          "denom": "scrt",
+          "exponent": 6
+        }
+      ],
+      "type_asset": "ics20",
+      "base": "uscrt",
+      "name": "Secret Network",
+      "display": "scrt",
+      "symbol": "SCRT",
+      "traces": [
+        {
+          "type": "ibc",
+          "counterparty": {
+            "chain_name": "secretnetwork",
+            "base_denom": "uscrt",
+            "channel_id": "channel-111"
+          },
+          "chain": {
+            "channel_id": "channel-63",
+            "path": "transfer/channel-63/uscrt"
+          }
+        }
+      ],
+      "logo_URIs": {
+        "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/secretnetwork/images/scrt.png",
+        "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/secretnetwork/images/scrt.svg"
+      },
+      "coingecko_id": "secret",
+      "images": [
+        {
+          "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/secretnetwork/images/scrt.png",
+          "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/secretnetwork/images/scrt.svg"
+        }
+      ]
     }
   ]
 }

--- a/teritori/assetlist.json
+++ b/teritori/assetlist.json
@@ -197,7 +197,6 @@
       "display": "usdc",
       "name": "USD Coin",
       "symbol": "USDC",
-      "coingecko_id": "usd-coin",
       "traces": [
         {
           "type": "ibc",
@@ -218,6 +217,10 @@
       },
       "images": [
         {
+          "image_sync": {
+            "chain_name": "noble",
+            "base_denom": "uusdc"
+          },
           "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/noble/images/USDCoin.png",
           "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/noble/images/USDCoin.svg"
         }
@@ -258,9 +261,12 @@
         "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/secretnetwork/images/scrt.png",
         "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/secretnetwork/images/scrt.svg"
       },
-      "coingecko_id": "secret",
       "images": [
         {
+          "image_sync": {
+            "chain_name": "secretnetwork",
+            "base_denom": "uscrt"
+          },
           "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/secretnetwork/images/scrt.png",
           "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/secretnetwork/images/scrt.svg"
         }


### PR DESCRIPTION
- Added USD Coin asset with denom units and traces for IBC
- Added Secret Network asset with denom units and traces for IBC

Tested with 

> teritorid query ibc-transfer denom-hash transfer/channel-62/uusdc

hash: FE98AAD68F02F03565E9FA39A5E627946699B2B07115889ED812D8BA639576A9
> teritorid query ibc-transfer denom-hash transfer/channel-63/uscrt

hash: F3F6BDEE1A79664B169D742651107BF4E03FA67E931452E27380B75F5917B7E9
