### PR TITLE
fix neutron-secretnetwork

### DIFF
--- a/_IBC/neutron-secretnetwork.json
+++ b/_IBC/neutron-secretnetwork.json
@@ -2,23 +2,23 @@
   "$schema": "../ibc_data.schema.json",
   "chain_1": {
     "chain_name": "neutron",
-    "client_id": "07-tendermint-75",
-    "connection_id": "connection-54"
+    "client_id": "07-tendermint-85",
+    "connection_id": "connection-63"
   },
   "chain_2": {
     "chain_name": "secretnetwork",
-    "client_id":  "07-tendermint-19",
-    "connection_id": "connection-139"
+    "client_id":  "07-tendermint-199",
+    "connection_id": "connection-192"
   },
   "channels": [
     {
       "chain_1": {
-        "channel_id": "channel-57",
+        "channel_id": "channel-1551",
         "port_id": "transfer"
       },
       "chain_2": {
-        "channel_id": "channel-104",
-        "port_id": "wasm.secret1tqmms5awftpuhalcv5h5mg76fa0tkdz4jv9ex4"
+        "channel_id": "channel-144",
+        "port_id": "transfer"
       },
       "ordering": "unordered",
       "version": "ics20-1",


### PR DESCRIPTION
The older mentioned channel was never used and expired by now
a new official transfer channel is now opened, Timewave will make an ICA channel on top of it and a WASM channel for CW20s from Secret will follow