### PR TITLE
move pro-delegators dYdX RPC at the end of the list

### DIFF
--- a/dydx/chain.json
+++ b/dydx/chain.json
@@ -182,10 +182,6 @@
   "apis": {
     "rpc": [
       {
-        "address": "https://community.nuxian-node.ch:6797/dydx/trpc",
-        "provider": "PRO Delegators"
-      },
-      {
         "address": "https://dydx-dao-rpc.polkachu.com",
         "provider": "Polkachu"
       },
@@ -228,6 +224,10 @@
       {
         "address": "https://dydx-rpc.enigma-validator.com",
         "provider": "Enigma"
+      },
+      {
+        "address": "https://community.nuxian-node.ch:6797/dydx/trpc",
+        "provider": "PRO Delegators"
       }
     ],
     "rest": [


### PR DESCRIPTION
The PRO Delegators [RPC endpoint](https://github.com/cosmos/chain-registry/blame/master/dydx/chain.json#L184-L187) on is not configured correctly and all of the routes return 404 (i.e. [/health](https://community.nuxian-node.ch:6797/health?)), which impacts third parties that use the chain registry RPC list.

This PR moves it down the RPC list it does not affect parties using the first RPC of the list by default, like the [Squid API](https://github.com/skip-mev/skip-router-sdk/blob/8c426403d5ddd90509abe2c5490191bcc29f8904/packages/core/src/client.ts#L1224).