### PR TITLE
Update Evmos latest v16.0.3 binary information

### DIFF
--- a/evmos/chain.json
+++ b/evmos/chain.json
@@ -36,11 +36,12 @@
   },
   "codebase": {
     "git_repo": "https://github.com/evmos/evmos",
-    "recommended_version": "v16.0.2",
+    "recommended_version": "v16.0.3",
     "compatible_versions": [
       "v16.0.0",
       "v16.0.1",
-      "v16.0.2"
+      "v16.0.2",
+      "v16.0.3",
     ],
     "cosmos_sdk_version": "v0.47.5-evmos.2",
     "consensus": {
@@ -49,11 +50,11 @@
     },
     "ibc_go_version": "7.3.1",
     "binaries": {
-      "linux/amd64": "https://github.com/evmos/evmos/releases/download/v16.0.2/evmos_16.0.2_Linux_amd64.tar.gz",
-      "linux/arm64": "https://github.com/evmos/evmos/releases/download/v16.0.2/evmos_16.0.2_Linux_arm64.tar.gz",
-      "darwin/amd64": "https://github.com/evmos/evmos/releases/download/v16.0.2/evmos_16.0.2_Darwin_amd64.tar.gz",
-      "darwin/arm64": "https://github.com/evmos/evmos/releases/download/v16.0.2/evmos_16.0.2_Darwin_arm64.tar.gz",
-      "windows/amd64": "https://github.com/evmos/evmos/releases/download/v16.0.2/evmos_16.0.2_Windows_amd64.zip"
+      "linux/amd64": "https://github.com/evmos/evmos/releases/download/v16.0.3/evmos_16.0.3_Linux_amd64.tar.gz",
+      "linux/arm64": "https://github.com/evmos/evmos/releases/download/v16.0.3/evmos_16.0.3_Linux_arm64.tar.gz",
+      "darwin/amd64": "https://github.com/evmos/evmos/releases/download/v16.0.3/evmos_16.0.3_Darwin_amd64.tar.gz",
+      "darwin/arm64": "https://github.com/evmos/evmos/releases/download/v16.0.3/evmos_16.0.3_Darwin_arm64.tar.gz",
+      "windows/amd64": "https://github.com/evmos/evmos/releases/download/v16.0.3/evmos_16.0.3_Windows_amd64.zip"
     },
     "genesis": {
       "genesis_url": "https://archive.evmos.org/mainnet/genesis.json"

--- a/evmos/chain.json
+++ b/evmos/chain.json
@@ -41,7 +41,7 @@
       "v16.0.0",
       "v16.0.1",
       "v16.0.2",
-      "v16.0.3",
+      "v16.0.3"
     ],
     "cosmos_sdk_version": "v0.47.5-evmos.2",
     "consensus": {
@@ -162,14 +162,15 @@
       },
       {
         "name": "v16.0.0",
-        "tag": "v16.0.2",
+        "tag": "v16.0.3",
         "proposal": 265,
         "height": 18295000,
-        "recommended_version": "v16.0.2",
+        "recommended_version": "v16.0.3",
         "compatible_versions": [
           "v16.0.0",
           "v16.0.1",
-          "v16.0.2"
+          "v16.0.2",
+          "v16.0.3"
         ],
         "cosmos_sdk_version": "v0.47.5-evmos.2",
         "consensus": {
@@ -178,11 +179,11 @@
         },
         "ibc_go_version": "v7.3.1",
         "binaries": {
-          "linux/amd64": "https://github.com/evmos/evmos/releases/download/v16.0.2/evmos_16.0.2_Linux_amd64.tar.gz",
-          "linux/arm64": "https://github.com/evmos/evmos/releases/download/v16.0.2/evmos_16.0.2_Linux_arm64.tar.gz",
-          "darwin/amd64": "https://github.com/evmos/evmos/releases/download/v16.0.2/evmos_16.0.2_Darwin_amd64.tar.gz",
-          "darwin/arm64": "https://github.com/evmos/evmos/releases/download/v16.0.2/evmos_16.0.2_Darwin_arm64.tar.gz",
-          "windows/amd64": "https://github.com/evmos/evmos/releases/download/v16.0.2/evmos_16.0.2_Windows_amd64.zip"
+          "linux/amd64": "https://github.com/evmos/evmos/releases/download/v16.0.3/evmos_16.0.3_Linux_amd64.tar.gz",
+          "linux/arm64": "https://github.com/evmos/evmos/releases/download/v16.0.3/evmos_16.0.3_Linux_arm64.tar.gz",
+          "darwin/amd64": "https://github.com/evmos/evmos/releases/download/v16.0.3/evmos_16.0.3_Darwin_amd64.tar.gz",
+          "darwin/arm64": "https://github.com/evmos/evmos/releases/download/v16.0.3/evmos_16.0.3_Darwin_arm64.tar.gz",
+          "windows/amd64": "https://github.com/evmos/evmos/releases/download/v16.0.3/evmos_16.0.3_Windows_amd64.zip"
         },
         "next_version_name": ""
       }


### PR DESCRIPTION
This PR updates Evmos binary information to the latest patch release v16.0.03