### PR TITLE
Added axlUSDC and noble USDC as fee tokens for Terra

### DIFF
--- a/terra2/chain.json
+++ b/terra2/chain.json
@@ -18,6 +18,20 @@
         "low_gas_price": 0.015,
         "average_gas_price": 0.015,
         "high_gas_price": 0.04
+      },
+      {
+        "denom": "ibc/B3504E092456BA618CC28AC671A71FB08C6CA0FD0BE7C8A5B5A3E2DD933CC9E4",
+        "fixed_min_gas_price": 0.018,
+        "low_gas_price": 0.018,
+        "average_gas_price": 0.018,
+        "high_gas_price": 0.04
+      },
+      {
+        "denom": "ibc/2C962DAB9F57FE0921435426AE75196009FAA1981BF86991203C8411F8980FDB",
+        "fixed_min_gas_price": 0.018,
+        "low_gas_price": 0.018,
+        "average_gas_price": 0.018,
+        "high_gas_price": 0.04
       }
     ]
   },


### PR DESCRIPTION
Majority of validators have updated their config to support axlUSDC and noble USDC on Terra.

https://commonwealth.im/terra/discussion/14892-add-stablecoins-as-gas-fee-tokens-on-terra).