### PR TITLE
Update akash-persistence.json to new path

### DIFF
--- a/_IBC/akash-persistence.json
+++ b/_IBC/akash-persistence.json
@@ -1,28 +1,28 @@
 {
-  "$schema": "../ibc_data.schema.json",
-  "chain_1": {
-    "chain_name": "akash",
-    "client_id": "07-tendermint-15",
-    "connection_id": "connection-8"
-  },
-  "chain_2": {
-    "chain_name": "persistence",
-    "client_id": "07-tendermint-5",
-    "connection_id": "connection-4"
-  },
-  "channels": [
-    {
-      "chain_1": {
-        "channel_id": "channel-6",
-        "port_id": "transfer"
-      },
-      "chain_2": {
-        "channel_id": "channel-5",
-        "port_id": "transfer"
-      },
-      "ordering": "unordered",
-      "version": "ics20-1",
-      "tags": {}
-    }
-  ]
+    "$schema": "../ibc_data.schema.json",
+    "chain_1": {
+        "chain_name": "akash",
+        "client_id": "07-tendermint-188",
+        "connection_id": "connection-174"
+    },
+    "chain_2": {
+        "chain_name": "persistence",
+        "client_id": "07-tendermint-169",
+        "connection_id": "connection-214"
+    },
+    "channels": [
+        {
+            "chain_1": {
+                "channel_id": "channel-127",
+                "port_id": "transfer"
+            },
+            "chain_2": {
+                "channel_id": "channel-213",
+                "port_id": "transfer"
+            },
+            "ordering": "unordered",
+            "version": "ics20-1",
+            "tags": {}
+        }
+    ]
 }


### PR DESCRIPTION
The replaced path has expired for years, and no assets have been transferred using the path. The new path created will be actively utilized.

Can be checked here: https://www.mintscan.io/persistence/relayers/channel-5/akash/channel-6