### PR TITLE
Remove CGID from Terra2::ASTRO

### DIFF
--- a/terra2/assetlist.json
+++ b/terra2/assetlist.json
@@ -55,7 +55,6 @@
       "logo_URIs": {
         "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/terra2/images/astro-cw20.svg"
       },
-      "coingecko_id": "astroport-fi",
       "images": [
         {
           "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/terra2/images/astro-cw20.svg"


### PR DESCRIPTION
Remove CGID from Terra2::ASTRO
Belongs only on Neutron's ASTRO