### PR TITLE
Upgrade Evmos to v17.0.0

### DIFF
--- a/evmos/chain.json
+++ b/evmos/chain.json
@@ -40,7 +40,7 @@
     "compatible_versions": [
       "v17.0.0"
     ],
-    "cosmos_sdk_version": "evmos/cosmos-sdk v0.47.8-evmos",
+    "cosmos_sdk_version": "evmos/cosmos-sdk v0.47.5-evmos.2",
     "consensus": {
       "type": "cometbft",
       "version": "v0.37.4"
@@ -189,7 +189,7 @@
         "compatible_versions": [
           "v17.0.0"
         ],
-        "cosmos_sdk_version": "evmos/cosmos-sdk v0.47.8-evmos",
+        "cosmos_sdk_version": "evmos/cosmos-sdk v0.47.5-evmos.2",
         "consensus": {
           "type": "cometbft",
           "version": "v0.37.4"

--- a/evmos/chain.json
+++ b/evmos/chain.json
@@ -36,25 +36,22 @@
   },
   "codebase": {
     "git_repo": "https://github.com/evmos/evmos",
-    "recommended_version": "v16.0.3",
+    "recommended_version": "v17.0.0",
     "compatible_versions": [
-      "v16.0.0",
-      "v16.0.1",
-      "v16.0.2",
-      "v16.0.3"
+      "v17.0.0"
     ],
-    "cosmos_sdk_version": "v0.47.5-evmos.2",
+    "cosmos_sdk_version": "evmos/cosmos-sdk v0.47.8-evmos",
     "consensus": {
       "type": "cometbft",
-      "version": "v0.37.3-0.20230920093934-46df7b597e3c"
+      "version": "v0.37.4"
     },
-    "ibc_go_version": "7.3.1",
+    "ibc_go_version": "7.4.0",
     "binaries": {
-      "linux/amd64": "https://github.com/evmos/evmos/releases/download/v16.0.3/evmos_16.0.3_Linux_amd64.tar.gz",
-      "linux/arm64": "https://github.com/evmos/evmos/releases/download/v16.0.3/evmos_16.0.3_Linux_arm64.tar.gz",
-      "darwin/amd64": "https://github.com/evmos/evmos/releases/download/v16.0.3/evmos_16.0.3_Darwin_amd64.tar.gz",
-      "darwin/arm64": "https://github.com/evmos/evmos/releases/download/v16.0.3/evmos_16.0.3_Darwin_arm64.tar.gz",
-      "windows/amd64": "https://github.com/evmos/evmos/releases/download/v16.0.3/evmos_16.0.3_Windows_amd64.zip"
+      "linux/amd64": "https://github.com/evmos/evmos/releases/download/v17.0.0/evmos_17.0.0_Linux_amd64.tar.gz",
+      "linux/arm64": "https://github.com/evmos/evmos/releases/download/v17.0.0/evmos_17.0.0_Linux_arm64.tar.gz",
+      "darwin/amd64": "https://github.com/evmos/evmos/releases/download/v17.0.0/evmos_17.0.0_Darwin_amd64.tar.gz",
+      "darwin/arm64": "https://github.com/evmos/evmos/releases/download/v17.0.0/evmos_17.0.0_Darwin_arm64.tar.gz",
+      "windows/amd64": "https://github.com/evmos/evmos/releases/download/v17.0.0/evmos_17.0.0_Windows_amd64.zip"
     },
     "genesis": {
       "genesis_url": "https://archive.evmos.org/mainnet/genesis.json"
@@ -162,15 +159,12 @@
       },
       {
         "name": "v16.0.0",
-        "tag": "v16.0.3",
+        "tag": "v16.0.4",
         "proposal": 265,
         "height": 18295000,
-        "recommended_version": "v16.0.3",
+        "recommended_version": "v16.0.4",
         "compatible_versions": [
-          "v16.0.0",
-          "v16.0.1",
-          "v16.0.2",
-          "v16.0.3"
+          "v16.0.4"
         ],
         "cosmos_sdk_version": "v0.47.5-evmos.2",
         "consensus": {
@@ -179,11 +173,34 @@
         },
         "ibc_go_version": "v7.3.1",
         "binaries": {
-          "linux/amd64": "https://github.com/evmos/evmos/releases/download/v16.0.3/evmos_16.0.3_Linux_amd64.tar.gz",
-          "linux/arm64": "https://github.com/evmos/evmos/releases/download/v16.0.3/evmos_16.0.3_Linux_arm64.tar.gz",
-          "darwin/amd64": "https://github.com/evmos/evmos/releases/download/v16.0.3/evmos_16.0.3_Darwin_amd64.tar.gz",
-          "darwin/arm64": "https://github.com/evmos/evmos/releases/download/v16.0.3/evmos_16.0.3_Darwin_arm64.tar.gz",
-          "windows/amd64": "https://github.com/evmos/evmos/releases/download/v16.0.3/evmos_16.0.3_Windows_amd64.zip"
+          "linux/amd64": "https://github.com/evmos/evmos/releases/download/v16.0.4/evmos_16.0.4_Linux_amd64.tar.gz",
+          "linux/arm64": "https://github.com/evmos/evmos/releases/download/v16.0.4/evmos_16.0.4_Linux_arm64.tar.gz",
+          "darwin/amd64": "https://github.com/evmos/evmos/releases/download/v16.0.4/evmos_16.0.4_Darwin_amd64.tar.gz",
+          "darwin/arm64": "https://github.com/evmos/evmos/releases/download/v16.0.4/evmos_16.0.4_Darwin_arm64.tar.gz",
+          "windows/amd64": "https://github.com/evmos/evmos/releases/download/v16.0.4/evmos_16.0.4_Windows_amd64.zip"
+        },
+        "next_version_name": "v17.0.0"
+      },
+      {
+        "name": "v17.0.0",
+        "tag": "v17.0.0",
+        "height": 20101000,
+        "recommended_version": "v17.0.0",
+        "compatible_versions": [
+          "v17.0.0"
+        ],
+        "cosmos_sdk_version": "evmos/cosmos-sdk v0.47.8-evmos",
+        "consensus": {
+          "type": "cometbft",
+          "version": "v0.37.4"
+        },
+        "ibc_go_version": "7.4.0",
+        "binaries": {
+          "linux/amd64": "https://github.com/evmos/evmos/releases/download/v17.0.0/evmos_17.0.0_Linux_amd64.tar.gz",
+          "linux/arm64": "https://github.com/evmos/evmos/releases/download/v17.0.0/evmos_17.0.0_Linux_arm64.tar.gz",
+          "darwin/amd64": "https://github.com/evmos/evmos/releases/download/v17.0.0/evmos_17.0.0_Darwin_amd64.tar.gz",
+          "darwin/arm64": "https://github.com/evmos/evmos/releases/download/v17.0.0/evmos_17.0.0_Darwin_arm64.tar.gz",
+          "windows/amd64": "https://github.com/evmos/evmos/releases/download/v17.0.0/evmos_17.0.0_Windows_amd64.zip"
         },
         "next_version_name": ""
       }


### PR DESCRIPTION
https://github.com/evmos/evmos/releases/tag/v17.0.0

Non-prop based upgrade, so there is no proposal. Binary on v16 was changed to v16.0.4 before halt-height, new binary v17.0.0 works with cosmovisor as v17.0.0 regardless of there being no prop