### PR TITLE
Add Coingecko ID to XRP on Coreum Chain

### DIFF
--- a/coreum/assetlist.json
+++ b/coreum/assetlist.json
@@ -79,7 +79,8 @@
       "logo_URIs": {
         "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/_non-cosmos/xrpl/images/xrp.png",
         "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/_non-cosmos/xrpl/images/xrp.svg"
-      }
+      },
+      "coingecko_id": "ripple"
     }
   ]
 }


### PR DESCRIPTION
This PR adds the coingecko ID `ripple` to the `XRP` asset for `Coreum` chain