### PR TITLE
Fix dYdX Testnet assets

### DIFF
--- a/testnets/dydxtestnet/assetlist.json
+++ b/testnets/dydxtestnet/assetlist.json
@@ -6,19 +6,18 @@
       "description": "The native staking token of dYdX Protocol.",
       "denom_units": [
         {
-          "denom": "adydx",
+          "denom": "adv4tnt",
           "exponent": 0
         },
         {
-          "denom": "dydx",
+          "denom": "dv4tnt",
           "exponent": 18
         }
       ],
-      "base": "adydx",
+      "base": "adv4tnt",
       "name": "dYdX",
-      "display": "dydx",
-      "symbol": "DYDX",
-      "coingecko_id": "dydx",
+      "display": "dv4tnt",
+      "symbol": "DV4TNT",
       "traces": [
         {
           "type": "test-mintage",

--- a/testnets/dydxtestnet/chain.json
+++ b/testnets/dydxtestnet/chain.json
@@ -16,7 +16,7 @@
   "fees": {
     "fee_tokens": [
       {
-        "denom": "adydx",
+        "denom": "adv4tnt",
         "fixed_min_gas_price": 12500000000,
         "low_gas_price": 12500000000,
         "average_gas_price": 12500000000,
@@ -27,7 +27,7 @@
   "staking": {
     "staking_tokens": [
       {
-        "denom": "adydx"
+        "denom": "adv4tnt"
       }
     ]
   },


### PR DESCRIPTION
The primary token of the dYdX testnet is DV4TNT not DYDX