### PR TITLE
Update Osmosis to Version v24

### DIFF
--- a/osmosis/chain.json
+++ b/osmosis/chain.json
@@ -41,28 +41,25 @@
       "name": "v3",
       "genesis_url": "https://github.com/osmosis-labs/networks/raw/main/osmosis-1/genesis.json"
     },
-    "recommended_version": "v23.0.8",
+    "recommended_version": "v24.0.0",
     "compatible_versions": [
-      "v23.0.8",
-      "v23.0.6",
-      "v23.0.3",
-      "v23.0.0"
+      "v24.0.0"
     ],
-    "cosmos_sdk_version": "osmosis-labs/cosmos-sdk v0.47.5-v23-osmo-4",
+    "cosmos_sdk_version": "osmosis-labs/cosmos-sdk v0.47.5-v24-osmo-5",
     "consensus": {
       "type": "cometbft",
-      "version": "osmosis-labs/cometbft v0.37.4-v23-osmo-3"
+      "version": "osmosis-labs/cometbft v0.37.4-v24-osmo-2"
     },
     "cosmwasm_version": "osmosis-labs/wasmd v0.45.0-osmo",
     "cosmwasm_enabled": true,
-    "ibc_go_version": "v7.3.1",
+    "ibc_go_version": "v7.4.0",
     "ics_enabled": [
       "ics20-1"
     ],
     "go_version": "1.21",
     "binaries": {
-      "linux/amd64": "https://github.com/osmosis-labs/osmosis/releases/download/v23.0.8/osmosisd-23.0.8-linux-amd64",
-      "linux/arm64": "https://github.com/osmosis-labs/osmosis/releases/download/v23.0.8/osmosisd-23.0.8-linux-arm64"
+      "linux/amd64": "https://github.com/osmosis-labs/osmosis/releases/download/v24.0.0/osmosisd-24.0.0-linux-amd64",
+      "linux/arm64": "https://github.com/osmosis-labs/osmosis/releases/download/v24.0.0/osmosisd-24.0.0-linux-arm64"
     }
   },
   "images": [

--- a/osmosis/chain.json
+++ b/osmosis/chain.json
@@ -41,8 +41,9 @@
       "name": "v3",
       "genesis_url": "https://github.com/osmosis-labs/networks/raw/main/osmosis-1/genesis.json"
     },
-    "recommended_version": "v24.0.0",
+    "recommended_version": "v24.0.1",
     "compatible_versions": [
+      "v24.0.1",
       "v24.0.0"
     ],
     "cosmos_sdk_version": "osmosis-labs/cosmos-sdk v0.47.5-v24-osmo-5",
@@ -58,8 +59,8 @@
     ],
     "go_version": "1.21",
     "binaries": {
-      "linux/amd64": "https://github.com/osmosis-labs/osmosis/releases/download/v24.0.0/osmosisd-24.0.0-linux-amd64",
-      "linux/arm64": "https://github.com/osmosis-labs/osmosis/releases/download/v24.0.0/osmosisd-24.0.0-linux-arm64"
+      "linux/amd64": "https://github.com/osmosis-labs/osmosis/releases/download/v24.0.1/osmosisd-24.0.1-linux-amd64",
+      "linux/arm64": "https://github.com/osmosis-labs/osmosis/releases/download/v24.0.1/osmosisd-24.0.1-linux-arm64"
     }
   },
   "images": [

--- a/osmosis/versions.json
+++ b/osmosis/versions.json
@@ -357,11 +357,12 @@
     },
     {
       "name": "v24",
-      "tag": "v24.0.0",
+      "tag": "v24.0.1",
       "proposal": 763,
       "height": 14830300,
-      "recommended_version": "v24.0.0",
+      "recommended_version": "v24.0.1",
       "compatible_versions": [
+        "v24.0.1",
         "v24.0.0"
       ],
       "cosmos_sdk_version": "osmosis-labs/cosmos-sdk v0.47.5-v24-osmo-5",
@@ -377,8 +378,8 @@
       ],
       "go_version": "1.21",
       "binaries": {
-        "linux/amd64": "https://github.com/osmosis-labs/osmosis/releases/download/v24.0.0/osmosisd-24.0.0-linux-amd64",
-        "linux/arm64": "https://github.com/osmosis-labs/osmosis/releases/download/v24.0.0/osmosisd-24.0.0-linux-arm64"
+        "linux/amd64": "https://github.com/osmosis-labs/osmosis/releases/download/v24.0.1/osmosisd-24.0.1-linux-amd64",
+        "linux/arm64": "https://github.com/osmosis-labs/osmosis/releases/download/v24.0.1/osmosisd-24.0.1-linux-arm64"
       },
       "previous_version_name": "v23",
       "next_version_name": ""

--- a/osmosis/versions.json
+++ b/osmosis/versions.json
@@ -353,6 +353,34 @@
         "linux/arm64": "https://github.com/osmosis-labs/osmosis/releases/download/v23.0.8/osmosisd-23.0.8-linux-arm64"
       },
       "previous_version_name": "v22",
+      "next_version_name": "v24"
+    },
+    {
+      "name": "v24",
+      "tag": "v24.0.0",
+      "proposal": 763,
+      "height": 14830300,
+      "recommended_version": "v24.0.0",
+      "compatible_versions": [
+        "v24.0.0"
+      ],
+      "cosmos_sdk_version": "osmosis-labs/cosmos-sdk v0.47.5-v24-osmo-5",
+      "consensus": {
+        "type": "cometbft",
+        "version": "osmosis-labs/cometbft v0.37.4-v24-osmo-2"
+      },
+      "cosmwasm_version": "osmosis-labs/wasmd v0.45.0-osmo",
+      "cosmwasm_enabled": true,
+      "ibc_go_version": "v7.4.0",
+      "ics_enabled": [
+        "ics20-1"
+      ],
+      "go_version": "1.21",
+      "binaries": {
+        "linux/amd64": "https://github.com/osmosis-labs/osmosis/releases/download/v24.0.0/osmosisd-24.0.0-linux-amd64",
+        "linux/arm64": "https://github.com/osmosis-labs/osmosis/releases/download/v24.0.0/osmosisd-24.0.0-linux-arm64"
+      },
+      "previous_version_name": "v23",
       "next_version_name": ""
     }
   ]


### PR DESCRIPTION
Update Osmosis to Version v24

https://github.com/osmosis-labs/osmosis/blob/v24.0.0/CHANGELOG.md
https://github.com/osmosis-labs/osmosis/blob/main/go.mod