### PR TITLE
Update IBC for cosmoshub-irisnet

### DIFF
--- a/_IBC/cosmoshub-irisnet.json
+++ b/_IBC/cosmoshub-irisnet.json
@@ -6,7 +6,7 @@
     "connection_id": "connection-187"
   },
   "chain_2": {
-    "chain_name": "irishub",
+    "chain_name": "irisnet",
     "client_id": "07-tendermint-1",
     "connection_id": "connection-1"
   },

--- a/_IBC/cosmoshub-irisnet.json
+++ b/_IBC/cosmoshub-irisnet.json
@@ -2,27 +2,30 @@
   "$schema": "../ibc_data.schema.json",
   "chain_1": {
     "chain_name": "cosmoshub",
-    "client_id": "07-tendermint-384",
-    "connection_id": "connection-338"
+    "client_id": "07-tendermint-141",
+    "connection_id": "connection-187"
   },
   "chain_2": {
-    "chain_name": "irisnet",
-    "client_id": "07-tendermint-31",
-    "connection_id": "connection-22"
+    "chain_name": "irishub",
+    "client_id": "07-tendermint-1",
+    "connection_id": "connection-1"
   },
   "channels": [
     {
       "chain_1": {
-        "channel_id": "channel-182",
+        "channel_id": "channel-91",
         "port_id": "transfer"
       },
       "chain_2": {
-        "channel_id": "channel-12",
+        "channel_id": "channel-0",
         "port_id": "transfer"
       },
       "ordering": "unordered",
       "version": "ics20-1",
-      "tags": {}
+      "tags": {
+        "status": "live",
+        "preferred": true
+      }
     }
   ]
 }


### PR DESCRIPTION
the channel-0 in IRIShub was created early when the chain supported IBC ics20, and be running by IRISnet officially. have to update the previous in the repo as the id of client and connection are different.