### PR TITLE
Update deprecated FURY.legacy CW20 asset

### DIFF
--- a/juno/assetlist.json
+++ b/juno/assetlist.json
@@ -671,8 +671,8 @@
         }
       ],
       "base": "cw20:juno1cltgm8v842gu54srmejewghnd6uqa26lzkpa635wzra9m9xuudkqa2gtcz",
-      "name": "Fanfury",
-      "display": "fury.legacy",
+      "name": "FURY.legacy",
+      "display": "fury",
       "symbol": "FURY.legacy",
       "logo_URIs": {
         "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/juno/images/fanfury.png"

--- a/juno/assetlist.json
+++ b/juno/assetlist.json
@@ -657,7 +657,7 @@
       ]
     },
     {
-      "description": "The native token cw20 for Fanfury on Juno Chain",
+      "description": "The deprecated cw20 token for Fanfury on Juno Chain",
       "type_asset": "cw20",
       "address": "juno1cltgm8v842gu54srmejewghnd6uqa26lzkpa635wzra9m9xuudkqa2gtcz",
       "denom_units": [
@@ -672,8 +672,8 @@
       ],
       "base": "cw20:juno1cltgm8v842gu54srmejewghnd6uqa26lzkpa635wzra9m9xuudkqa2gtcz",
       "name": "Fanfury",
-      "display": "fury",
-      "symbol": "FURY",
+      "display": "fury.legacy",
+      "symbol": "FURY.legacy",
       "logo_URIs": {
         "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/juno/images/fanfury.png"
       },


### PR DESCRIPTION

![image](https://github.com/cosmos/chain-registry/assets/131477257/361cbfe6-0b9b-44f4-a20c-074f5b2fff3e)[
Coingecko listing and migration notice](https://www.coingecko.com/en/coins/fanfury).

A Cw20 version of FURY was initially minted on Juno network but was deprecated later after migration to the native Furya Chain.
The entry resides in [Cosmos registry](https://github.com/cosmos/chain-registry/blob/master/furya/assetlist.json).

Corrections have to be made to reflect the current version of the token to avoid confusion.

This is probably the step one. Any further direction regarding this would also be appreciated.