### PR TITLE
Update osmosis chain.json

### DIFF
--- a/osmosis/chain.json
+++ b/osmosis/chain.json
@@ -37,14 +37,15 @@
   },
   "codebase": {
     "git_repo": "https://github.com/osmosis-labs/osmosis",
-    "recommended_version": "v20.5.0",
+    "recommended_version": "v22.0.0",
     "compatible_versions": [
-      "v20.5.0"
+      "v22.0.0"
     ],
     "binaries": {
-      "linux/amd64": "https://github.com/osmosis-labs/osmosis/releases/download/v20.5.0/osmosisd-20.5.0-linux-amd64",
-      "linux/arm64": "https://github.com/osmosis-labs/osmosis/releases/download/v20.5.0/osmosisd-20.5.0-linux-arm64"
+      "linux/amd64": "https://github.com/osmosis-labs/osmosis/releases/download/v22.0.0/osmosisd-22.0.0-linux-amd64",
+      "linux/arm64": "https://github.com/osmosis-labs/osmosis/releases/download/v22.0.0/osmosisd-22.0.0-linux-arm64"
     },
+    "go_version": "1.21",
     "cosmos_sdk_version": "osmosis-labs/cosmos-sdk@0.45.0-rc1.0.20230922030206-734f99fba785",
     "consensus": {
       "type": "tendermint",


### PR DESCRIPTION
include `go_version`
update to codebase `v22`