### PR TITLE
Add Check for Duplicate chain_ids

### DIFF
--- a/.github/workflows/utility/chain_registry.mjs
+++ b/.github/workflows/utility/chain_registry.mjs
@@ -43,8 +43,10 @@ export const nonChainDirectories = [
   "chain.schema.json",
   "ibc_data.schema.json",
   "memo_keys.schema.json",
+  "versions.schema.json",
   "README.md",
-  "LICENSE"
+  "LICENSE",
+  "package.json"
 ]
 
 export const assetSchema = {

--- a/.github/workflows/utility/chain_registry_local.mjs
+++ b/.github/workflows/utility/chain_registry_local.mjs
@@ -43,8 +43,10 @@ export const nonChainDirectories = [
   "chain.schema.json",
   "ibc_data.schema.json",
   "memo_keys.schema.json",
+  "versions.schema.json",
   "README.md",
-  "LICENSE"
+  "LICENSE",
+  "package.json"
 ]
 
 export const assetSchema = {


### PR DESCRIPTION
Add Check for Duplicate chain_ids
Killed chains do not count.
Chains without chain.json or underfined chain_id are skipped.