### PR TITLE
Fix Moonbeam's Assets `type_asset`

### DIFF
--- a/_non-cosmos/moonbeam/assetlist.json
+++ b/_non-cosmos/moonbeam/assetlist.json
@@ -52,7 +52,6 @@
           "exponent": 18
         }
       ],
-      "type_asset": "substrate",
       "base": "0xacc15dc74880c9944775448304b263d191c6077f",
       "name": "Wrapped Moonbeam",
       "display": "wglmr",
@@ -94,7 +93,6 @@
           "exponent": 10
         }
       ],
-      "type_asset": "substrate",
       "base": "0xffffffff1fcacbd218edc0eba20fc2308c778080",
       "name": "Wrapped Polkadot",
       "display": "xcdot",
@@ -137,7 +135,6 @@
           "exponent": 18
         }
       ],
-      "type_asset": "substrate",
       "base": "0x14df360966a1c4582d2b18edbdae432ea0a27575",
       "name": "Axelar Wrapped Dai Stablecoin",
       "display": "axldai",
@@ -178,7 +175,6 @@
           "exponent": 18
         }
       ],
-      "type_asset": "substrate",
       "base": "0x61C82805453a989E99B544DFB7031902e9bac448",
       "name": "Axelar Wrapped Frax",
       "display": "axlfrax",
@@ -219,7 +215,6 @@
           "exponent": 6
         }
       ],
-      "type_asset": "substrate",
       "base": "0xca01a1d0993565291051daff390892518acfad3a",
       "name": "Axelar Wrapped USD Coin",
       "display": "axlusdc",
@@ -260,7 +255,6 @@
           "exponent": 6
         }
       ],
-      "type_asset": "substrate",
       "base": "0xdfd74af792bc6d45d1803f425ce62dd16f8ae038",
       "name": "Axelar Wrapped Tether USD",
       "display": "axlusdt",


### PR DESCRIPTION
Fix Moonbeam's Assets `type_asset`
Had duplicate properties for type_asset
Removed the substrate one on addressed assets--kept as erc20