### PR TITLE
Fix SCRX denoms

### DIFF
--- a/source/assetlist.json
+++ b/source/assetlist.json
@@ -37,7 +37,7 @@
           "denom": "ibc/FC5A7360EEED0713AE3E83E9D55A69AF873056A172AC495890ACE4582FF9685A",
           "exponent": 0,
           "aliases": [
-            "srcx"
+            "nsrcx"
           ]
         },
         {


### PR DESCRIPTION
Fix SCRX denoms
they had 'srcx' as the unit for both 0 and 9 exponent, which is ambiguous