### PR TITLE
Remove Neutron Fee Tokens

### DIFF
--- a/neutron/chain.json
+++ b/neutron/chain.json
@@ -50,18 +50,6 @@
         "low_gas_price": 0.0004,
         "average_gas_price": 0.0004,
         "high_gas_price": 0.0004
-      },
-      {
-        "denom": "ibc/B559A80D62249C8AA07A380E2A2BEA6E5CA9A6F079C912C3A9E9B494105E4F81",
-        "low_gas_price": 0.008,
-        "average_gas_price": 0.008,
-        "high_gas_price": 0.008
-      },
-      {
-        "denom": "ibc/B7864B03E1B9FD4F049243E92ABD691586F682137037A9F3FCA5222815620B3C",
-        "low_gas_price": 0.0006,
-        "average_gas_price": 0.0006,
-        "high_gas_price": 0.0006
       }
     ]
   },


### PR DESCRIPTION
Remove Neutron Fee Tokens because they aren't registered.