### PR TITLE
Fix: remove duplicated info for Teritori

### DIFF
--- a/teritori/chain.json
+++ b/teritori/chain.json
@@ -33,10 +33,6 @@
     "compatible_versions": [
       "v2.0.6"
     ],
-    "recommended_version": "v2.0.6",
-    "compatible_versions": [
-      "v2.0.6"
-    ],
     "ibc_go_version": "v7.3.1",
     "cosmos_sdk_version": "v0.47.6",
     "consensus": {


### PR DESCRIPTION
In the teritori chain configuration file, the codebase information was repeated twice