### PR TITLE
Correct the nibiru-osmosis.json IBC connection

### DIFF
--- a/_IBC/nibiru-osmosis.json
+++ b/_IBC/nibiru-osmosis.json
@@ -13,7 +13,7 @@
   "channels": [
     {
       "chain_1": {
-        "channel_id": "channel-139",
+        "channel_id": "channel-0",
         "port_id": "transfer"
       },
       "chain_2": {


### PR DESCRIPTION
Correct the nibiru-osmosis.json IBC connection

Appears the previous value was a copypastypo, while the connection appears to actually be
channel-0
![image](https://github.com/cosmos/chain-registry/assets/95667791/aa4cda7d-0caa-4aa7-850a-763f7da53678)
