### PR TITLE
Update some Stride gas prices to reflect majority of validators' configs

### DIFF
--- a/stride/chain.json
+++ b/stride/chain.json
@@ -94,16 +94,16 @@
       },
       {
         "denom": "stadydx",
-        "fixed_min_gas_price": 12500000000,
-        "low_gas_price": 12500000000,
-        "average_gas_price": 12500000000,
+        "fixed_min_gas_price": 15000000000,
+        "low_gas_price": 15000000000,
+        "average_gas_price": 15000000000,
         "high_gas_price": 20000000000
       },
       {
         "denom": "stadym",
-        "fixed_min_gas_price": 8000000000,
-        "low_gas_price": 8000000000,
-        "average_gas_price": 8000000000,
+        "fixed_min_gas_price": 15000000000,
+        "low_gas_price": 15000000000,
+        "average_gas_price": 15000000000,
         "high_gas_price": 20000000000
       }
     ]


### PR DESCRIPTION
Raises gas prices for stDYDX and stDYM on Stride chain, to reflect the most common config among validators. 

Please let me know if you have any questions! 