### PR TITLE
Halt-height upgrade for Juno (v20)

### DIFF
--- a/juno/chain.json
+++ b/juno/chain.json
@@ -40,12 +40,12 @@
   },
   "codebase": {
     "git_repo": "https://github.com/CosmosContracts/juno",
-    "recommended_version": "v19.1.0",
+    "recommended_version": "v20.0.0",
     "compatible_versions": [
-      "v19.1.0"
+      "v20.0.0"
     ],
     "binaries": {
-      "linux/amd64": "https://github.com/CosmosContracts/juno/releases/download/v19.1.0/junod"
+      "linux/amd64": "https://github.com/CosmosContracts/juno/releases/download/v20.0.0/junod"
     },
     "cosmos_sdk_version": "v0.47.6",
     "consensus": {
@@ -192,12 +192,12 @@
         "name": "v19",
         "proposal": 333,
         "height": 13678871,
-        "recommended_version": "v19.1.0",
+        "recommended_version": "v20.0.0",
         "compatible_versions": [
-          "v19.1.0"
+          "v20.0.0"
         ],
         "binaries": {
-          "linux/amd64": "https://github.com/CosmosContracts/juno/releases/download/v19.1.0/junod"
+          "linux/amd64": "https://github.com/CosmosContracts/juno/releases/download/v20.0.0/junod"
         },
         "cosmos_sdk_version": "v0.47.6",
         "consensus": {


### PR DESCRIPTION
Halt height upgrade for Juno - even though the tag is `v20.0.0` it's still part of the `v19` upgrade handler. Removed old versions from compatible list.