### PR TITLE
Fix xASTRO image URL

### DIFF
--- a/neutron/assetlist.json
+++ b/neutron/assetlist.json
@@ -438,11 +438,11 @@
       ],
       "images": [
         {
-          "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/neutron/images/xASTRO.svg"
+          "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/neutron/images/xAstro.svg"
         }
       ],
       "logo_URIs": {
-          "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/neutron/images/xASTRO.svg"
+          "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/neutron/images/xAstro.svg"
       },
       "socials": {
         "website": "https://astroport.fi/",


### PR DESCRIPTION
Fix xASTRO image URL
Due to capitalized letters, the URL did not go to the uploaded image