### PR TITLE
Remove extraneous space

### DIFF
--- a/juno/assetlist.json
+++ b/juno/assetlist.json
@@ -732,7 +732,7 @@
         "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/juno/images/hopers.png",
         "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/juno/images/hopers.svg"
       },
-      "coingecko_id": "hopers-io ",
+      "coingecko_id": "hopers-io",
       "images": [
         {
           "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/juno/images/hopers.png",


### PR DESCRIPTION
This removes a space in the coingecko ID of the hopers token on juno.