### PR TITLE
Update `ibc` neutron-sei

### DIFF
--- a/_IBC/neutron-sei.json
+++ b/_IBC/neutron-sei.json
@@ -2,22 +2,22 @@
   "$schema": "../ibc_data.schema.json",
   "chain_1": {
     "chain_name": "neutron",
-    "client_id": "07-tendermint-37",
-    "connection_id": "connection-28"
+    "client_id": "07-tendermint-89",
+    "connection_id": "connection-65"
   },
   "chain_2": {
     "chain_name": "sei",
-    "client_id": "07-tendermint-27",
-    "connection_id": "connection-16"
+    "client_id": "07-tendermint-123",
+    "connection_id": "connection-157"
   },
   "channels": [
     {
       "chain_1": {
-        "channel_id": "channel-19",
+        "channel_id": "channel-2016",
         "port_id": "transfer"
       },
       "chain_2": {
-        "channel_id": "channel-15",
+        "channel_id": "channel-66",
         "port_id": "transfer"
       },
       "ordering": "unordered",


### PR DESCRIPTION
Old clients between Neutron and Sei were expired - new clients, connections and channels have been created. 

There were [only 2 successful (test) txs on the old channel pair](https://www.mintscan.io/neutron/relayers/channel-19/sei/channel-15), the 2nd tx was by the astroport team