### PR TITLE
update dYdX RPC list order

### DIFF
--- a/dydx/chain.json
+++ b/dydx/chain.json
@@ -182,16 +182,16 @@
   "apis": {
     "rpc": [
       {
+        "address": "https://dydx-rpc.kingnodes.com:443",
+        "provider": "Kingnodes 👑"
+      },
+      {
         "address": "https://dydx-dao-rpc.polkachu.com",
         "provider": "Polkachu"
       },
       {
         "address": "https://dydx-mainnet-full-rpc.public.blastapi.io",
         "provider": "Bware Labs"
-      },
-      {
-        "address": "https://dydx-rpc.kingnodes.com:443",
-        "provider": "Kingnodes 👑"
       },
       {
         "address": "https://dydx-rpc.lavenderfive.com:443",


### PR DESCRIPTION
Update the order of RPC endpoints so Polkachu is no longer the first on the list.

This is because Polkachu has blocked any usage from a Github Action, which is not desirable when working with something like https://github.com/cosmos/chain-registry/pull/4136.