### PR TITLE
Update `ibc` axelar-bitsong

### DIFF
--- a/_IBC/axelar-bitsong.json
+++ b/_IBC/axelar-bitsong.json
@@ -2,22 +2,22 @@
   "$schema": "../ibc_data.schema.json",
   "chain_1": {
     "chain_name": "axelar",
-    "client_id": "07-tendermint-201",
-    "connection_id": "connection-182"
+    "client_id": "07-tendermint-207",
+    "connection_id": "connection-188"
   },
   "chain_2": {
     "chain_name": "bitsong",
-    "client_id": "07-tendermint-79",
-    "connection_id": "connection-54"
+    "client_id": "07-tendermint-81",
+    "connection_id": "connection-56"
   },
   "channels": [
     {
       "chain_1": {
-        "channel_id": "channel-140",
+        "channel_id": "channel-145",
         "port_id": "transfer"
       },
       "chain_2": {
-        "channel_id": "channel-28",
+        "channel_id": "channel-30",
         "port_id": "transfer"
       },
       "ordering": "unordered",


### PR DESCRIPTION
Previous client on the axelar side has expired due to a relayer misconfiguration. The channel was only used for testing. New channels have been created as per request, the config error has been fixed on our side.