### PR TITLE
Update Data Validation to find Invalid Units

### DIFF
--- a/.github/workflows/utility/validate_data.mjs
+++ b/.github/workflows/utility/validate_data.mjs
@@ -13,37 +13,123 @@
 import * as path from 'path';
 import * as chain_reg from './chain_registry_local.mjs';
 
+
+const chainIdMap = new Map();
+
+
+function checkChainIdConflict(chain_name) {
+
+  // Not concerned by conflicts with 'Killed' chains--could be a hard fork
+  let chain_status = chain_reg.getFileProperty(chain_name, "chain", "status");
+  if (!chain_status || chain_status === "killed") { return; }
+
+  let chain_id = chain_reg.getFileProperty(chain_name, "chain", "chain_id");
+  if (!chain_id) { return; } // must have a chainId
+  if (chainIdMap.has(chain_id)) {
+    let conflict_chain_name = chainIdMap.get(chain_id);
+    throw new Error(`Duplicate chain ID for ${chain_name} found! Chain ID ${chain_id} is also claimed by ${conflict_chain_name}.`);
+  }
+  chainIdMap.set(chain_id, chain_name);
+
+}
+
+function checkFeesAreRegistered(chain_name) {
+
+  let fees = chain_reg.getFileProperty(chain_name, "chain", "fees");
+  fees?.fee_tokens?.forEach((fee_token) => {
+    if (!fee_token.denom) {
+      throw new Error(`One of ${chain_name}'s fee tokens does not have denom specified.`);
+    }
+    if (!chain_reg.getAssetProperty(chain_name, fee_token.denom, "base")) {
+      throw new Error(`Chain ${chain_name} does not have fee token ${fee_token.denom} defined in it's Assetlist.`);
+    }
+  });
+
+}
+
+function checkDenomUnits(asset) {
+
+  if (!asset.base) { return; }
+  let VALID_BASE_UNIT;
+  let VALID_DISPLAY_UNIT;
+  asset.denom_units?.forEach((denom_unit) => {
+  
+    let denom_and_aliases = [];
+    denom_and_aliases.push(denom_unit.denom);
+    denom_unit.aliases?.forEach((alias) => {
+      if (denom_and_aliases.includes(alias)) { return; }
+      denom_and_aliases.push(alias);
+    });
+
+    //find base unit
+    if (denom_and_aliases.includes(asset.base)) { 
+      if (denom_unit.exponent !== 0) {
+        throw new Error(`Base denomination ${asset.base} is not defined as having 0 exponent.`)
+      }
+      if (VALID_BASE_UNIT) {
+        throw new Error(`Base denomination ${asset.base} refers to multiple denom_units.`);
+      }
+      VALID_BASE_UNIT = true;
+    }
+
+    //find display unit
+    if (asset.display) {
+      if (denom_and_aliases.includes(asset.display)) { 
+        if (VALID_DISPLAY_UNIT) {
+          throw new Error(`Display denomination ${asset.display} refers to multiple denom_units.`);
+        }
+        VALID_DISPLAY_UNIT = true;
+      }
+    }
+
+    //check if IBC hashes contain lowercase letters
+    denom_and_aliases.forEach((denom) => {
+      if (!denom.startsWith("ibc/")) { return; }
+      const substring = denom.substring(4);
+      if (substring.toUpperCase() !== substring) {
+        throw new Error(`Denom ${denom} is an IBC hash denomination, yet contains lowercase letters after "ibc/"`);
+      }
+    });
+
+  });
+
+  if (!VALID_BASE_UNIT) {
+    throw new Error(`Base denomination ${asset.base} is not defined as a denom_unit.`);
+  }
+  if (!VALID_DISPLAY_UNIT) {
+    throw new Error(`Display denomination ${asset.display} is not defined as a denom_unit.`);
+  }
+
+}
+
+
 export function validate_chain_files() {
 
+  //get Chain Names
   const chainRegChains = chain_reg.getChains();
-  const chainIdMap = new Map();
 
   //iterate each chain
   chainRegChains.forEach((chain_name) => {
 
+    //console.log(chain_name);
+
     //check if chain_id is registered by another chain
-    let CHAIN_KILLED = chain_reg.getFileProperty(chain_name, "chain", "status");
-    if (!CHAIN_KILLED) {
-      let chain_id = chain_reg.getFileProperty(chain_name, "chain", "chain_id");
-      if (chain_id) {
-        if (chainIdMap.has(chain_id)) {
-          let conflict_chain_name = chainIdMap.get(chain_id);
-          throw new Error(`Duplicate chain ID found! Chain ID ${chain_id} is already claimed by ${conflict_chain_name}.`);
-        }
-        chainIdMap.set(chain_id, chain_name);
-      }
-    }
+    checkChainIdConflict(chain_name);
 
     //check if all fee tokens are registered
-    let fees = chain_reg.getFileProperty(chain_name, "chain", "fees");
-    fees?.fee_tokens?.forEach((fee_token) => {
-      if (!fee_token.denom) {
-        throw new Error(`One of ${chain_name}'s fee tokens does not have denom specified.`);
-      }
-      if (!chain_reg.getAssetProperty(chain_name, fee_token.denom, "base")) {
-        throw new Error(`Chain ${chain_name} does not have fee token ${fee_token.denom} defined in it's Assetlist.`);
-      }
+    checkFeesAreRegistered(chain_name);
+
+    //get chain's assets
+    const chainAssets = chain_reg.getFileProperty(chain_name, "assetlist", "assets");
+    
+    //iterate each asset
+    chainAssets?.forEach((asset) => {
+    
+      //check denom units
+      checkDenomUnits(asset);
+    
     });
+
 
   });
 

--- a/highbury/assetlist.json
+++ b/highbury/assetlist.json
@@ -71,7 +71,7 @@
       ],
       "base": "jinxy",
       "name": "Jinxy",
-      "display": "JINXy",
+      "display": "JINXY",
       "symbol": "JINXy",
       "logo_URIs": {
         "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/highbury/images/jinxy.png",

--- a/juno/assetlist.json
+++ b/juno/assetlist.json
@@ -842,7 +842,7 @@
           "exponent": 6
         }
       ],
-      "base": "juno1s2dp05rspeuzzpzyzdchk262szehrtfpz847uvf98cnwh53ulx4qg20qwj",
+      "base": "cw20:juno1s2dp05rspeuzzpzyzdchk262szehrtfpz847uvf98cnwh53ulx4qg20qwj",
       "name": "Banana Token",
       "display": "banana",
       "symbol": "BANANA",

--- a/osmosis/assetlist.json
+++ b/osmosis/assetlist.json
@@ -14081,7 +14081,7 @@
       "type_asset": "ics20",
       "base": "ibc/F49DFB3BC8105C57EE7F17EC2402438825B31212CFDD81681EB87911E934F32C",
       "name": "Nomic",
-      "display": "nomic",
+      "display": "nom",
       "symbol": "nomic.NOM",
       "traces": [
         {

--- a/teritori/assetlist.json
+++ b/teritori/assetlist.json
@@ -134,7 +134,10 @@
       "denom_units": [
         {
           "denom": "ibc/1FECA3491D88F4AD24DE0948ED96718CA6D93F6730CEE7708E621B953594BB5E",
-          "exponent": 0
+          "exponent": 0,
+          "aliases": [
+            "ukuji"
+          ]
         },
         {
           "denom": "kuji",
@@ -142,7 +145,7 @@
         }
       ],
       "type_asset": "ics20",
-      "base": "ukuji",
+      "base": "ibc/1FECA3491D88F4AD24DE0948ED96718CA6D93F6730CEE7708E621B953594BB5E",
       "name": "Kujira",
       "display": "kuji",
       "symbol": "KUJI",
@@ -189,7 +192,7 @@
         }
       ],
       "type_asset": "ics20",
-      "base": "uusdc",
+      "base": "ibc/FE98AAD68F02F03565E9FA39A5E627946699B2B07115889ED812D8BA639576A9",
       "display": "usdc",
       "name": "USD Coin",
       "symbol": "USDC",
@@ -235,7 +238,7 @@
         }
       ],
       "type_asset": "ics20",
-      "base": "uscrt",
+      "base": "ibc/F3F6BDEE1A79664B169D742651107BF4E03FA67E931452E27380B75F5917B7E9",
       "name": "Secret Network",
       "display": "scrt",
       "symbol": "SCRT",

--- a/terra/assetlist.json
+++ b/terra/assetlist.json
@@ -2795,7 +2795,7 @@
         },
         {
           "denom": "alot",
-          "exponent": 0
+          "exponent": 6
         }
       ],
       "type_asset": "cw20",
@@ -4447,7 +4447,7 @@
         },
         {
           "denom": "lctfancard",
-          "exponent": 0
+          "exponent": 6
         }
       ],
       "type_asset": "cw20",
@@ -4577,7 +4577,7 @@
         },
         {
           "denom": "cstfancard",
-          "exponent": 0
+          "exponent": 6
         }
       ],
       "type_asset": "cw20",

--- a/terra2/assetlist.json
+++ b/terra2/assetlist.json
@@ -73,18 +73,17 @@
       "denom_units": [
         {
           "denom": "cw20:terra1spkm49wd9dqkranhrks4cupecl3rtgeqqljq3qrvrrts2ev2gw6sy5vz3k",
-          "exponent": 0
-        },
-        {
-          "denom": "Dinheiros",
-          "exponent": 0
+          "exponent": 0,
+          "aliases": [
+            "Dinheiros"
+          ]
         }
       ],
       "type_asset": "cw20",
       "address": "terra1spkm49wd9dqkranhrks4cupecl3rtgeqqljq3qrvrrts2ev2gw6sy5vz3k",
       "base": "cw20:terra1spkm49wd9dqkranhrks4cupecl3rtgeqqljq3qrvrrts2ev2gw6sy5vz3k",
       "name": "dinheiro",
-      "display": "Dinheiros",
+      "display": "cw20:terra1spkm49wd9dqkranhrks4cupecl3rtgeqqljq3qrvrrts2ev2gw6sy5vz3k",
       "symbol": "DINHEIROS",
       "logo_URIs": {
         "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/terra2/images/Dinheiros.png"

--- a/testnets/arkeonetworktestnet/assetlist.json
+++ b/testnets/arkeonetworktestnet/assetlist.json
@@ -7,6 +7,10 @@
       "denom_units": [
         {
           "denom": "uarkeo",
+          "exponent": 0
+        },
+        {
+          "denom": "arkeo",
           "exponent": 6
         }
       ],

--- a/testnets/fetchhubtestnet/assetlist.json
+++ b/testnets/fetchhubtestnet/assetlist.json
@@ -16,7 +16,7 @@
       ],
       "base": "atestfet",
       "name": "fetch-ai",
-      "display": "fet",
+      "display": "testfet",
       "symbol": "FET",
       "logo_URIs": {
         "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/fetchhub/images/fet.png",

--- a/testnets/lavatestnet/chain.json
+++ b/testnets/lavatestnet/chain.json
@@ -5,7 +5,7 @@
   "network_type": "testnet",
   "website": "https://www.lavanet.xyz/",
   "pretty_name": "Lava",
-  "chain_id": "lava-testnet-2",
+  "chain_id": "lava-testnet-1",
   "bech32_prefix": "lava@",
   "daemon_name": "lavad",
   "node_home": "$HOME/.lava",

--- a/testnets/permtestnet/chain.json
+++ b/testnets/permtestnet/chain.json
@@ -4,7 +4,7 @@
     "status": "live",
     "network_type": "testnet",
     "pretty_name": "Perm Testnet",
-    "chain_id": "testnet-1",
+    "chain_id": "INVALID-ID-permtestnet-testnet-1",
     "bech32_prefix": "perm",
     "daemon_name": "permd",
     "node_home": "$HOME/.perm",

--- a/testnets/quasartestnet/assetlist.json
+++ b/testnets/quasartestnet/assetlist.json
@@ -31,7 +31,7 @@
             "exponent": 6
           }
         ],
-        "base": "uay",
+        "base": "uayy",
         "name": "AYY",
         "display": "ayy",
         "symbol": "AYY"
@@ -46,7 +46,7 @@
             "exponent": 6
           }
         ],
-        "base": "oro",
+        "base": "uoro",
         "name": "oro",
         "display": "oro",
         "symbol": "ORO"

--- a/testnets/ulastestnet/assetlist.json
+++ b/testnets/ulastestnet/assetlist.json
@@ -16,7 +16,7 @@
       ],
       "base": "uulas",
       "name": "ULAS Network",
-      "display": "ULAS",
+      "display": "ulas",
       "symbol": "ULAS",
       "logo_URIs": {
         "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/testnets/ulastestnet/images/logo.png"

--- a/testnets/uniontestnet/assetlist.json
+++ b/testnets/uniontestnet/assetlist.json
@@ -18,7 +18,7 @@
       ],
       "base": "muno",
       "name": "Union",
-      "display": "union",
+      "display": "uno",
       "symbol": "UNO",
       "logo_URIs": {
         "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/testnets/uniontestnet/images/union.png"

--- a/testnets/wavehashtestnet/chain.json
+++ b/testnets/wavehashtestnet/chain.json
@@ -4,7 +4,7 @@
     "status": "live",
     "network_type": "testnet",
     "pretty_name": "wavehash Testnet",
-    "chain_id": "testnet-1",
+    "chain_id": "INVALID-ID-wavehashtestnet-testnet-1",
     "bech32_prefix": "wavehash",
     "daemon_name": "wavehashd",
     "node_home": "$HOME/.wavehash",

--- a/testnets/xiontestnet/assetlist.json
+++ b/testnets/xiontestnet/assetlist.json
@@ -96,7 +96,7 @@
         }
       ],
       "type_asset": "ics20",
-      "base": "ibc/6AE2756AA7EAA8FA06E11472EA05CA681BD8D3FBC1AAA9F06C79D1EC1C90DC9B",
+      "base": "ibc/92E0120F15D037353CFB73C14651FC8930ADC05B93100FD7754D3A689E53B333",
       "name": "Osmosis OSMO Token",
       "display": "osmo",
       "symbol": "OSMO",


### PR DESCRIPTION
Specifically, missing base or display unit, that base is 0 exponent, and that ibc hash denoms are all uppercase.
Also, updated some testnet chain-ids, because they had already been taken.
Various denom_unit corrections--there were a number of invalid units specified throughout the registry, and this validation caught many of the issues.