### PR TITLE
Add dymension coingecko id

### DIFF
--- a/dymension/assetlist.json
+++ b/dymension/assetlist.json
@@ -22,6 +22,7 @@
         "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/dymension/images/dymension-logo.png",
         "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/dymension/images/dymension-logo.svg"
       },
+      "coingecko_id": "dymension",
       "images": [
         {
           "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/dymension/images/dymension-logo.png",


### PR DESCRIPTION
## This PR
- Adds/Sets the `coingecko_id` field to `dymension` for the `dym` asset on `Dymension`
- Can verify here: https://www.coingecko.com/en/coins/dymension