### PR TITLE
update odin-osmosis client_id

### DIFF
--- a/_IBC/odin-osmosis.json
+++ b/_IBC/odin-osmosis.json
@@ -7,7 +7,7 @@
   },
   "chain_2": {
     "chain_name": "osmosis",
-    "client_id": "07-tendermint-3088",
+    "client_id": "07-tendermint-2007",
     "connection_id": "connection-1551"
   },
   "channels": [

--- a/_IBC/odin-osmosis.json
+++ b/_IBC/odin-osmosis.json
@@ -27,6 +27,23 @@
         "preferred": true,
         "dex": "osmosis"
       }
+    },
+    {
+      "chain_1": {
+        "channel_id": "channel-74",
+        "port_id": "transfer"
+      },
+      "chain_2": {
+        "channel_id": "channel-20925",
+        "port_id": "transfer"
+      },
+      "ordering": "unordered",
+      "version": "ics20-1",
+      "tags": {
+        "status": "live",
+        "preferred": true,
+        "dex": "osmosis"
+      }
     }
   ]
 }

--- a/_IBC/odin-osmosis.json
+++ b/_IBC/odin-osmosis.json
@@ -27,23 +27,6 @@
         "preferred": true,
         "dex": "osmosis"
       }
-    },
-    {
-      "chain_1": {
-        "channel_id": "channel-74",
-        "port_id": "transfer"
-      },
-      "chain_2": {
-        "channel_id": "channel-20925",
-        "port_id": "transfer"
-      },
-      "ordering": "unordered",
-      "version": "ics20-1",
-      "tags": {
-        "status": "live",
-        "preferred": true,
-        "dex": "osmosis"
-      }
     }
   ]
 }


### PR DESCRIPTION
I believe this is the correct client.  

cc @Cordtus 

```
osmosisd q ibc connection connections --limit 50000 | jq '.connections[] | select(.id == "connection-1551") | {client_id, counterparty}'
{
  "client_id": "07-tendermint-2007",
  "counterparty": {
    "client_id": "07-tendermint-10",
    "connection_id": "connection-9",
    "prefix": {
      "key_prefix": "aWJj"
    }
  }
}
```
Also, odin-protocol requested a 2nd channel be created for use by doki.

![image](https://github.com/cosmos/chain-registry/assets/807940/7c3ee5da-3662-4fe4-a4e8-3aed2ccaac08)



