### PR TITLE
Update Osmosis assetlist.json 5

### DIFF
--- a/osmosis/assetlist.json
+++ b/osmosis/assetlist.json
@@ -1890,7 +1890,6 @@
           "denom": "ibc/FE2CD1E6828EC0FAB8AF39BAC45BC25B965BA67CCBC50C13A14BD610B0D1E2C4",
           "exponent": 0,
           "aliases": [
-            "boot",
             "boot"
           ]
         }
@@ -1898,7 +1897,7 @@
       "type_asset": "ics20",
       "base": "ibc/FE2CD1E6828EC0FAB8AF39BAC45BC25B965BA67CCBC50C13A14BD610B0D1E2C4",
       "name": "bostrom",
-      "display": "boot",
+      "display": "ibc/FE2CD1E6828EC0FAB8AF39BAC45BC25B965BA67CCBC50C13A14BD610B0D1E2C4",
       "symbol": "BOOT",
       "traces": [
         {
@@ -6707,7 +6706,7 @@
       "type_asset": "ics20",
       "base": "ibc/E27CD305D33F150369AB526AEB6646A76EC3FFB1A6CA58A663B5DE657A89D55D",
       "name": "Dyson Protocol",
-      "display": "dys",
+      "display": "ibc/E27CD305D33F150369AB526AEB6646A76EC3FFB1A6CA58A663B5DE657A89D55D",
       "symbol": "DYS",
       "traces": [
         {
@@ -12258,7 +12257,6 @@
           "denom": "ibc/4F3B0EC2FE2D370D10C3671A1B7B06D2A964C721470C305CBB846ED60E6CAA20",
           "exponent": 0,
           "aliases": [
-            "hydrogen",
             "hydrogen"
           ]
         }
@@ -12266,7 +12264,7 @@
       "type_asset": "ics20",
       "base": "ibc/4F3B0EC2FE2D370D10C3671A1B7B06D2A964C721470C305CBB846ED60E6CAA20",
       "name": "Bostrom Hydrogen",
-      "display": "hydrogen",
+      "display": "ibc/4F3B0EC2FE2D370D10C3671A1B7B06D2A964C721470C305CBB846ED60E6CAA20",
       "symbol": "HYDROGEN",
       "traces": [
         {
@@ -12300,7 +12298,6 @@
           "denom": "ibc/BCDB35B7390806F35E716D275E1E017999F8281A81B6F128F087EF34D1DFA761",
           "exponent": 0,
           "aliases": [
-            "tocyb",
             "tocyb"
           ]
         }
@@ -12308,7 +12305,7 @@
       "type_asset": "ics20",
       "base": "ibc/BCDB35B7390806F35E716D275E1E017999F8281A81B6F128F087EF34D1DFA761",
       "name": "Bostrom Tocyb",
-      "display": "tocyb",
+      "display": "ibc/BCDB35B7390806F35E716D275E1E017999F8281A81B6F128F087EF34D1DFA761",
       "symbol": "TOCYB",
       "traces": [
         {
@@ -12342,7 +12339,6 @@
           "denom": "ibc/D3A1900B2B520E45608B5671ADA461E1109628E89B4289099557C6D3996F7DAA",
           "exponent": 0,
           "aliases": [
-            "millivolt",
             "millivolt"
           ]
         },
@@ -12391,7 +12387,6 @@
           "denom": "ibc/020F5162B7BC40656FC5432622647091F00D53E82EE8D21757B43D3282F25424",
           "exponent": 0,
           "aliases": [
-            "milliampere",
             "milliampere"
           ]
         },


### PR DESCRIPTION
Update Osmosis assetlist.json 5

Few tweaks and fixes.
Display property is updated. No longer duplicates keywords or denom_unit aliases.