### PR TITLE
Update Osmosis' Assetlist

### DIFF
--- a/osmosis/assetlist.json
+++ b/osmosis/assetlist.json
@@ -33,11 +33,7 @@
       "keywords": [
         "dex",
         "staking"
-      ],
-      "socials": {
-        "website": "https://osmosis.zone",
-        "twitter": "https://twitter.com/osmosiszone"
-      }
+      ]
     },
     {
       "denom_units": [
@@ -69,11 +65,7 @@
       "keywords": [
         "memecoin",
         "defi"
-      ],
-      "socials": {
-        "website": "https://ion.wtf",
-        "twitter": "https://twitter.com/_IONDAO"
-      }
+      ]
     },
     {
       "description": "Circle's stablecoin on Axelar",
@@ -126,8 +118,8 @@
         }
       ],
       "logo_URIs": {
-        "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/osmosis/images/usdc.axl.png",
-        "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/osmosis/images/usdc.axl.svg"
+        "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/osmosis/images/usdc.axl.svg",
+        "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/osmosis/images/usdc.axl.png"
       },
       "images": [
         {
@@ -195,8 +187,7 @@
         }
       ],
       "logo_URIs": {
-        "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/_non-cosmos/ethereum/images/eth-white.png",
-        "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/_non-cosmos/ethereum/images/eth-white.svg"
+        "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/_non-cosmos/ethereum/images/eth-white.png"
       },
       "images": [
         {
@@ -256,8 +247,8 @@
         }
       ],
       "logo_URIs": {
-        "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/osmosis/images/wbtc.axl.png",
-        "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/osmosis/images/wbtc.axl.svg"
+        "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/osmosis/images/wbtc.axl.svg",
+        "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/osmosis/images/wbtc.axl.png"
       },
       "images": [
         {
@@ -324,8 +315,7 @@
         }
       ],
       "logo_URIs": {
-        "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/axelar/images/usdt.png",
-        "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/axelar/images/usdt.svg"
+        "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/osmosis/images/usdt.axl.svg"
       },
       "images": [
         {
@@ -668,8 +658,7 @@
         }
       ],
       "logo_URIs": {
-        "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/_non-cosmos/polygon/images/matic-purple.png",
-        "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/_non-cosmos/polygon/images/matic-purple.svg"
+        "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/_non-cosmos/polygon/images/matic-purple.png"
       },
       "images": [
         {
@@ -729,8 +718,7 @@
         }
       ],
       "logo_URIs": {
-        "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/_non-cosmos/avalanche/images/avax.png",
-        "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/_non-cosmos/avalanche/images/avax.svg"
+        "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/_non-cosmos/avalanche/images/avax.png"
       },
       "images": [
         {
@@ -859,7 +847,7 @@
       "base": "ibc/3FF92D26B407FD61AE95D975712A7C319CDE28DE4D80BDC9978D935932B991D7",
       "name": "Wrapped Polkadot (Axelar)",
       "display": "dot",
-      "symbol": "DOT.axl",
+      "symbol": "moonbeam.DOT.axl",
       "traces": [
         {
           "type": "bridge",
@@ -891,8 +879,7 @@
         }
       ],
       "logo_URIs": {
-        "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/_non-cosmos/polkadot/images/dot.png",
-        "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/_non-cosmos/polkadot/images/dot.svg"
+        "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/osmosis/images/dot.axl.svg"
       },
       "images": [
         {
@@ -1689,7 +1676,7 @@
       ],
       "type_asset": "ics20",
       "base": "ibc/F3FF7A84A73B62921538642F9797C423D2B4C4ACB3C7FCFFCE7F12AA69909C4B",
-      "name": "ixo",
+      "name": "Impacts Hub",
       "display": "ixo",
       "symbol": "IXO",
       "traces": [
@@ -2206,7 +2193,8 @@
         }
       ],
       "keywords": [
-        "osmosis_unstable"
+        "osmosis_unstable",
+        "osmosis-unstable"
       ]
     },
     {
@@ -2350,6 +2338,9 @@
           "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/konstellation/images/darc.png",
           "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/konstellation/images/darc.svg"
         }
+      ],
+      "keywords": [
+        "osmosis-unstable"
       ]
     },
     {
@@ -2369,7 +2360,7 @@
       ],
       "type_asset": "ics20",
       "base": "ibc/67795E528DF67C5606FC20F824EA39A6EF55BA133F4DC79C90A8C47A0901E17C",
-      "name": "Umee",
+      "name": "UX Chain",
       "display": "umee",
       "symbol": "UMEE",
       "traces": [
@@ -2627,7 +2618,8 @@
         }
       ],
       "keywords": [
-        "osmosis_unstable"
+        "osmosis_unstable",
+        "osmosis-unstable"
       ]
     },
     {
@@ -2913,7 +2905,8 @@
         }
       ],
       "keywords": [
-        "osmosis_unstable"
+        "osmosis_unstable",
+        "osmosis-unstable"
       ]
     },
     {
@@ -3213,8 +3206,7 @@
         }
       ],
       "logo_URIs": {
-        "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/_non-cosmos/ethereum/images/wbtc.png",
-        "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/_non-cosmos/ethereum/images/wbtc.svg"
+        "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/osmosis/images/wbtc.grv.svg"
       },
       "images": [
         {
@@ -3277,7 +3269,7 @@
         }
       ],
       "logo_URIs": {
-        "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/_non-cosmos/ethereum/images/weth.svg"
+        "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/osmosis/images/weth.grv.svg"
       },
       "images": [
         {
@@ -3339,7 +3331,7 @@
         }
       ],
       "logo_URIs": {
-        "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/_non-cosmos/ethereum/images/usdc.svg"
+        "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/osmosis/images/usdc.grv.svg"
       },
       "images": [
         {
@@ -3401,7 +3393,7 @@
         }
       ],
       "logo_URIs": {
-        "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/_non-cosmos/ethereum/images/dai.svg"
+        "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/osmosis/images/dai.grv.svg"
       },
       "images": [
         {
@@ -3463,7 +3455,7 @@
         }
       ],
       "logo_URIs": {
-        "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/_non-cosmos/ethereum/images/usdt.svg"
+        "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/osmosis/images/usdt.grv.svg"
       },
       "images": [
         {
@@ -4115,7 +4107,8 @@
         }
       ],
       "keywords": [
-        "osmosis_unstable"
+        "osmosis_unstable",
+        "osmosis-unstable"
       ]
     },
     {
@@ -4169,7 +4162,8 @@
         }
       ],
       "keywords": [
-        "osmosis_unlisted"
+        "osmosis_unlisted",
+        "osmosis-unlisted"
       ]
     },
     {
@@ -4223,7 +4217,8 @@
         }
       ],
       "keywords": [
-        "osmosis_unlisted"
+        "osmosis_unlisted",
+        "osmosis-unlisted"
       ]
     },
     {
@@ -4390,7 +4385,8 @@
         }
       ],
       "keywords": [
-        "osmosis_unlisted"
+        "osmosis_unlisted",
+        "osmosis-unlisted"
       ]
     },
     {
@@ -4619,7 +4615,8 @@
         }
       ],
       "keywords": [
-        "osmosis_unstable"
+        "osmosis_unstable",
+        "osmosis-unstable"
       ]
     },
     {
@@ -4667,7 +4664,8 @@
         }
       ],
       "keywords": [
-        "osmosis_unstable"
+        "osmosis_unstable",
+        "osmosis-unstable"
       ]
     },
     {
@@ -4958,7 +4956,8 @@
         }
       ],
       "keywords": [
-        "osmosis_unstable"
+        "osmosis_unstable",
+        "osmosis-unstable"
       ]
     },
     {
@@ -6299,9 +6298,9 @@
       ],
       "type_asset": "ics20",
       "base": "ibc/7CE5F388D661D82A0774E47B5129DA51CC7129BD1A70B5FA6BCEBB5B0A2FAEAF",
-      "name": "Fanfury",
+      "name": "FURY.legacy",
       "display": "fury",
-      "symbol": "FURY",
+      "symbol": "FURY.legacy",
       "traces": [
         {
           "type": "ibc-cw20",
@@ -6679,6 +6678,14 @@
       "display": "stkatom",
       "symbol": "stkATOM",
       "traces": [
+        {
+          "type": "liquid-stake",
+          "counterparty": {
+            "chain_name": "cosmoshub",
+            "base_denom": "uatom"
+          },
+          "provider": "pSTAKE"
+        },
         {
           "type": "ibc",
           "counterparty": {
@@ -7114,7 +7121,7 @@
       "base": "ibc/231FD77ECCB2DB916D314019DA30FE013202833386B1908A191D16989AD80B5A",
       "name": "USD Coin (Polygon)",
       "display": "polygon-usdc",
-      "symbol": "polygon.USDC",
+      "symbol": "polygon.USDC.axl",
       "traces": [
         {
           "type": "synthetic",
@@ -7154,7 +7161,7 @@
         }
       ],
       "logo_URIs": {
-        "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/_non-cosmos/ethereum/images/usdc.svg"
+        "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/osmosis/images/polygon.usdc.svg"
       },
       "images": [
         {
@@ -7184,7 +7191,7 @@
       "base": "ibc/F17C9CA112815613C5B6771047A093054F837C3020CBA59DFFD9D780A8B2984C",
       "name": "USD Coin (Avalanche)",
       "display": "avalanche-usdc",
-      "symbol": "avalanche.USDC",
+      "symbol": "avalanche.USDC.axl",
       "traces": [
         {
           "type": "synthetic",
@@ -7224,7 +7231,7 @@
         }
       ],
       "logo_URIs": {
-        "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/_non-cosmos/ethereum/images/usdc.svg"
+        "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/osmosis/images/avalanche.usdc.svg"
       },
       "images": [
         {
@@ -7808,7 +7815,8 @@
         }
       ],
       "keywords": [
-        "osmosis_unstable"
+        "osmosis_unstable",
+        "osmosis-unstable"
       ]
     },
     {
@@ -9121,7 +9129,6 @@
       ]
     },
     {
-      "description": "",
       "denom_units": [
         {
           "denom": "ibc/E47F4E97C534C95B942729E1B25DBDE111EA791411CFF100515050BEA0AC0C6B",
@@ -9448,7 +9455,7 @@
         }
       ],
       "logo_URIs": {
-        "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/_non-cosmos/ethereum/images/wsteth.svg"
+        "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/osmosis/images/wstETH.axl.svg"
       },
       "images": [
         {
@@ -10738,7 +10745,7 @@
         }
       ],
       "logo_URIs": {
-        "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/_non-cosmos/ethereum/images/usdt.svg"
+        "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/osmosis/images/usdt.hole.svg"
       },
       "images": [
         {
@@ -10849,7 +10856,7 @@
         }
       ],
       "logo_URIs": {
-        "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/_non-cosmos/aptos/images/aptos.svg"
+        "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/_non-cosmos/aptos/images/apt-dm.svg"
       },
       "images": [
         {
@@ -11002,7 +11009,7 @@
         }
       ],
       "logo_URIs": {
-        "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/_non-cosmos/ethereum/images/usdc.svg"
+        "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/osmosis/images/usdc.hole.svg"
       },
       "images": [
         {
@@ -11069,8 +11076,7 @@
         }
       ],
       "logo_URIs": {
-        "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/_non-cosmos/ethereum/images/eth-white.png",
-        "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/_non-cosmos/ethereum/images/eth-white.svg"
+        "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/osmosis/images/weth.hole.svg"
       },
       "images": [
         {
@@ -11134,8 +11140,7 @@
         }
       ],
       "logo_URIs": {
-        "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/noble/images/USDCoin.png",
-        "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/noble/images/USDCoin.svg"
+        "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/_non-cosmos/ethereum/images/usdc.svg"
       },
       "images": [
         {
@@ -11732,7 +11737,6 @@
       ]
     },
     {
-      "description": "",
       "denom_units": [
         {
           "denom": "ibc/D79E7D83AB399BFFF93433E54FAA480C191248FC556924A2A8351AE2638B3877",
@@ -11815,8 +11819,7 @@
         }
       ],
       "logo_URIs": {
-        "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/dydx/images/dydx.png",
-        "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/dydx/images/dydx.svg"
+        "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/dydx/images/dydx-circle.svg"
       },
       "images": [
         {
@@ -12019,7 +12022,7 @@
       "description": "The Revenue & Governance token of Unstake.fi",
       "denom_units": [
         {
-          "denom": "ibc/690EB0A0CA0DA2DC1E9CF62FB23C935AE5C7E9F57919CF89690521D5D70948A7",
+          "denom": "ibc/F74225B0AFD2F675AF56E9BE3F235486BCDE5C5E09AA88A97AFD2E052ABFE04C",
           "exponent": 0,
           "aliases": [
             "factory/kujira1aaudpfr9y23lt9d45hrmskphpdfaq9ajxd3ukh/unstk"
@@ -12031,7 +12034,7 @@
         }
       ],
       "type_asset": "ics20",
-      "base": "ibc/690EB0A0CA0DA2DC1E9CF62FB23C935AE5C7E9F57919CF89690521D5D70948A7",
+      "base": "ibc/F74225B0AFD2F675AF56E9BE3F235486BCDE5C5E09AA88A97AFD2E052ABFE04C",
       "name": "Unstake Fi",
       "display": "nstk",
       "symbol": "NSTK",
@@ -12222,7 +12225,8 @@
         }
       ],
       "keywords": [
-        "osmosis_unlisted"
+        "osmosis_unlisted",
+        "osmosis-unlisted"
       ]
     },
     {
@@ -12266,6 +12270,9 @@
         {
           "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/qwoyn/images/qwoyn.png"
         }
+      ],
+      "keywords": [
+        "gaming"
       ]
     },
     {
@@ -12571,6 +12578,14 @@
       "symbol": "stkOSMO",
       "traces": [
         {
+          "type": "liquid-stake",
+          "counterparty": {
+            "chain_name": "osmosis",
+            "base_denom": "uosmo"
+          },
+          "provider": "pSTAKE"
+        },
+        {
           "type": "ibc",
           "counterparty": {
             "chain_name": "persistence",
@@ -12600,7 +12615,6 @@
     },
     {
       "description": "Levana Well-funded Perps is a protocol for perpetual swaps, which are leveraged trading contracts.",
-      "extended_description": "Levana Well-funded Perps is a protocol for perpetual swaps, which are leveraged trading contracts. It aims to manage risk and provide benefits to both traders and liquidity providers.\n\nFor traders, Levana's solution is to make all positions \"well-funded,\" meaning that the maximum profit for each position is locked in advance. This eliminates the possibility of bad debt and insolvency, providing greater security.\n\nLiquidity providers, on the other hand, receive a yield for taking on the risk of market instability. They supply funds that act as collateral, and in return, they earn a fee with a risk premium.\n\nThe protocol addresses the issues with existing perpetual swap models, such as the virtual AMM. These models rely on complex mechanisms to maintain price stability, but they have limitations and can be risky in volatile markets.\n\nBy separating different trading pairs and creating a decentralized market for liquidity, Levana reduces the risk of contagion between different markets. This also makes it easier to expand to other blockchain networks.\n\nOverall, Levana's perpetual swaps protocol offers a reliable and secure platform for traders and liquidity providers. It ensures fair settlement, minimizes risks, and allows for the development of additional financial protocols on top of tokenized positions.",
       "denom_units": [
         {
           "denom": "factory/osmo1mlng7pz4pnyxtpq0akfwall37czyk9lukaucsrn30ameplhhshtqdvfm5c/ulvn",
@@ -12626,7 +12640,8 @@
           "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/osmosis/images/levana.svg"
         },
         {
-          "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/osmosis/images/levana.png"
+          "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/osmosis/images/levana.png",
+          "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/osmosis/images/levana.svg"
         }
       ],
       "coingecko_id": "levana-protocol"
@@ -12676,7 +12691,8 @@
         }
       ],
       "keywords": [
-        "osmosis_unstable"
+        "osmosis_unstable",
+        "osmosis-unstable"
       ]
     },
     {
@@ -12985,7 +13001,8 @@
         }
       ],
       "keywords": [
-        "osmosis_unlisted"
+        "osmosis_unlisted",
+        "osmosis-unlisted"
       ]
     },
     {
@@ -13103,7 +13120,8 @@
         }
       ],
       "keywords": [
-        "osmosis_unlisted"
+        "osmosis_unlisted",
+        "osmosis-unlisted"
       ]
     },
     {
@@ -13237,7 +13255,8 @@
         }
       ],
       "keywords": [
-        "osmosis_unlisted"
+        "osmosis_unlisted",
+        "osmosis-unlisted"
       ]
     },
     {
@@ -13558,7 +13577,8 @@
           "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/_non-cosmos/ethereum/images/wbtc.png",
           "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/_non-cosmos/ethereum/images/wbtc.svg"
         }
-      ]
+      ],
+      "coingecko_id": "wrapped-bitcoin"
     },
     {
       "description": "Baddest coin on Cosmos",
@@ -13853,6 +13873,111 @@
       ]
     },
     {
+      "description": "Stride's liquid staked SAGA",
+      "denom_units": [
+        {
+          "denom": "ibc/2CD9F8161C3FC332E78EF0C25F6E684D09379FB2F56EF9267E7EC139642EC57B",
+          "exponent": 0,
+          "aliases": [
+            "stusaga"
+          ]
+        },
+        {
+          "denom": "stSAGA",
+          "exponent": 6
+        }
+      ],
+      "type_asset": "ics20",
+      "base": "ibc/2CD9F8161C3FC332E78EF0C25F6E684D09379FB2F56EF9267E7EC139642EC57B",
+      "name": "Stride Staked SAGA",
+      "display": "stSAGA",
+      "symbol": "stSAGA",
+      "traces": [
+        {
+          "type": "liquid-stake",
+          "counterparty": {
+            "chain_name": "saga",
+            "base_denom": "usaga"
+          },
+          "provider": "Stride"
+        },
+        {
+          "type": "ibc",
+          "counterparty": {
+            "chain_name": "stride",
+            "base_denom": "stusaga",
+            "channel_id": "channel-5"
+          },
+          "chain": {
+            "channel_id": "channel-326",
+            "path": "transfer/channel-326/stusaga"
+          }
+        }
+      ],
+      "logo_URIs": {
+        "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/stride/images/stsaga.png",
+        "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/stride/images/stsaga.svg"
+      },
+      "images": [
+        {
+          "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/stride/images/stsaga.png",
+          "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/stride/images/stsaga.svg"
+        }
+      ]
+    },
+    {
+      "denom_units": [
+        {
+          "denom": "ibc/C04DFC9BCD893E57F2BEFE40F63EFD18D2768514DBD5F63ABD2FF7F48FC01D36",
+          "exponent": 0,
+          "aliases": [
+            "stinj"
+          ]
+        },
+        {
+          "denom": "stINJ",
+          "exponent": 18
+        }
+      ],
+      "type_asset": "ics20",
+      "base": "ibc/C04DFC9BCD893E57F2BEFE40F63EFD18D2768514DBD5F63ABD2FF7F48FC01D36",
+      "name": "Stride Staked INJ",
+      "display": "stINJ",
+      "symbol": "stINJ",
+      "traces": [
+        {
+          "type": "liquid-stake",
+          "counterparty": {
+            "chain_name": "injective",
+            "base_denom": "inj"
+          },
+          "provider": "Stride"
+        },
+        {
+          "type": "ibc",
+          "counterparty": {
+            "chain_name": "stride",
+            "base_denom": "stinj",
+            "channel_id": "channel-5"
+          },
+          "chain": {
+            "channel_id": "channel-326",
+            "path": "transfer/channel-326/stinj"
+          }
+        }
+      ],
+      "logo_URIs": {
+        "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/stride/images/stinj.png",
+        "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/stride/images/stinj.svg"
+      },
+      "images": [
+        {
+          "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/stride/images/stinj.png",
+          "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/stride/images/stinj.svg"
+        }
+      ]
+    },
+    {
       "description": "GLTO-ERC20 on injective",
       "denom_units": [
         {
@@ -13992,131 +14117,54 @@
         }
       ],
       "keywords": [
-        "osmosis_unlisted"
+        "osmosis_unlisted",
+        "osmosis-unlisted"
       ]
     },
     {
+      "description": "Astroport is a neutral marketplace where anyone, from anywhere in the galaxy, can dock to trade their wares.",
       "denom_units": [
         {
-          "denom": "ibc/0B3C3D06228578334B66B57FBFBA4033216CEB8119B27ACDEE18D92DA5B28D43",
+          "denom": "ibc/C25A2303FE24B922DAFFDCE377AC5A42E5EF746806D32E2ED4B610DE85C203F7",
           "exponent": 0,
           "aliases": [
-            "avalanche-uusdc"
+            "cw20:terra1nsuqsk6kh58ulczatwev87ttq2z6r3pusulg9r24mfj2fvtzd4uq3exn26"
           ]
         },
         {
-          "denom": "avalanche-usdc",
+          "denom": "astro.cw20",
           "exponent": 6
         }
       ],
       "type_asset": "ics20",
-      "base": "ibc/0B3C3D06228578334B66B57FBFBA4033216CEB8119B27ACDEE18D92DA5B28D43",
-      "name": "Wormhole USDC(Avalanche)",
-      "display": "avalanche-usdc",
-      "symbol": "avalanche.USDC.wh",
+      "base": "ibc/C25A2303FE24B922DAFFDCE377AC5A42E5EF746806D32E2ED4B610DE85C203F7",
+      "name": "Astroport CW20 Token",
+      "display": "astro.cw20",
+      "symbol": "ASTRO.cw20",
       "traces": [
         {
-          "type": "ibc",
+          "type": "ibc-cw20",
           "counterparty": {
-            "chain_name": "gateway",
-            "base_denom": "factory/wormhole14ejqjyq8um4p3xfqj74yld5waqljf88fz25yxnma0cngspxe3les00fpjx/5ZLmAZpcbaP4EGyihSmpfwryzDr84h51tboV392BCjW4",
-            "channel_id": "channel-3"
+            "chain_name": "terra2",
+            "base_denom": "cw20:terra1nsuqsk6kh58ulczatwev87ttq2z6r3pusulg9r24mfj2fvtzd4uq3exn26",
+            "port": "wasm.terra1jhfjnm39y3nn9l4520mdn4k5mw23nz0674c4gsvyrcr90z9tqcvst22fce",
+            "channel_id": "channel-392"
           },
           "chain": {
-            "channel_id": "channel-2186",
-            "path": "transfer/channel-2186/factory/wormhole14ejqjyq8um4p3xfqj74yld5waqljf88fz25yxnma0cngspxe3les00fpjx/5ZLmAZpcbaP4EGyihSmpfwryzDr84h51tboV392BCjW4"
+            "port": "transfer",
+            "channel_id": "channel-21671",
+            "path": "transfer/channel-21671/cw20:terra1nsuqsk6kh58ulczatwev87ttq2z6r3pusulg9r24mfj2fvtzd4uq3exn26"
           }
         }
       ],
-      "images": [
-        {
-          "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/osmosis/images/usdc.hole.png",
-          "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/osmosis/images/usdc.hole.svg"
-        }
-      ],
       "logo_URIs": {
-        "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/osmosis/images/usdc.hole.png",
-        "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/osmosis/images/usdc.hole.svg"
-      }
-    },
-    {
-      "description": "Sail DAO is a liquidity deployment and management DAO built as a collaboration between the Osmosis and Migaloo Blockchains.",
-      "extended_description": "Sail DAO is a liquidity deployment and management DAO built as a collaboration between the Osmosis and Migaloo Blockchains. Seeded by both the Osmosis Community Pool and the Migaloo Foundation, Sail DAO is open to hear offers from cosmos based projects that hope to seed liquidity for their token on the Osmosis blockchain. Along with the creation of this DAO the White Whale DEX is deployed on Osmosis, being the first DEX apart from Osmosis to deploy on the chain, it is a great step towards Osmosis becoming an ecosystem from an appchain. Migaloo incubated projects are encouraged to participate in OTC deals with Sail DAO in order to seed or enhance liquidity on WW's Osmosis DEX. However, offers are not limited to Migaloo projects and liquidity is not limitied to being deployed on WW DEX. The treasury of this DAO can be deployed however it wishes at the discretion of the Sail DAO voters. The Osmosis CP has been given veto authorization over any props introduced in this DAO and has also been given clawback rights if this venture ever gets off track.",
-      "denom_units": [
-        {
-          "denom": "factory/osmo1rckme96ptawr4zwexxj5g5gej9s2dmud8r2t9j0k0prn5mch5g4snzzwjv/sail",
-          "exponent": 0
-        },
-        {
-          "denom": "sail",
-          "exponent": 6
-        }
-      ],
-      "base": "factory/osmo1rckme96ptawr4zwexxj5g5gej9s2dmud8r2t9j0k0prn5mch5g4snzzwjv/sail",
-      "name": "Sail",
-      "display": "sail",
-      "symbol": "SAIL",
-      "logo_URIs": {
-        "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/osmosis/images/sail.png"
+        "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/terra2/images/astro-cw20.svg"
       },
       "images": [
         {
-          "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/osmosis/images/sail.png"
+          "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/terra2/images/astro-cw20.svg"
         }
-      ],
-      "socials": {
-        "website": "https://daodao.zone/dao/osmo106tvcj58rvdn9k36m9m3xcmcwk2c3fgft3ldcst9lgy05gcmjanqexru3h/home",
-        "twitter": "https://twitter.com/Sail_DAO_"
-      }
-    },
-    {
-      "description": "Nomic's native token.",
-      "denom_units": [
-        {
-          "denom": "ibc/F49DFB3BC8105C57EE7F17EC2402438825B31212CFDD81681EB87911E934F32C",
-          "exponent": 0,
-          "aliases": [
-            "unom"
-          ]
-        },
-        {
-          "denom": "nom",
-          "exponent": 6
-        }
-      ],
-      "type_asset": "ics20",
-      "base": "ibc/F49DFB3BC8105C57EE7F17EC2402438825B31212CFDD81681EB87911E934F32C",
-      "name": "Nomic",
-      "display": "nom",
-      "symbol": "nomic.NOM",
-      "traces": [
-        {
-          "type": "ibc",
-          "counterparty": {
-            "chain_name": "nomic",
-            "base_denom": "unom",
-            "channel_id": "channel-1"
-          },
-          "chain": {
-            "channel_id": "channel-6897",
-            "path": "transfer/channel-6897/unom"
-          }
-        }
-      ],
-      "images": [
-        {
-          "image_sync": {
-            "chain_name": "nomic",
-            "base_denom": "unom"
-          },
-          "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/nomic/images/nom.png",
-          "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/nomic/images/nom.svg"
-        }
-      ],
-      "logo_URIs": {
-        "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/nomic/images/nom.png",
-        "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/nomic/images/nom.svg"
-      }
+      ]
     },
     {
       "description": "A clan of 11y bad kids crafting chaos on the Cosmos eco. One bad memecoin to rule them all  $BADKID. Airdropped to Badkids NFT holders and $STARS stakers. It's so bad, your wallet's throwing a tantrum for it.",
@@ -14146,58 +14194,645 @@
       ]
     },
     {
-      "description": "The governance and utility token of Yieldmos, the Interchain Automation Protocol",
+      "description": "Solana USD Coin (Wormhole), Solana USDC, factory/wormhole14ejqjyq8um4p3xfqj74yld5waqljf88fz25yxnma0cngspxe3les00fpjx/HJk1XMDRNUbRrpKkNZYui7SwWDMjXZAsySzqgyNcQoU3",
       "denom_units": [
         {
-          "denom": "factory/osmo1vdvnznwg597qngrq9mnfcfk0am9jdc9y446jewhcqdreqz4r75xq5j5zvy/ymos",
-          "exponent": 0
+          "denom": "ibc/F08DE332018E8070CC4C68FE06E04E254F527556A614F5F8F9A68AF38D367E45",
+          "exponent": 0,
+          "aliases": [
+            "factory/wormhole14ejqjyq8um4p3xfqj74yld5waqljf88fz25yxnma0cngspxe3les00fpjx/HJk1XMDRNUbRrpKkNZYui7SwWDMjXZAsySzqgyNcQoU3"
+          ]
         },
         {
-          "denom": "ymos",
-          "exponent": 6
+          "denom": "wormhole/HJk1XMDRNUbRrpKkNZYui7SwWDMjXZAsySzqgyNcQoU3/6",
+          "exponent": 6,
+          "aliases": []
         }
       ],
-      "type_asset": "sdk.coin",
-      "address": "osmo1vdvnznwg597qngrq9mnfcfk0am9jdc9y446jewhcqdreqz4r75xq5j5zvy",
-      "base": "factory/osmo1vdvnznwg597qngrq9mnfcfk0am9jdc9y446jewhcqdreqz4r75xq5j5zvy/ymos",
-      "name": "Yieldmos Coin",
-      "display": "ymos",
-      "symbol": "YMOS",
+      "type_asset": "ics20",
+      "base": "ibc/F08DE332018E8070CC4C68FE06E04E254F527556A614F5F8F9A68AF38D367E45",
+      "name": "Solana USD Coin (Wormhole)",
+      "display": "wormhole/HJk1XMDRNUbRrpKkNZYui7SwWDMjXZAsySzqgyNcQoU3/6",
+      "symbol": "solana.USDC.wh",
+      "traces": [
+        {
+          "type": "synthetic",
+          "counterparty": {
+            "chain_name": "forex",
+            "base_denom": "USD"
+          },
+          "provider": "Circle"
+        },
+        {
+          "type": "additional-mintage",
+          "counterparty": {
+            "chain_name": "ethereum",
+            "base_denom": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48"
+          },
+          "provider": "Circle"
+        },
+        {
+          "type": "bridge",
+          "counterparty": {
+            "chain_name": "solana",
+            "base_denom": "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v"
+          },
+          "provider": "Wormhole"
+        },
+        {
+          "type": "ibc",
+          "counterparty": {
+            "chain_name": "gateway",
+            "base_denom": "factory/wormhole14ejqjyq8um4p3xfqj74yld5waqljf88fz25yxnma0cngspxe3les00fpjx/HJk1XMDRNUbRrpKkNZYui7SwWDMjXZAsySzqgyNcQoU3",
+            "channel_id": "channel-3"
+          },
+          "chain": {
+            "channel_id": "channel-2186",
+            "path": "transfer/channel-2186/factory/wormhole14ejqjyq8um4p3xfqj74yld5waqljf88fz25yxnma0cngspxe3les00fpjx/HJk1XMDRNUbRrpKkNZYui7SwWDMjXZAsySzqgyNcQoU3"
+          }
+        }
+      ],
       "logo_URIs": {
-        "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/osmosis/images/ymos.png"
+        "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/osmosis/images/solana.USDC.wh.svg",
+        "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/osmosis/images/solana.USDC.wh.png"
       },
       "images": [
         {
-          "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/osmosis/images/ymos.png"
+          "image_sync": {
+            "chain_name": "solana",
+            "base_denom": "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v"
+          },
+          "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/_non-cosmos/ethereum/images/usdc.svg"
+        },
+        {
+          "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/osmosis/images/solana.USDC.wh.png",
+          "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/osmosis/images/solana.USDC.wh.svg"
         }
       ]
     },
     {
-      "description": "The memecoin built for the Celestia community",
+      "description": "The native staking and governance token of Humans.ai.",
       "denom_units": [
         {
-          "denom": "factory/osmo1nr8zfakf6jauye3uqa9lrmr5xumee5n42lv92z/toro",
+          "denom": "ibc/35CECC330D11DD00FACB555D07687631E0BC7D226260CC5F015F6D7980819533",
+          "exponent": 0,
+          "aliases": [
+            "aheart"
+          ]
+        },
+        {
+          "denom": "heart",
+          "exponent": 18
+        }
+      ],
+      "type_asset": "ics20",
+      "base": "ibc/35CECC330D11DD00FACB555D07687631E0BC7D226260CC5F015F6D7980819533",
+      "name": "Humans.ai",
+      "display": "heart",
+      "symbol": "HEART",
+      "traces": [
+        {
+          "type": "ibc",
+          "counterparty": {
+            "chain_name": "humans",
+            "base_denom": "aheart",
+            "channel_id": "channel-4"
+          },
+          "chain": {
+            "channel_id": "channel-20082",
+            "path": "transfer/channel-20082/aheart"
+          }
+        }
+      ],
+      "logo_URIs": {
+        "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/humans/images/heart-dark-mode.png"
+      },
+      "images": [
+        {
+          "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/humans/images/heart-dark-mode.png",
+          "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/humans/images/heart-dark-mode.svg",
+          "theme": {
+            "dark_mode": true
+          }
+        }
+      ]
+    },
+    {
+      "description": "The token of Teledisko DAO.",
+      "denom_units": [
+        {
+          "denom": "ibc/2BF9656CAB0384A31167DB9B0254F0FB1CB4346A229BD7E5CBDCBB911C3740F7",
+          "exponent": 0,
+          "aliases": [
+            "erc20/0x1cFc8f1FE8D5668BAFF2724547EcDbd6f013a280"
+          ]
+        },
+        {
+          "denom": "berlin",
+          "exponent": 18
+        }
+      ],
+      "type_asset": "ics20",
+      "base": "ibc/2BF9656CAB0384A31167DB9B0254F0FB1CB4346A229BD7E5CBDCBB911C3740F7",
+      "name": "Teledisko DAO",
+      "display": "berlin",
+      "symbol": "BERLIN",
+      "traces": [
+        {
+          "type": "ibc",
+          "counterparty": {
+            "chain_name": "evmos",
+            "base_denom": "erc20/0x1cFc8f1FE8D5668BAFF2724547EcDbd6f013a280",
+            "channel_id": "channel-0"
+          },
+          "chain": {
+            "channel_id": "channel-204",
+            "path": "transfer/channel-204/erc20/0x1cFc8f1FE8D5668BAFF2724547EcDbd6f013a280"
+          }
+        }
+      ],
+      "logo_URIs": {
+        "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/evmos/images/berlin.png",
+        "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/evmos/images/berlin.svg"
+      },
+      "images": [
+        {
+          "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/evmos/images/berlin.png",
+          "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/evmos/images/berlin.svg"
+        }
+      ]
+    },
+    {
+      "description": "The native token of Scorum",
+      "denom_units": [
+        {
+          "denom": "ibc/178248C262DE2E141EE6287EE7AB0854F05F25B0A3F40C4B912FA1C7E51F466E",
+          "exponent": 0,
+          "aliases": [
+            "nscr"
+          ]
+        },
+        {
+          "denom": "scr",
+          "exponent": 9
+        }
+      ],
+      "type_asset": "ics20",
+      "base": "ibc/178248C262DE2E141EE6287EE7AB0854F05F25B0A3F40C4B912FA1C7E51F466E",
+      "name": "Scorum",
+      "display": "scr",
+      "symbol": "SCR",
+      "traces": [
+        {
+          "type": "ibc",
+          "counterparty": {
+            "chain_name": "scorum",
+            "base_denom": "nscr",
+            "channel_id": "channel-1"
+          },
+          "chain": {
+            "channel_id": "channel-20100",
+            "path": "transfer/channel-20100/nscr"
+          }
+        }
+      ],
+      "logo_URIs": {
+        "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/scorum/images/scr.png",
+        "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/scorum/images/scr.svg"
+      },
+      "images": [
+        {
+          "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/scorum/images/scr.png",
+          "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/scorum/images/scr.svg"
+        }
+      ]
+    },
+    {
+      "description": "The native token of Chain4Energy",
+      "denom_units": [
+        {
+          "denom": "ibc/62118FB4D5FEDD5D2B18DC93648A745CD5E5B01D420E9B7A5FED5381CB13A7E8",
+          "exponent": 0,
+          "aliases": [
+            "uc4e"
+          ]
+        },
+        {
+          "denom": "c4e",
+          "exponent": 6
+        }
+      ],
+      "type_asset": "ics20",
+      "base": "ibc/62118FB4D5FEDD5D2B18DC93648A745CD5E5B01D420E9B7A5FED5381CB13A7E8",
+      "name": "C4E",
+      "display": "c4e",
+      "symbol": "C4E",
+      "traces": [
+        {
+          "type": "ibc",
+          "counterparty": {
+            "chain_name": "chain4energy",
+            "base_denom": "uc4e",
+            "channel_id": "channel-1"
+          },
+          "chain": {
+            "channel_id": "channel-22172",
+            "path": "transfer/channel-22172/uc4e"
+          }
+        }
+      ],
+      "logo_URIs": {
+        "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/chain4energy/images/c4e.png"
+      },
+      "images": [
+        {
+          "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/chain4energy/images/c4e.png"
+        }
+      ],
+      "keywords": [
+        "osmosis-unlisted"
+      ]
+    },
+    {
+      "description": "Bitmos opens doors for BRC20 tokens to thrive alongside established players in the Cosmos Network, revolutionizing decentralized finance (DeFi) for all.",
+      "denom_units": [
+        {
+          "denom": "ibc/7D389F0ABF1E4D45BE6D7BBE36A2C50EA0559C01E076B02F8E381E685EC1F942",
+          "exponent": 0,
+          "aliases": [
+            "cw20:terra1sxe8u2hjczlekwfkcq0rs28egt38pg3wqzfx4zcrese4fnvzzupsk9gjkq"
+          ]
+        },
+        {
+          "denom": "bitmos",
+          "exponent": 6
+        }
+      ],
+      "type_asset": "ics20",
+      "base": "ibc/7D389F0ABF1E4D45BE6D7BBE36A2C50EA0559C01E076B02F8E381E685EC1F942",
+      "name": "Bitmos",
+      "display": "bitmos",
+      "symbol": "BMOS",
+      "traces": [
+        {
+          "type": "ibc-cw20",
+          "counterparty": {
+            "chain_name": "terra2",
+            "base_denom": "cw20:terra1sxe8u2hjczlekwfkcq0rs28egt38pg3wqzfx4zcrese4fnvzzupsk9gjkq",
+            "port": "wasm.terra1e0mrzy8077druuu42vs0hu7ugguade0cj65dgtauyaw4gsl4kv0qtdf2au",
+            "channel_id": "channel-26"
+          },
+          "chain": {
+            "port": "transfer",
+            "channel_id": "channel-341",
+            "path": "transfer/channel-341/cw20:terra1sxe8u2hjczlekwfkcq0rs28egt38pg3wqzfx4zcrese4fnvzzupsk9gjkq"
+          }
+        }
+      ],
+      "logo_URIs": {
+        "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/terra2/images/bitmos.png"
+      },
+      "images": [
+        {
+          "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/terra2/images/bitmos.png"
+        }
+      ]
+    },
+    {
+      "description": "The SRCX token of Source Protocol.",
+      "denom_units": [
+        {
+          "denom": "ibc/C97473CD237EBA2F94FDFA6ABA5EC0E22FA140655D73D2A2754F03A347BBA40B",
+          "exponent": 0,
+          "aliases": [
+            "nsrcx",
+            "ibc/FC5A7360EEED0713AE3E83E9D55A69AF873056A172AC495890ACE4582FF9685A"
+          ]
+        },
+        {
+          "denom": "srcx",
+          "exponent": 9
+        }
+      ],
+      "type_asset": "ics20",
+      "base": "ibc/C97473CD237EBA2F94FDFA6ABA5EC0E22FA140655D73D2A2754F03A347BBA40B",
+      "name": "Source Token",
+      "display": "srcx",
+      "symbol": "SRCX",
+      "traces": [
+        {
+          "type": "bridge",
+          "counterparty": {
+            "chain_name": "binancesmartchain",
+            "base_denom": "0x454b90716a9435e7161a9aea5cf00e0acbe565ae",
+            "contract": "0xC891aBa0b42818fb4c975Bf6461033c62BCE75ff"
+          },
+          "chain": {
+            "contract": "0xC891aBa0b42818fb4c975Bf6461033c62BCE75ff"
+          },
+          "provider": "DeltaSwap.io"
+        },
+        {
+          "type": "ibc",
+          "counterparty": {
+            "chain_name": "planq",
+            "base_denom": "erc20/0x091F9A57A3F58d758b6572E9d41675918EAC7F09",
+            "channel_id": "channel-61"
+          },
+          "chain": {
+            "channel_id": "channel-1",
+            "path": "transfer/channel-1/erc20/0x091F9A57A3F58d758b6572E9d41675918EAC7F09"
+          }
+        },
+        {
+          "type": "ibc",
+          "counterparty": {
+            "chain_name": "source",
+            "base_denom": "ibc/FC5A7360EEED0713AE3E83E9D55A69AF873056A172AC495890ACE4582FF9685A",
+            "channel_id": "channel-0"
+          },
+          "chain": {
+            "channel_id": "channel-8945",
+            "path": "transfer/channel-8945/transfer/channel-1/erc20/0x091F9A57A3F58d758b6572E9d41675918EAC7F09"
+          }
+        }
+      ],
+      "logo_URIs": {
+        "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/_non-cosmos/binancesmartchain/images/srcx.png"
+      },
+      "images": [
+        {
+          "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/_non-cosmos/binancesmartchain/images/srcx.png"
+        }
+      ]
+    },
+    {
+      "description": "The revenue token for Pylons",
+      "denom_units": [
+        {
+          "denom": "ibc/0835781EF3F3ADD053874323AB660C75B50B18B16733CAB783CA6BBD78244EDF",
+          "exponent": 0,
+          "aliases": [
+            "ubedrock"
+          ]
+        },
+        {
+          "denom": "rock",
+          "exponent": 6
+        }
+      ],
+      "type_asset": "ics20",
+      "base": "ibc/0835781EF3F3ADD053874323AB660C75B50B18B16733CAB783CA6BBD78244EDF",
+      "name": "Pylons",
+      "display": "rock",
+      "symbol": "ROCK",
+      "traces": [
+        {
+          "type": "ibc",
+          "counterparty": {
+            "chain_name": "pylons",
+            "base_denom": "ubedrock",
+            "channel_id": "channel-29"
+          },
+          "chain": {
+            "channel_id": "channel-17683",
+            "path": "transfer/channel-17683/ubedrock"
+          }
+        }
+      ],
+      "logo_URIs": {
+        "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/pylons/images/pylons.png"
+      },
+      "images": [
+        {
+          "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/pylons/images/pylons.png"
+        }
+      ]
+    },
+    {
+      "description": "BSKT tracks the top assets across the crypto ecosystem",
+      "denom_units": [
+        {
+          "denom": "ibc/CDD1E59BD5034C1B2597DD199782204EB397DB93200AA2E99C0AF3A66B2915FA",
+          "exponent": 0,
+          "aliases": [
+            "6gnCPhXtLnUD76HjQuSYPENLSZdG8RvDB1pTLM5aLSJA",
+            "wormhole14ejqjyq8um4p3xfqj74yld5waqljf88fz25yxnma0cngspxe3les00fpjx/bqqqpqsxzelp2hdfd4cgmxr6ekpatlj8yt2eghk52vst",
+            "factory/wormhole14ejqjyq8um4p3xfqj74yld5waqljf88fz25yxnma0cngspxe3les00fpjx/bqqqpqsxzelp2hdfd4cgmxr6ekpatlj8yt2eghk52vst"
+          ]
+        },
+        {
+          "denom": "wormhole/bqqqpqsxzelp2hdfd4cgmxr6ekpatlj8yt2eghk52vst/5",
+          "exponent": 5,
+          "aliases": [
+            "bskt"
+          ]
+        }
+      ],
+      "type_asset": "ics20",
+      "base": "ibc/CDD1E59BD5034C1B2597DD199782204EB397DB93200AA2E99C0AF3A66B2915FA",
+      "name": "Basket",
+      "display": "wormhole/bqqqpqsxzelp2hdfd4cgmxr6ekpatlj8yt2eghk52vst/5",
+      "symbol": "BSKT",
+      "traces": [
+        {
+          "type": "bridge",
+          "counterparty": {
+            "chain_name": "solana",
+            "base_denom": "6gnCPhXtLnUD76HjQuSYPENLSZdG8RvDB1pTLM5aLSJA"
+          },
+          "provider": "Wormhole"
+        },
+        {
+          "type": "ibc",
+          "counterparty": {
+            "chain_name": "gateway",
+            "base_denom": "factory/wormhole14ejqjyq8um4p3xfqj74yld5waqljf88fz25yxnma0cngspxe3les00fpjx/bqqqpqsxzelp2hdfd4cgmxr6ekpatlj8yt2eghk52vst",
+            "channel_id": "channel-3"
+          },
+          "chain": {
+            "channel_id": "channel-2186",
+            "path": "transfer/channel-2186/factory/wormhole14ejqjyq8um4p3xfqj74yld5waqljf88fz25yxnma0cngspxe3les00fpjx/bqqqpqsxzelp2hdfd4cgmxr6ekpatlj8yt2eghk52vst"
+          }
+        }
+      ],
+      "logo_URIs": {
+        "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/_non-cosmos/solana/images/bskt.png"
+      },
+      "images": [
+        {
+          "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/_non-cosmos/solana/images/bskt.png"
+        }
+      ]
+    },
+    {
+      "description": "The native staking and governance token of the AIOZ Network.",
+      "denom_units": [
+        {
+          "denom": "ibc/BB0AFE2AFBD6E883690DAE4B9168EAC2B306BCC9C9292DACBB4152BBB08DB25F",
+          "exponent": 0,
+          "aliases": [
+            "attoaioz"
+          ]
+        },
+        {
+          "denom": "nanoaioz",
+          "exponent": 9
+        },
+        {
+          "denom": "aioz",
+          "exponent": 18
+        }
+      ],
+      "type_asset": "ics20",
+      "base": "ibc/BB0AFE2AFBD6E883690DAE4B9168EAC2B306BCC9C9292DACBB4152BBB08DB25F",
+      "name": "AIOZ Network",
+      "display": "aioz",
+      "symbol": "AIOZ",
+      "traces": [
+        {
+          "type": "ibc",
+          "counterparty": {
+            "chain_name": "aioz",
+            "base_denom": "attoaioz",
+            "channel_id": "channel-1"
+          },
+          "chain": {
+            "channel_id": "channel-779",
+            "path": "transfer/channel-779/attoaioz"
+          }
+        }
+      ],
+      "logo_URIs": {
+        "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/aioz/images/aioz.png",
+        "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/aioz/images/aioz.svg"
+      },
+      "images": [
+        {
+          "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/aioz/images/aioz.png",
+          "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/aioz/images/aioz.svg"
+        }
+      ]
+    },
+    {
+      "description": "Stride's liquid staked DYM",
+      "denom_units": [
+        {
+          "denom": "ibc/D53E785DC9C5C2CA50CADB1EFE4DE5D0C30418BE0E9C6F2AF9F092A247E8BC22",
+          "exponent": 0,
+          "aliases": [
+            "stadym"
+          ]
+        },
+        {
+          "denom": "stDYM",
+          "exponent": 18
+        }
+      ],
+      "type_asset": "ics20",
+      "base": "ibc/D53E785DC9C5C2CA50CADB1EFE4DE5D0C30418BE0E9C6F2AF9F092A247E8BC22",
+      "name": "Stride Staked DYM",
+      "display": "stDYM",
+      "symbol": "stDYM",
+      "traces": [
+        {
+          "type": "liquid-stake",
+          "counterparty": {
+            "chain_name": "dymension",
+            "base_denom": "adym"
+          },
+          "provider": "Stride"
+        },
+        {
+          "type": "ibc",
+          "counterparty": {
+            "chain_name": "stride",
+            "base_denom": "stadym",
+            "channel_id": "channel-5"
+          },
+          "chain": {
+            "channel_id": "channel-326",
+            "path": "transfer/channel-326/stadym"
+          }
+        }
+      ],
+      "logo_URIs": {
+        "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/stride/images/stdym.png",
+        "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/stride/images/stdym.svg"
+      },
+      "images": [
+        {
+          "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/stride/images/stdym.png",
+          "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/stride/images/stdym.svg"
+        }
+      ]
+    },
+    {
+      "description": "DOKI the last Dragon",
+      "denom_units": [
+        {
+          "denom": "ibc/C12C353A83CD1005FC38943410B894DBEC5F2ABC97FC12908F0FB03B970E8E1B",
+          "exponent": 0,
+          "aliases": [
+            "udoki"
+          ]
+        },
+        {
+          "denom": "doki",
+          "exponent": 6
+        }
+      ],
+      "type_asset": "ics20",
+      "base": "ibc/C12C353A83CD1005FC38943410B894DBEC5F2ABC97FC12908F0FB03B970E8E1B",
+      "name": "DOKI",
+      "display": "doki",
+      "symbol": "DOKI",
+      "traces": [
+        {
+          "type": "ibc",
+          "counterparty": {
+            "chain_name": "odin",
+            "base_denom": "udoki",
+            "channel_id": "channel-3"
+          },
+          "chain": {
+            "channel_id": "channel-258",
+            "path": "transfer/channel-258/udoki"
+          }
+        }
+      ],
+      "logo_URIs": {
+        "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/odin/images/doki_Logo.png"
+      },
+      "images": [
+        {
+          "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/odin/images/doki_Logo.png"
+        }
+      ]
+    },
+    {
+      "description": "Sail DAO is a liquidity deployment and management DAO built as a collaboration between the Osmosis and Migaloo Blockchains.",
+      "denom_units": [
+        {
+          "denom": "factory/osmo1rckme96ptawr4zwexxj5g5gej9s2dmud8r2t9j0k0prn5mch5g4snzzwjv/sail",
           "exponent": 0
         },
         {
-          "denom": "toro",
+          "denom": "sail",
           "exponent": 6
         }
       ],
       "type_asset": "sdk.coin",
-      "address": "osmo1nr8zfakf6jauye3uqa9lrmr5xumee5n42lv92z",
-      "base": "factory/osmo1nr8zfakf6jauye3uqa9lrmr5xumee5n42lv92z/toro",
-      "name": "TORO",
-      "display": "toro",
-      "symbol": "TORO",
+      "base": "factory/osmo1rckme96ptawr4zwexxj5g5gej9s2dmud8r2t9j0k0prn5mch5g4snzzwjv/sail",
+      "name": "Sail",
+      "display": "sail",
+      "symbol": "SAIL",
       "logo_URIs": {
-        "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/osmosis/images/toro.png",
-        "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/osmosis/images/toro.svg"
+        "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/osmosis/images/sail.png"
       },
       "images": [
         {
-          "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/osmosis/images/toro.png",
-          "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/osmosis/images/toro.svg"
+          "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/osmosis/images/sail.png"
         }
       ]
     },
@@ -14245,52 +14880,210 @@
       ]
     },
     {
-      "description": "BackBone Labs Liquid Staked OSMO",
+      "description": "XRP bridged from XRPL",
       "denom_units": [
         {
-          "denom": "factory/osmo1s3l0lcqc7tu0vpj6wdjz9wqpxv8nk6eraevje4fuwkyjnwuy82qsx3lduv/boneOsmo",
-          "exponent": 0
+          "denom": "ibc/63A7CA0B6838AD8CAD6B5103998FF9B9B6A6F06FBB9638BFF51E63E0142339F3",
+          "exponent": 0,
+          "aliases": [
+            "drop",
+            "drop-core1zhs909jp9yktml6qqx9f0ptcq2xnhhj99cja03j3lfcsp2pgm86studdrz"
+          ]
         },
         {
-          "denom": "bOSMO",
+          "denom": "xrp",
           "exponent": 6
         }
       ],
-      "address": "osmo1s3l0lcqc7tu0vpj6wdjz9wqpxv8nk6eraevje4fuwkyjnwuy82qsx3lduv",
-      "base": "factory/osmo1s3l0lcqc7tu0vpj6wdjz9wqpxv8nk6eraevje4fuwkyjnwuy82qsx3lduv/boneOsmo",
-      "name": "BackBone Labs Liquid Staked OSMO",
-      "display": "bOSMO",
-      "symbol": "bOSMO",
+      "type_asset": "ics20",
+      "base": "ibc/63A7CA0B6838AD8CAD6B5103998FF9B9B6A6F06FBB9638BFF51E63E0142339F3",
+      "name": "Ripple (Coreum)",
+      "display": "xrp",
+      "symbol": "XRP.core",
+      "traces": [
+        {
+          "type": "bridge",
+          "counterparty": {
+            "chain_name": "xrpl",
+            "base_denom": "drop"
+          },
+          "provider": "Coreum"
+        },
+        {
+          "type": "ibc",
+          "counterparty": {
+            "chain_name": "coreum",
+            "base_denom": "drop-core1zhs909jp9yktml6qqx9f0ptcq2xnhhj99cja03j3lfcsp2pgm86studdrz",
+            "channel_id": "channel-2"
+          },
+          "chain": {
+            "channel_id": "channel-2188",
+            "path": "transfer/channel-2188/drop-core1zhs909jp9yktml6qqx9f0ptcq2xnhhj99cja03j3lfcsp2pgm86studdrz"
+          }
+        }
+      ],
       "logo_URIs": {
-        "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/osmosis/images/bOSMO.png"
+        "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/osmosis/images/xrp.core.png"
       },
       "images": [
         {
-          "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/osmosis/images/bOSMO.png"
+          "image_sync": {
+            "chain_name": "xrpl",
+            "base_denom": "drop"
+          },
+          "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/_non-cosmos/xrpl/images/xrp.png",
+          "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/_non-cosmos/xrpl/images/xrp.svg"
+        },
+        {
+          "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/osmosis/images/xrp.core.png"
         }
       ]
     },
     {
-      "description": "Memecoin for The International Brane Wave",
+      "description": "The Original Meme Coin of SEI Network",
       "denom_units": [
         {
-          "denom": "factory/osmo13gu58hzw3e9aqpj25h67m7snwcjuccd7v4p55w/brnz",
+          "denom": "ibc/86074B8DF625A75C25D52FA6112E3FD5446BA41FE418880C168CA99D10E22F05",
           "exponent": 0,
           "aliases": [
-            "brnz"
+            "cw20:sei1hrndqntlvtmx2kepr0zsfgr7nzjptcc72cr4ppk4yav58vvy7v3s4er8ed"
           ]
+        },
+        {
+          "denom": "SEIYAN",
+          "exponent": 6
         }
       ],
-      "base": "factory/osmo13gu58hzw3e9aqpj25h67m7snwcjuccd7v4p55w/brnz",
-      "name": "Branez",
-      "display": "factory/osmo13gu58hzw3e9aqpj25h67m7snwcjuccd7v4p55w/brnz",
-      "symbol": "BRNZ",
+      "type_asset": "ics20",
+      "base": "ibc/86074B8DF625A75C25D52FA6112E3FD5446BA41FE418880C168CA99D10E22F05",
+      "name": "SEIYAN",
+      "display": "SEIYAN",
+      "symbol": "SEIYAN",
+      "traces": [
+        {
+          "type": "ibc-cw20",
+          "counterparty": {
+            "chain_name": "sei",
+            "base_denom": "cw20:sei1hrndqntlvtmx2kepr0zsfgr7nzjptcc72cr4ppk4yav58vvy7v3s4er8ed",
+            "port": "transfer",
+            "channel_id": "channel-0"
+          },
+          "chain": {
+            "port": "transfer",
+            "channel_id": "channel-782",
+            "path": "transfer/channel-782/cw20:sei1hrndqntlvtmx2kepr0zsfgr7nzjptcc72cr4ppk4yav58vvy7v3s4er8ed"
+          }
+        }
+      ],
       "logo_URIs": {
-        "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/osmosis/images/BRNZ.svg"
+        "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/sei/images/SEIYAN.png"
       },
       "images": [
         {
-          "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/osmosis/images/BRNZ.svg"
+          "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/sei/images/SEIYAN.png"
+        }
+      ],
+      "keywords": [
+        "osmosis-unlisted"
+      ]
+    },
+    {
+      "description": "The native token of Nibiru network",
+      "denom_units": [
+        {
+          "denom": "ibc/4017C65CEA338196ECCEC3FE3FE8258F23D1DE88F1D95750CC912C7A1C1016FF",
+          "exponent": 0,
+          "aliases": [
+            "unibi"
+          ]
+        },
+        {
+          "denom": "nibi",
+          "exponent": 6
+        }
+      ],
+      "type_asset": "ics20",
+      "base": "ibc/4017C65CEA338196ECCEC3FE3FE8258F23D1DE88F1D95750CC912C7A1C1016FF",
+      "name": "Nibiru",
+      "display": "nibi",
+      "symbol": "NIBI",
+      "traces": [
+        {
+          "type": "ibc",
+          "counterparty": {
+            "chain_name": "nibiru",
+            "base_denom": "unibi",
+            "channel_id": "channel-0"
+          },
+          "chain": {
+            "channel_id": "channel-21113",
+            "path": "transfer/channel-21113/unibi"
+          }
+        }
+      ],
+      "logo_URIs": {
+        "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/nibiru/images/nibiru.png",
+        "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/nibiru/images/nibiru.svg"
+      },
+      "images": [
+        {
+          "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/nibiru/images/nibiru.png",
+          "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/nibiru/images/nibiru.svg"
+        }
+      ]
+    },
+    {
+      "description": "BEAST-ERC20 on injective",
+      "denom_units": [
+        {
+          "denom": "ibc/B84F8CC583A54DA8173711C0B66B22FDC1954FEB1CA8DBC66C89919DAFE02000",
+          "exponent": 0,
+          "aliases": [
+            "peggy0xA4426666addBE8c4985377d36683D17FB40c31Be"
+          ]
+        },
+        {
+          "denom": "beast",
+          "exponent": 6
+        }
+      ],
+      "type_asset": "ics20",
+      "base": "ibc/B84F8CC583A54DA8173711C0B66B22FDC1954FEB1CA8DBC66C89919DAFE02000",
+      "name": "Gelotto BEAST (Peggy)",
+      "display": "beast",
+      "symbol": "BEAST",
+      "traces": [
+        {
+          "type": "bridge",
+          "counterparty": {
+            "chain_name": "ethereum",
+            "base_denom": "0xA4426666addBE8c4985377d36683D17FB40c31Be"
+          },
+          "provider": "Peggy"
+        },
+        {
+          "type": "ibc",
+          "counterparty": {
+            "chain_name": "injective",
+            "base_denom": "peggy0xA4426666addBE8c4985377d36683D17FB40c31Be",
+            "channel_id": "channel-8"
+          },
+          "chain": {
+            "channel_id": "channel-122",
+            "path": "transfer/channel-122/peggy0xA4426666addBE8c4985377d36683D17FB40c31Be"
+          }
+        }
+      ],
+      "logo_URIs": {
+        "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/_non-cosmos/ethereum/images/beast.png"
+      },
+      "images": [
+        {
+          "image_sync": {
+            "chain_name": "ethereum",
+            "base_denom": "0xA4426666addBE8c4985377d36683D17FB40c31Be"
+          },
+          "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/_non-cosmos/ethereum/images/beast.png"
         }
       ]
     },
@@ -14311,7 +15104,7 @@
       ],
       "type_asset": "ics20",
       "base": "ibc/D3FAF77F5DE21C18413B164751239BA7D521A9D8EA53BFE553AADF338A721480",
-      "name": "CVN",
+      "name": "ConsciousDAO",
       "display": "cvnt",
       "symbol": "CVN",
       "traces": [
@@ -14337,11 +15130,92 @@
           "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/conscious/images/cvn.png",
           "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/conscious/images/cvn.svg"
         }
+      ],
+      "keywords": [
+        "osmosis-unlisted"
+      ]
+    },
+    {
+      "description": "The memecoin built for the Celestia community",
+      "denom_units": [
+        {
+          "denom": "factory/osmo1nr8zfakf6jauye3uqa9lrmr5xumee5n42lv92z/toro",
+          "exponent": 0
+        },
+        {
+          "denom": "toro",
+          "exponent": 6
+        }
+      ],
+      "type_asset": "sdk.coin",
+      "address": "osmo1nr8zfakf6jauye3uqa9lrmr5xumee5n42lv92z",
+      "base": "factory/osmo1nr8zfakf6jauye3uqa9lrmr5xumee5n42lv92z/toro",
+      "name": "TORO",
+      "display": "toro",
+      "symbol": "TORO",
+      "logo_URIs": {
+        "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/osmosis/images/toro.png",
+        "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/osmosis/images/toro.svg"
+      },
+      "images": [
+        {
+          "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/osmosis/images/toro.png",
+          "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/osmosis/images/toro.svg"
+        }
+      ]
+    },
+    {
+      "description": "Sayve is a revolutionary language learning app in the Web3 era that combines gamification, blockchain technology, and a Metaverse experience to motivate users to learn languages while earning rewards.",
+      "denom_units": [
+        {
+          "denom": "ibc/06EF575844982382F4D1BC3830D294557A30EDB3CD223153AFC8DFEF06349C56",
+          "exponent": 0,
+          "aliases": [
+            "cw20:terra1xp9hrhthzddnl7j5du83gqqr4wmdjm5t0guzg9jp6jwrtpukwfjsjgy4f3"
+          ]
+        },
+        {
+          "denom": "sayve",
+          "exponent": 6
+        }
+      ],
+      "type_asset": "ics20",
+      "base": "ibc/06EF575844982382F4D1BC3830D294557A30EDB3CD223153AFC8DFEF06349C56",
+      "name": "sayve",
+      "display": "sayve",
+      "symbol": "SAYVE",
+      "traces": [
+        {
+          "type": "ibc-cw20",
+          "counterparty": {
+            "chain_name": "terra2",
+            "base_denom": "cw20:terra1xp9hrhthzddnl7j5du83gqqr4wmdjm5t0guzg9jp6jwrtpukwfjsjgy4f3",
+            "port": "wasm.terra1e0mrzy8077druuu42vs0hu7ugguade0cj65dgtauyaw4gsl4kv0qtdf2au",
+            "channel_id": "channel-26"
+          },
+          "chain": {
+            "port": "transfer",
+            "channel_id": "channel-341",
+            "path": "transfer/channel-341/cw20:terra1xp9hrhthzddnl7j5du83gqqr4wmdjm5t0guzg9jp6jwrtpukwfjsjgy4f3"
+          }
+        }
+      ],
+      "logo_URIs": {
+        "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/terra2/images/sayve.png",
+        "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/terra2/images/sayve.svg"
+      },
+      "images": [
+        {
+          "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/terra2/images/sayve.png",
+          "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/terra2/images/sayve.svg"
+        }
+      ],
+      "keywords": [
+        "osmosis-unlisted"
       ]
     },
     {
       "description": "LAB - Everything is an Experiment",
-      "extended_description": "LAB - Everything is an Experiment\n\nUse 10 $LAB tokens to mint 1 Mad Scientist NFT on Backbone Labs Osmosis Launchpad. You will then be able to trade your NFTs on the marketplace. You can also choose to hold onto your $LAB tokens as unrevealed NFTs and trade it.\n\n Fair Launch: The event was marked by the absence of whitelists (WLs), no bots and no lock, ensuring an equitable opportunity for all interested parties.\n\nPreparation for the Launch: Participants were given a 52.91-hour window to deposit $OSMO into a pool on Streamswap.\n\nThe Swap Process: After the initial deposit period, $OSMO was converted into $LAB tokens over an additional hour, allowing for a smooth transition and fair distribution.",
       "denom_units": [
         {
           "denom": "factory/osmo17fel472lgzs87ekt9dvk0zqyh5gl80sqp4sk4n/LAB",
@@ -14352,6 +15226,7 @@
           "exponent": 6
         }
       ],
+      "type_asset": "sdk.coin",
       "address": "osmo17fel472lgzs87ekt9dvk0zqyh5gl80sqp4sk4n",
       "base": "factory/osmo17fel472lgzs87ekt9dvk0zqyh5gl80sqp4sk4n/LAB",
       "name": "LAB",
@@ -14367,86 +15242,92 @@
       ]
     },
     {
-      "description": "OnE mEmEcOiN tO cOnNeCt oL ImBeCiles - aNd in Da Cosmos BiNd DeM",
+      "description": "BackBone Labs Liquid Staked OSMO",
       "denom_units": [
         {
-          "denom": "factory/osmo1kqdw6pvn0xww6tyfv2sqvkkencdz0qw406x54r/IBC",
+          "denom": "factory/osmo1s3l0lcqc7tu0vpj6wdjz9wqpxv8nk6eraevje4fuwkyjnwuy82qsx3lduv/boneOsmo",
           "exponent": 0
         },
         {
-          "denom": "IBC",
+          "denom": "bOSMO",
           "exponent": 6
         }
       ],
-      "base": "factory/osmo1kqdw6pvn0xww6tyfv2sqvkkencdz0qw406x54r/IBC",
-      "name": "IBC",
-      "display": "IBC",
-      "symbol": "IBC",
+      "type_asset": "sdk.coin",
+      "address": "osmo1s3l0lcqc7tu0vpj6wdjz9wqpxv8nk6eraevje4fuwkyjnwuy82qsx3lduv",
+      "base": "factory/osmo1s3l0lcqc7tu0vpj6wdjz9wqpxv8nk6eraevje4fuwkyjnwuy82qsx3lduv/boneOsmo",
+      "name": "BackBone Labs Liquid Staked OSMO",
+      "display": "bOSMO",
+      "symbol": "bOSMO",
       "logo_URIs": {
-        "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/osmosis/images/ibc.png"
-      },
-      "coingecko_id": "",
-      "keywords": [
-        "memecoin"
-      ],
-      "socials": {
-        "webiste": "https://www.ibcmeme.wtf",
-        "twitter": "https://twitter.com/IBCmemecoin"
+        "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/osmosis/images/bOSMO.png"
       },
       "images": [
         {
-          "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/osmosis/images/ibc.png"
+          "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/osmosis/images/bOSMO.png"
         }
+      ],
+      "keywords": [
+        "osmosis-unlisted"
       ]
     },
     {
-      "description": "Astroport is a neutral marketplace where anyone, from anywhere in the galaxy, can dock to trade their wares.",
+      "description": "PUNDIX token is the native token that functions within the Pundi X ecosystem, including PundiX Chain and XPOS.",
       "denom_units": [
         {
-          "denom": "ibc/B8C608CEE08C4F30A15A7955306F2EDAF4A02BB191CABC4185C1A57FD978DA1B",
+          "denom": "ibc/2EB516F83C9FF44AB6826F269CA98A5622608C6C955E12112E58F23A324FEE07",
           "exponent": 0,
           "aliases": [
-            "uastro"
+            "ibc/55367B7B6572631B78A93C66EF9FDFCE87CDE372CC4ED7848DA78C1EB1DCDD78"
           ]
         },
         {
-          "denom": "astro",
-          "exponent": 6
+          "denom": "PUNDIX",
+          "exponent": 18
         }
       ],
       "type_asset": "ics20",
-      "base": "ibc/B8C608CEE08C4F30A15A7955306F2EDAF4A02BB191CABC4185C1A57FD978DA1B",
-      "name": "Astroport token",
-      "display": "astro",
-      "symbol": "ASTRO",
+      "base": "ibc/2EB516F83C9FF44AB6826F269CA98A5622608C6C955E12112E58F23A324FEE07",
+      "name": "Pundi X Token",
+      "display": "PUNDIX",
+      "symbol": "PUNDIX",
       "traces": [
         {
           "type": "ibc",
           "counterparty": {
-            "chain_name": "neutron",
-            "base_denom": "factory/neutron1ffus553eet978k024lmssw0czsxwr97mggyv85lpcsdkft8v9ufsz3sa07/astro",
-            "channel_id": "channel-10"
+            "chain_name": "fxcore",
+            "base_denom": "eth0x0FD10b9899882a6f2fcb5c371E17e70FdEe00C38",
+            "channel_id": "channel-0"
           },
           "chain": {
-            "channel_id": "channel-874",
-            "path": "transfer/channel-874/factory/neutron1ffus553eet978k024lmssw0czsxwr97mggyv85lpcsdkft8v9ufsz3sa07/astro"
+            "channel_id": "channel-0",
+            "path": "transfer/channel-0/eth0x0FD10b9899882a6f2fcb5c371E17e70FdEe00C38"
+          }
+        },
+        {
+          "type": "ibc",
+          "counterparty": {
+            "chain_name": "pundix",
+            "base_denom": "ibc/55367B7B6572631B78A93C66EF9FDFCE87CDE372CC4ED7848DA78C1EB1DCDD78",
+            "channel_id": "channel-1"
+          },
+          "chain": {
+            "channel_id": "channel-12618",
+            "path": "transfer/channel-12618/transfer/channel-0/eth0x0FD10b9899882a6f2fcb5c371E17e70FdEe00C38"
           }
         }
       ],
+      "logo_URIs": {
+        "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/_non-cosmos/ethereum/images/pundix.png"
+      },
       "images": [
         {
-          "image_sync": {
-            "chain_name": "neutron",
-            "base_denom": "factory/neutron1ffus553eet978k024lmssw0czsxwr97mggyv85lpcsdkft8v9ufsz3sa07/astro"
-          },
-          "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/neutron/images/astro.png",
-          "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/neutron/images/astro.svg"
+          "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/_non-cosmos/ethereum/images/pundix.png"
         }
       ],
-      "logo_URIs": {
-        "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/neutron/images/astro.png",
-        "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/neutron/images/astro.svg"
-      }
+      "keywords": [
+        "osmosis-unlisted"
+      ]
     },
     {
       "description": "The native fee, governance and staking token of the Tinkernet Parachain.",
@@ -14513,52 +15394,530 @@
       ]
     },
     {
+      "description": "W is the native token powering the Wormhole interoperability platform.",
       "denom_units": [
         {
-          "denom": "ibc/04FAC73DFF7F1DD59395948F2F043B0BBF978AD4533EE37E811340F501A08FFB",
+          "denom": "ibc/AC6EE43E608B5A7EEE460C960480BC1C3708010E32B2071C429DA259836E10C3",
           "exponent": 0,
           "aliases": [
-            "factory/migaloo1d0uma9qzcts4fzt7ml39xp44aut5k6qyjfzz4asalnecppppr3rsl52vvv/rstk"
+            "factory/wormhole14ejqjyq8um4p3xfqj74yld5waqljf88fz25yxnma0cngspxe3les00fpjx/2Wb6ueMFc9WLc2eyYVha6qnwHKbwzUXdooXsg6XXVvos"
           ]
         },
         {
-          "denom": "rstk",
+          "denom": "w",
           "exponent": 6
         }
       ],
       "type_asset": "ics20",
-      "base": "ibc/04FAC73DFF7F1DD59395948F2F043B0BBF978AD4533EE37E811340F501A08FFB",
-      "name": "Restake DAO Token",
-      "display": "rstk",
-      "symbol": "RSTK",
+      "base": "ibc/AC6EE43E608B5A7EEE460C960480BC1C3708010E32B2071C429DA259836E10C3",
+      "name": "Wormhole Token",
+      "display": "w",
+      "symbol": "W",
+      "traces": [
+        {
+          "type": "bridge",
+          "counterparty": {
+            "chain_name": "solana",
+            "base_denom": "85VBFQZC9TZkfaptBWjvUw7YbZjy52A6mjtPGjstQAmQ"
+          },
+          "provider": "Wormhole"
+        },
+        {
+          "type": "ibc",
+          "counterparty": {
+            "chain_name": "gateway",
+            "base_denom": "factory/wormhole14ejqjyq8um4p3xfqj74yld5waqljf88fz25yxnma0cngspxe3les00fpjx/2Wb6ueMFc9WLc2eyYVha6qnwHKbwzUXdooXsg6XXVvos",
+            "channel_id": "channel-3"
+          },
+          "chain": {
+            "channel_id": "channel-2186",
+            "path": "transfer/channel-2186/factory/wormhole14ejqjyq8um4p3xfqj74yld5waqljf88fz25yxnma0cngspxe3les00fpjx/2Wb6ueMFc9WLc2eyYVha6qnwHKbwzUXdooXsg6XXVvos"
+          }
+        }
+      ],
+      "logo_URIs": {
+        "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/_non-cosmos/solana/images/w.png"
+      },
+      "images": [
+        {
+          "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/_non-cosmos/solana/images/w.png"
+        }
+      ]
+    },
+    {
+      "description": "The native token of dHealth",
+      "denom_units": [
+        {
+          "denom": "ibc/320F8D6EC17E14436D19C6D844BB9A5AE9B9A209F6D18364A2191FF08E8732A9",
+          "exponent": 0,
+          "aliases": [
+            "udhp"
+          ]
+        },
+        {
+          "denom": "dhp",
+          "exponent": 6
+        }
+      ],
+      "type_asset": "ics20",
+      "base": "ibc/320F8D6EC17E14436D19C6D844BB9A5AE9B9A209F6D18364A2191FF08E8732A9",
+      "name": "dHealth",
+      "display": "dhp",
+      "symbol": "DHP",
       "traces": [
         {
           "type": "ibc",
           "counterparty": {
-            "chain_name": "migaloo",
-            "base_denom": "factory/migaloo1d0uma9qzcts4fzt7ml39xp44aut5k6qyjfzz4asalnecppppr3rsl52vvv/rstk",
-            "channel_id": "channel-5"
+            "chain_name": "dhealth",
+            "base_denom": "udhp",
+            "channel_id": "channel-1"
           },
           "chain": {
-            "channel_id": "channel-642",
-            "path": "transfer/channel-642/factory/migaloo1d0uma9qzcts4fzt7ml39xp44aut5k6qyjfzz4asalnecppppr3rsl52vvv/rstk"
+            "channel_id": "channel-38776",
+            "path": "transfer/channel-38776/udhp"
           }
         }
       ],
+      "logo_URIs": {
+        "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/dhealth/images/dhp.png",
+        "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/dhealth/images/dhp.svg"
+      },
       "images": [
         {
-          "image_sync": {
-            "chain_name": "migaloo",
-            "base_denom": "factory/migaloo1d0uma9qzcts4fzt7ml39xp44aut5k6qyjfzz4asalnecppppr3rsl52vvv/rstk"
+          "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/dhealth/images/dhp.png",
+          "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/dhealth/images/dhp.svg"
+        }
+      ],
+      "keywords": [
+        "osmosis-unlisted"
+      ]
+    },
+    {
+      "description": "The native token of Furya",
+      "denom_units": [
+        {
+          "denom": "ibc/42D0FBF9DDC72D7359D309A93A6DF9F6FDEE3987EA1C5B3CDE95C06FCE183F12",
+          "exponent": 0,
+          "aliases": [
+            "ufury"
+          ]
+        },
+        {
+          "denom": "fury",
+          "exponent": 6
+        }
+      ],
+      "type_asset": "ics20",
+      "base": "ibc/42D0FBF9DDC72D7359D309A93A6DF9F6FDEE3987EA1C5B3CDE95C06FCE183F12",
+      "name": "furya",
+      "display": "fury",
+      "symbol": "FURY",
+      "traces": [
+        {
+          "type": "ibc",
+          "counterparty": {
+            "chain_name": "furya",
+            "base_denom": "ufury",
+            "channel_id": "channel-3"
           },
-          "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/migaloo/images/rstk.png",
-          "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/migaloo/images/rstk.svg"
+          "chain": {
+            "channel_id": "channel-8690",
+            "path": "transfer/channel-8690/ufury"
+          }
         }
       ],
       "logo_URIs": {
-        "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/migaloo/images/rstk.png",
-        "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/migaloo/images/rstk.svg"
-      }
+        "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/furya/images/ufury.png",
+        "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/furya/images/ufury.svg"
+      },
+      "images": [
+        {
+          "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/furya/images/ufury.png",
+          "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/furya/images/ufury.svg",
+          "theme": {
+            "primary_color_hex": "#eaf143"
+          }
+        }
+      ],
+      "keywords": [
+        "gaming",
+        "staking",
+        "osmosis-unlisted"
+      ]
+    },
+    {
+      "description": "The native staking and governance token of Saga.",
+      "denom_units": [
+        {
+          "denom": "ibc/094FB70C3006906F67F5D674073D2DAFAFB41537E7033098F5C752F211E7B6C2",
+          "exponent": 0,
+          "aliases": [
+            "usaga"
+          ]
+        },
+        {
+          "denom": "saga",
+          "exponent": 6
+        }
+      ],
+      "type_asset": "ics20",
+      "base": "ibc/094FB70C3006906F67F5D674073D2DAFAFB41537E7033098F5C752F211E7B6C2",
+      "name": "Saga",
+      "display": "saga",
+      "symbol": "SAGA",
+      "traces": [
+        {
+          "type": "ibc",
+          "counterparty": {
+            "chain_name": "saga",
+            "base_denom": "usaga",
+            "channel_id": "channel-1"
+          },
+          "chain": {
+            "channel_id": "channel-38946",
+            "path": "transfer/channel-38946/usaga"
+          }
+        }
+      ],
+      "logo_URIs": {
+        "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/saga/images/saga_white.png",
+        "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/saga/images/saga_white.svg"
+      },
+      "images": [
+        {
+          "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/saga/images/saga.png",
+          "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/saga/images/saga.svg",
+          "theme": {
+            "primary_color_hex": "#000000",
+            "dark_mode": false
+          }
+        },
+        {
+          "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/saga/images/saga_white.png",
+          "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/saga/images/saga_white.svg",
+          "theme": {
+            "primary_color_hex": "#FFFFFF",
+            "dark_mode": true
+          }
+        }
+      ]
+    },
+    {
+      "description": "$ATOM to $1,000 LFG!!",
+      "denom_units": [
+        {
+          "denom": "ibc/0E77E090EC04C476DE2BC0A7056580AC47660DAEB7B0D4701C085E3A046AC7B7",
+          "exponent": 0,
+          "aliases": [
+            "uatom1klfg",
+            "factory/neutron13lkh47msw28yynspc5rnmty3yktk43wc3dsv0l/ATOM1KLFG"
+          ]
+        },
+        {
+          "denom": "ATOM1KLFG",
+          "exponent": 6
+        }
+      ],
+      "type_asset": "ics20",
+      "base": "ibc/0E77E090EC04C476DE2BC0A7056580AC47660DAEB7B0D4701C085E3A046AC7B7",
+      "name": "ATOM1KLFG",
+      "display": "ATOM1KLFG",
+      "symbol": "ATOM1KLFG",
+      "traces": [
+        {
+          "type": "ibc",
+          "counterparty": {
+            "chain_name": "neutron",
+            "base_denom": "factory/neutron13lkh47msw28yynspc5rnmty3yktk43wc3dsv0l/ATOM1KLFG",
+            "channel_id": "channel-10"
+          },
+          "chain": {
+            "channel_id": "channel-874",
+            "path": "transfer/channel-874/factory/neutron13lkh47msw28yynspc5rnmty3yktk43wc3dsv0l/ATOM1KLFG"
+          }
+        }
+      ],
+      "logo_URIs": {
+        "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/neutron/images/ATOM1KLFGc.png"
+      },
+      "images": [
+        {
+          "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/neutron/images/ATOM1KLFGc.png"
+        }
+      ]
+    },
+    {
+      "description": "The native EVM and Wasm, governance and staking token of the Shido Chain",
+      "denom_units": [
+        {
+          "denom": "ibc/BBE825F7D1673E1EBF05AB02000E23E6077967B79547A3733B60AE4ED62C4D32",
+          "exponent": 0,
+          "aliases": [
+            "shido"
+          ]
+        },
+        {
+          "denom": "SHIDO",
+          "exponent": 18
+        }
+      ],
+      "type_asset": "ics20",
+      "base": "ibc/BBE825F7D1673E1EBF05AB02000E23E6077967B79547A3733B60AE4ED62C4D32",
+      "name": "Shido",
+      "display": "SHIDO",
+      "symbol": "SHIDO",
+      "traces": [
+        {
+          "type": "ibc",
+          "counterparty": {
+            "chain_name": "shido",
+            "base_denom": "shido",
+            "channel_id": "channel-0"
+          },
+          "chain": {
+            "channel_id": "channel-38921",
+            "path": "transfer/channel-38921/shido"
+          }
+        }
+      ],
+      "logo_URIs": {
+        "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/shido/images/shido.png",
+        "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/shido/images/shido.svg"
+      },
+      "images": [
+        {
+          "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/shido/images/shido.png",
+          "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/shido/images/shido.svg"
+        }
+      ],
+      "keywords": [
+        "osmosis-unlisted"
+      ]
+    },
+    {
+      "description": "Decentralized Machine Learning",
+      "denom_units": [
+        {
+          "denom": "ibc/EFC1776BEFB7842F2DC7BABD9A3050E188145C99007ECC5F3526FED45A68D5F5",
+          "exponent": 0,
+          "aliases": [
+            "ucif"
+          ]
+        },
+        {
+          "denom": "cif",
+          "exponent": 6
+        }
+      ],
+      "type_asset": "ics20",
+      "base": "ibc/EFC1776BEFB7842F2DC7BABD9A3050E188145C99007ECC5F3526FED45A68D5F5",
+      "name": "Cifer",
+      "display": "cif",
+      "symbol": "CIF",
+      "traces": [
+        {
+          "type": "ibc",
+          "counterparty": {
+            "chain_name": "cifer",
+            "base_denom": "ucif",
+            "channel_id": "channel-1"
+          },
+          "chain": {
+            "channel_id": "channel-39205",
+            "path": "transfer/channel-39205/ucif"
+          }
+        }
+      ],
+      "logo_URIs": {
+        "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/cifer/images/cif.png",
+        "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/cifer/images/cif.svg"
+      },
+      "images": [
+        {
+          "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/cifer/images/cif.png",
+          "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/cifer/images/cif.svg"
+        }
+      ],
+      "keywords": [
+        "osmosis-unlisted"
+      ]
+    },
+    {
+      "description": "Hava Coin is the lifeblood of the Cosmos & Injective networks, rewarding builders and welcoming supporters. https://havacoin.xyz/",
+      "denom_units": [
+        {
+          "denom": "ibc/884EBC228DFCE8F1304D917A712AA9611427A6C1ECC3179B2E91D7468FB091A2",
+          "exponent": 0,
+          "aliases": [
+            "factory/inj1h0ypsdtjfcjynqu3m75z2zwwz5mmrj8rtk2g52/uhava"
+          ]
+        },
+        {
+          "denom": "hava",
+          "exponent": 6
+        }
+      ],
+      "type_asset": "ics20",
+      "base": "ibc/884EBC228DFCE8F1304D917A712AA9611427A6C1ECC3179B2E91D7468FB091A2",
+      "name": "Hava Coin",
+      "display": "hava",
+      "symbol": "HAVA",
+      "traces": [
+        {
+          "type": "ibc",
+          "counterparty": {
+            "chain_name": "injective",
+            "base_denom": "factory/inj1h0ypsdtjfcjynqu3m75z2zwwz5mmrj8rtk2g52/uhava",
+            "channel_id": "channel-8"
+          },
+          "chain": {
+            "channel_id": "channel-122",
+            "path": "transfer/channel-122/factory/inj1h0ypsdtjfcjynqu3m75z2zwwz5mmrj8rtk2g52/uhava"
+          }
+        }
+      ],
+      "logo_URIs": {
+        "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/injective/images/hava.png"
+      },
+      "images": [
+        {
+          "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/injective/images/hava.png"
+        }
+      ]
+    },
+    {
+      "description": "OnE mEmEcOiN tO cOnNeCt oL ImBeCiles - aNd in Da Cosmos BiNd DeM",
+      "denom_units": [
+        {
+          "denom": "factory/osmo1kqdw6pvn0xww6tyfv2sqvkkencdz0qw406x54r/IBC",
+          "exponent": 0
+        },
+        {
+          "denom": "IBC",
+          "exponent": 6
+        }
+      ],
+      "type_asset": "sdk.coin",
+      "base": "factory/osmo1kqdw6pvn0xww6tyfv2sqvkkencdz0qw406x54r/IBC",
+      "name": "IBC",
+      "display": "IBC",
+      "symbol": "IBC",
+      "logo_URIs": {
+        "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/osmosis/images/ibc.png"
+      },
+      "images": [
+        {
+          "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/osmosis/images/ibc.png"
+        }
+      ],
+      "keywords": [
+        "memecoin",
+        "osmosis-unlisted"
+      ]
+    },
+    {
+      "description": "Astroport is a neutral marketplace where anyone, from anywhere in the galaxy, can dock to trade their wares.",
+      "denom_units": [
+        {
+          "denom": "ibc/B8C608CEE08C4F30A15A7955306F2EDAF4A02BB191CABC4185C1A57FD978DA1B",
+          "exponent": 0,
+          "aliases": [
+            "uastro"
+          ]
+        },
+        {
+          "denom": "astro",
+          "exponent": 6
+        }
+      ],
+      "type_asset": "ics20",
+      "base": "ibc/B8C608CEE08C4F30A15A7955306F2EDAF4A02BB191CABC4185C1A57FD978DA1B",
+      "name": "Astroport token",
+      "display": "astro",
+      "symbol": "ASTRO",
+      "traces": [
+        {
+          "type": "ibc",
+          "counterparty": {
+            "chain_name": "neutron",
+            "base_denom": "factory/neutron1ffus553eet978k024lmssw0czsxwr97mggyv85lpcsdkft8v9ufsz3sa07/astro",
+            "channel_id": "channel-10"
+          },
+          "chain": {
+            "channel_id": "channel-874",
+            "path": "transfer/channel-874/factory/neutron1ffus553eet978k024lmssw0czsxwr97mggyv85lpcsdkft8v9ufsz3sa07/astro"
+          }
+        }
+      ],
+      "logo_URIs": {
+        "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/neutron/images/astro.png",
+        "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/neutron/images/astro.svg"
+      },
+      "images": [
+        {
+          "image_sync": {
+            "chain_name": "neutron",
+            "base_denom": "factory/neutron1ffus553eet978k024lmssw0czsxwr97mggyv85lpcsdkft8v9ufsz3sa07/astro"
+          },
+          "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/neutron/images/astro.png",
+          "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/neutron/images/astro.svg"
+        }
+      ]
+    },
+    {
+      "description": "Astroport is a neutral marketplace where anyone, from anywhere in the galaxy, can dock to trade their wares.",
+      "denom_units": [
+        {
+          "denom": "ibc/2ED09B03AA396BC2F35B741F4CA4A82D33A24A1007BFC1973299842DD626F564",
+          "exponent": 0,
+          "aliases": [
+            "uxastro",
+            "factory/neutron1zlf3hutsa4qnmue53lz2tfxrutp8y2e3rj4nkghg3rupgl4mqy8s5jgxsn/xASTRO"
+          ]
+        },
+        {
+          "denom": "xASTRO",
+          "exponent": 6
+        }
+      ],
+      "type_asset": "ics20",
+      "base": "ibc/2ED09B03AA396BC2F35B741F4CA4A82D33A24A1007BFC1973299842DD626F564",
+      "name": "Staked Astroport Token",
+      "display": "xASTRO",
+      "symbol": "xASTRO",
+      "traces": [
+        {
+          "type": "liquid-stake",
+          "counterparty": {
+            "chain_name": "neutron",
+            "base_denom": "factory/neutron1ffus553eet978k024lmssw0czsxwr97mggyv85lpcsdkft8v9ufsz3sa07/astro"
+          },
+          "provider": "Astroport"
+        },
+        {
+          "type": "ibc",
+          "counterparty": {
+            "chain_name": "neutron",
+            "base_denom": "factory/neutron1zlf3hutsa4qnmue53lz2tfxrutp8y2e3rj4nkghg3rupgl4mqy8s5jgxsn/xASTRO",
+            "channel_id": "channel-10"
+          },
+          "chain": {
+            "channel_id": "channel-874",
+            "path": "transfer/channel-874/factory/neutron1zlf3hutsa4qnmue53lz2tfxrutp8y2e3rj4nkghg3rupgl4mqy8s5jgxsn/xASTRO"
+          }
+        }
+      ],
+      "logo_URIs": {
+        "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/neutron/images/xAstro.svg"
+      },
+      "images": [
+        {
+          "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/neutron/images/xAstro.svg"
+        }
+      ],
+      "keywords": [
+        "osmosis-unlisted"
+      ]
     },
     {
       "description": "Gravity Bridge Paxos Gold",
@@ -14611,7 +15970,6 @@
         }
       ],
       "logo_URIs": {
-        "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/osmosis/images/paxg.grv.png",
         "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/osmosis/images/paxg.grv.svg"
       },
       "images": [
@@ -14626,6 +15984,242 @@
           },
           "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/_non-cosmos/ethereum/images/paxg.png",
           "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/_non-cosmos/ethereum/images/paxg.svg"
+        }
+      ]
+    },
+    {
+      "description": "Restake DAO Token",
+      "denom_units": [
+        {
+          "denom": "ibc/04FAC73DFF7F1DD59395948F2F043B0BBF978AD4533EE37E811340F501A08FFB",
+          "exponent": 0,
+          "aliases": [
+            "factory/migaloo1d0uma9qzcts4fzt7ml39xp44aut5k6qyjfzz4asalnecppppr3rsl52vvv/rstk"
+          ]
+        },
+        {
+          "denom": "rstk",
+          "exponent": 6
+        }
+      ],
+      "type_asset": "ics20",
+      "base": "ibc/04FAC73DFF7F1DD59395948F2F043B0BBF978AD4533EE37E811340F501A08FFB",
+      "name": "RESTAKE",
+      "display": "rstk",
+      "symbol": "RSTK",
+      "traces": [
+        {
+          "type": "ibc",
+          "counterparty": {
+            "chain_name": "migaloo",
+            "base_denom": "factory/migaloo1d0uma9qzcts4fzt7ml39xp44aut5k6qyjfzz4asalnecppppr3rsl52vvv/rstk",
+            "channel_id": "channel-5"
+          },
+          "chain": {
+            "channel_id": "channel-642",
+            "path": "transfer/channel-642/factory/migaloo1d0uma9qzcts4fzt7ml39xp44aut5k6qyjfzz4asalnecppppr3rsl52vvv/rstk"
+          }
+        }
+      ],
+      "logo_URIs": {
+        "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/migaloo/images/rstk.png",
+        "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/migaloo/images/rstk.svg"
+      },
+      "images": [
+        {
+          "image_sync": {
+            "chain_name": "migaloo",
+            "base_denom": "factory/migaloo1d0uma9qzcts4fzt7ml39xp44aut5k6qyjfzz4asalnecppppr3rsl52vvv/rstk"
+          },
+          "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/migaloo/images/rstk.png",
+          "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/migaloo/images/rstk.svg"
+        }
+      ]
+    },
+    {
+      "description": "The Revenue & Governance token of Unstake.fi",
+      "denom_units": [
+        {
+          "denom": "ibc/690EB0A0CA0DA2DC1E9CF62FB23C935AE5C7E9F57919CF89690521D5D70948A7",
+          "exponent": 0,
+          "aliases": [
+            "factory/kujira1aaudpfr9y23lt9d45hrmskphpdfaq9ajxd3ukh/unstk"
+          ]
+        },
+        {
+          "denom": "nstk",
+          "exponent": 6
+        }
+      ],
+      "type_asset": "ics20",
+      "base": "ibc/690EB0A0CA0DA2DC1E9CF62FB23C935AE5C7E9F57919CF89690521D5D70948A7",
+      "name": "Unstake Fi",
+      "display": "nstk",
+      "symbol": "NSTK",
+      "traces": [
+        {
+          "type": "ibc",
+          "counterparty": {
+            "chain_name": "kujira",
+            "base_denom": "factory/kujira1aaudpfr9y23lt9d45hrmskphpdfaq9ajxd3ukh/unstk",
+            "channel_id": "channel-3"
+          },
+          "chain": {
+            "channel_id": "channel-259",
+            "path": "transfer/channel-259/factory:kujira1aaudpfr9y23lt9d45hrmskphpdfaq9ajxd3ukh:unstk"
+          }
+        }
+      ],
+      "logo_URIs": {
+        "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/kujira/images/nstk.svg"
+      },
+      "images": [
+        {
+          "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/kujira/images/nstk.svg"
+        }
+      ]
+    },
+    {
+      "denom_units": [
+        {
+          "denom": "ibc/0B3C3D06228578334B66B57FBFBA4033216CEB8119B27ACDEE18D92DA5B28D43",
+          "exponent": 0,
+          "aliases": [
+            "avalanche-uusdc"
+          ]
+        },
+        {
+          "denom": "avalanche-usdc",
+          "exponent": 6
+        }
+      ],
+      "type_asset": "ics20",
+      "base": "ibc/0B3C3D06228578334B66B57FBFBA4033216CEB8119B27ACDEE18D92DA5B28D43",
+      "name": "Wormhole USDC(Avalanche)",
+      "display": "avalanche-usdc",
+      "symbol": "avalanche.USDC.wh",
+      "traces": [
+        {
+          "type": "ibc",
+          "counterparty": {
+            "chain_name": "gateway",
+            "base_denom": "factory/wormhole14ejqjyq8um4p3xfqj74yld5waqljf88fz25yxnma0cngspxe3les00fpjx/5ZLmAZpcbaP4EGyihSmpfwryzDr84h51tboV392BCjW4",
+            "channel_id": "channel-3"
+          },
+          "chain": {
+            "channel_id": "channel-2186",
+            "path": "transfer/channel-2186/factory/wormhole14ejqjyq8um4p3xfqj74yld5waqljf88fz25yxnma0cngspxe3les00fpjx/5ZLmAZpcbaP4EGyihSmpfwryzDr84h51tboV392BCjW4"
+          }
+        }
+      ],
+      "images": [
+        {
+          "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/osmosis/images/usdc.hole.png",
+          "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/osmosis/images/usdc.hole.svg"
+        }
+      ],
+      "logo_URIs": {
+        "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/osmosis/images/usdc.hole.png",
+        "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/osmosis/images/usdc.hole.svg"
+      }
+    },
+    {
+      "description": "Nomic's native token.",
+      "denom_units": [
+        {
+          "denom": "ibc/F49DFB3BC8105C57EE7F17EC2402438825B31212CFDD81681EB87911E934F32C",
+          "exponent": 0,
+          "aliases": [
+            "unom"
+          ]
+        },
+        {
+          "denom": "nom",
+          "exponent": 6
+        }
+      ],
+      "type_asset": "ics20",
+      "base": "ibc/F49DFB3BC8105C57EE7F17EC2402438825B31212CFDD81681EB87911E934F32C",
+      "name": "Nomic",
+      "display": "nom",
+      "symbol": "nomic.NOM",
+      "traces": [
+        {
+          "type": "ibc",
+          "counterparty": {
+            "chain_name": "nomic",
+            "base_denom": "unom",
+            "channel_id": "channel-1"
+          },
+          "chain": {
+            "channel_id": "channel-6897",
+            "path": "transfer/channel-6897/unom"
+          }
+        }
+      ],
+      "images": [
+        {
+          "image_sync": {
+            "chain_name": "nomic",
+            "base_denom": "unom"
+          },
+          "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/nomic/images/nom.png",
+          "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/nomic/images/nom.svg"
+        }
+      ],
+      "logo_URIs": {
+        "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/nomic/images/nom.png",
+        "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/nomic/images/nom.svg"
+      }
+    },
+    {
+      "description": "The governance and utility token of Yieldmos, the Interchain Automation Protocol",
+      "denom_units": [
+        {
+          "denom": "factory/osmo1vdvnznwg597qngrq9mnfcfk0am9jdc9y446jewhcqdreqz4r75xq5j5zvy/ymos",
+          "exponent": 0
+        },
+        {
+          "denom": "ymos",
+          "exponent": 6
+        }
+      ],
+      "type_asset": "sdk.coin",
+      "address": "osmo1vdvnznwg597qngrq9mnfcfk0am9jdc9y446jewhcqdreqz4r75xq5j5zvy",
+      "base": "factory/osmo1vdvnznwg597qngrq9mnfcfk0am9jdc9y446jewhcqdreqz4r75xq5j5zvy/ymos",
+      "name": "Yieldmos Coin",
+      "display": "ymos",
+      "symbol": "YMOS",
+      "logo_URIs": {
+        "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/osmosis/images/ymos.png"
+      },
+      "images": [
+        {
+          "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/osmosis/images/ymos.png"
+        }
+      ]
+    },
+    {
+      "description": "Memecoin for The International Brane Wave",
+      "denom_units": [
+        {
+          "denom": "factory/osmo13gu58hzw3e9aqpj25h67m7snwcjuccd7v4p55w/brnz",
+          "exponent": 0,
+          "aliases": [
+            "brnz"
+          ]
+        }
+      ],
+      "base": "factory/osmo13gu58hzw3e9aqpj25h67m7snwcjuccd7v4p55w/brnz",
+      "name": "Branez",
+      "display": "factory/osmo13gu58hzw3e9aqpj25h67m7snwcjuccd7v4p55w/brnz",
+      "symbol": "BRNZ",
+      "logo_URIs": {
+        "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/osmosis/images/BRNZ.svg"
+      },
+      "images": [
+        {
+          "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/osmosis/images/BRNZ.svg"
         }
       ]
     }

--- a/osmosis/assetlist.json
+++ b/osmosis/assetlist.json
@@ -33,7 +33,11 @@
       "keywords": [
         "dex",
         "staking"
-      ]
+      ],
+      "socails": {
+        "website": "https://osmosis.zone",
+        "twitter": "https://twitter.com/osmosiszone"
+      }
     },
     {
       "denom_units": [
@@ -65,7 +69,11 @@
       "keywords": [
         "memecoin",
         "defi"
-      ]
+      ],
+      "socails": {
+        "website": "https://ion.wtf",
+        "twitter": "https://twitter.com/_IONDAO"
+      }
     },
     {
       "description": "Circle's stablecoin on Axelar",
@@ -1294,9 +1302,6 @@
           "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/persistence/images/pstake.png",
           "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/persistence/images/pstake.svg"
         }
-      ],
-      "keywords": [
-        "canon"
       ]
     },
     {
@@ -2193,8 +2198,7 @@
         }
       ],
       "keywords": [
-        "osmosis_unstable",
-        "osmosis-unstable"
+        "osmosis_unstable"
       ]
     },
     {
@@ -2340,7 +2344,7 @@
         }
       ],
       "keywords": [
-        "osmosis-unstable"
+        "osmosis_unstable"
       ]
     },
     {
@@ -2618,8 +2622,7 @@
         }
       ],
       "keywords": [
-        "osmosis_unstable",
-        "osmosis-unstable"
+        "osmosis_unstable"
       ]
     },
     {
@@ -2905,8 +2908,7 @@
         }
       ],
       "keywords": [
-        "osmosis_unstable",
-        "osmosis-unstable"
+        "osmosis_unstable"
       ]
     },
     {
@@ -2952,9 +2954,6 @@
           "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/sifchain/images/rowan.png",
           "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/sifchain/images/rowan.svg"
         }
-      ],
-      "keywords": [
-        "osmosis_unstable"
       ]
     },
     {
@@ -4107,8 +4106,7 @@
         }
       ],
       "keywords": [
-        "osmosis_unstable",
-        "osmosis-unstable"
+        "osmosis_unstable"
       ]
     },
     {
@@ -4162,8 +4160,7 @@
         }
       ],
       "keywords": [
-        "osmosis_unlisted",
-        "osmosis-unlisted"
+        "osmosis_unlisted"
       ]
     },
     {
@@ -4217,8 +4214,7 @@
         }
       ],
       "keywords": [
-        "osmosis_unlisted",
-        "osmosis-unlisted"
+        "osmosis_unlisted"
       ]
     },
     {
@@ -4329,9 +4325,6 @@
         {
           "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/_non-cosmos/ethereum/images/rai.svg"
         }
-      ],
-      "keywords": [
-        "osmosis_unlisted"
       ]
     },
     {
@@ -4385,8 +4378,7 @@
         }
       ],
       "keywords": [
-        "osmosis_unlisted",
-        "osmosis-unlisted"
+        "osmosis_unlisted"
       ]
     },
     {
@@ -4565,9 +4557,6 @@
           "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/odin/images/odin.png",
           "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/odin/images/odin.svg"
         }
-      ],
-      "keywords": [
-        "osmosis_unstable"
       ]
     },
     {
@@ -4615,8 +4604,7 @@
         }
       ],
       "keywords": [
-        "osmosis_unstable",
-        "osmosis-unstable"
+        "osmosis_unstable"
       ]
     },
     {
@@ -4664,8 +4652,7 @@
         }
       ],
       "keywords": [
-        "osmosis_unstable",
-        "osmosis-unstable"
+        "osmosis_unstable"
       ]
     },
     {
@@ -4956,8 +4943,7 @@
         }
       ],
       "keywords": [
-        "osmosis_unstable",
-        "osmosis-unstable"
+        "osmosis_unstable"
       ]
     },
     {
@@ -7815,8 +7801,7 @@
         }
       ],
       "keywords": [
-        "osmosis_unstable",
-        "osmosis-unstable"
+        "osmosis_unstable"
       ]
     },
     {
@@ -12225,8 +12210,7 @@
         }
       ],
       "keywords": [
-        "osmosis_unlisted",
-        "osmosis-unlisted"
+        "osmosis_unlisted"
       ]
     },
     {
@@ -12615,6 +12599,7 @@
     },
     {
       "description": "Levana Well-funded Perps is a protocol for perpetual swaps, which are leveraged trading contracts.",
+      "extended_description": "Levana Well-funded Perps is a protocol for perpetual swaps, which are leveraged trading contracts. It aims to manage risk and provide benefits to both traders and liquidity providers.\n\nFor traders, Levana's solution is to make all positions \"well-funded,\" meaning that the maximum profit for each position is locked in advance. This eliminates the possibility of bad debt and insolvency, providing greater security.\n\nLiquidity providers, on the other hand, receive a yield for taking on the risk of market instability. They supply funds that act as collateral, and in return, they earn a fee with a risk premium.\n\nThe protocol addresses the issues with existing perpetual swap models, such as the virtual AMM. These models rely on complex mechanisms to maintain price stability, but they have limitations and can be risky in volatile markets.\n\nBy separating different trading pairs and creating a decentralized market for liquidity, Levana reduces the risk of contagion between different markets. This also makes it easier to expand to other blockchain networks.\n\nOverall, Levana's perpetual swaps protocol offers a reliable and secure platform for traders and liquidity providers. It ensures fair settlement, minimizes risks, and allows for the development of additional financial protocols on top of tokenized positions.",
       "denom_units": [
         {
           "denom": "factory/osmo1mlng7pz4pnyxtpq0akfwall37czyk9lukaucsrn30ameplhhshtqdvfm5c/ulvn",
@@ -12691,8 +12676,7 @@
         }
       ],
       "keywords": [
-        "osmosis_unstable",
-        "osmosis-unstable"
+        "osmosis_unstable"
       ]
     },
     {
@@ -13001,8 +12985,7 @@
         }
       ],
       "keywords": [
-        "osmosis_unlisted",
-        "osmosis-unlisted"
+        "osmosis_unlisted"
       ]
     },
     {
@@ -13120,8 +13103,7 @@
         }
       ],
       "keywords": [
-        "osmosis_unlisted",
-        "osmosis-unlisted"
+        "osmosis_unlisted"
       ]
     },
     {
@@ -13255,8 +13237,7 @@
         }
       ],
       "keywords": [
-        "osmosis_unlisted",
-        "osmosis-unlisted"
+        "osmosis_unlisted"
       ]
     },
     {
@@ -14040,9 +14021,6 @@
           "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/juno/images/glto.png",
           "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/juno/images/glto.svg"
         }
-      ],
-      "keywords": [
-        "osmosis_unlisted"
       ]
     },
     {
@@ -14117,8 +14095,7 @@
         }
       ],
       "keywords": [
-        "osmosis_unlisted",
-        "osmosis-unlisted"
+        "osmosis_unlisted"
       ]
     },
     {
@@ -14305,7 +14282,8 @@
         }
       ],
       "logo_URIs": {
-        "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/humans/images/heart-dark-mode.png"
+        "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/humans/images/heart-dark-mode.png",
+        "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/humans/images/heart-dark-mode.svg"
       },
       "images": [
         {
@@ -14450,7 +14428,7 @@
         }
       ],
       "keywords": [
-        "osmosis-unlisted"
+        "osmosis_unlisted"
       ]
     },
     {
@@ -14812,6 +14790,7 @@
     },
     {
       "description": "Sail DAO is a liquidity deployment and management DAO built as a collaboration between the Osmosis and Migaloo Blockchains.",
+      "extended_description": "Sail DAO is a liquidity deployment and management DAO built as a collaboration between the Osmosis and Migaloo Blockchains. Seeded by both the Osmosis Community Pool and the Migaloo Foundation, Sail DAO is open to hear offers from cosmos based projects that hope to seed liquidity for their token on the Osmosis blockchain. Along with the creation of this DAO the White Whale DEX is deployed on Osmosis, being the first DEX apart from Osmosis to deploy on the chain, it is a great step towards Osmosis becoming an ecosystem from an appchain. Migaloo incubated projects are encouraged to participate in OTC deals with Sail DAO in order to seed or enhance liquidity on WW's Osmosis DEX. However, offers are not limited to Migaloo projects and liquidity is not limitied to being deployed on WW DEX. The treasury of this DAO can be deployed however it wishes at the discretion of the Sail DAO voters. The Osmosis CP has been given veto authorization over any props introduced in this DAO and has also been given clawback rights if this venture ever gets off track.",
       "denom_units": [
         {
           "denom": "factory/osmo1rckme96ptawr4zwexxj5g5gej9s2dmud8r2t9j0k0prn5mch5g4snzzwjv/sail",
@@ -14834,7 +14813,11 @@
         {
           "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/osmosis/images/sail.png"
         }
-      ]
+      ],
+      "socails": {
+        "website": "https://daodao.zone/dao/osmo106tvcj58rvdn9k36m9m3xcmcwk2c3fgft3ldcst9lgy05gcmjanqexru3h/home",
+        "twitter": "https://twitter.com/Sail_DAO_"
+      }
     },
     {
       "description": "SHARK is the apex price prediction market within Cosmos.",
@@ -14984,7 +14967,7 @@
         }
       ],
       "keywords": [
-        "osmosis-unlisted"
+        "osmosis_unlisted"
       ]
     },
     {
@@ -15132,7 +15115,7 @@
         }
       ],
       "keywords": [
-        "osmosis-unlisted"
+        "osmosis_unlisted"
       ]
     },
     {
@@ -15211,11 +15194,12 @@
         }
       ],
       "keywords": [
-        "osmosis-unlisted"
+        "osmosis_unlisted"
       ]
     },
     {
       "description": "LAB - Everything is an Experiment",
+      "extended_description": "LAB - Everything is an Experiment\n\nUse 10 $LAB tokens to mint 1 Mad Scientist NFT on Backbone Labs Osmosis Launchpad. You will then be able to trade your NFTs on the marketplace. You can also choose to hold onto your $LAB tokens as unrevealed NFTs and trade it.\n\n Fair Launch: The event was marked by the absence of whitelists (WLs), no bots and no lock, ensuring an equitable opportunity for all interested parties.\n\nPreparation for the Launch: Participants were given a 52.91-hour window to deposit $OSMO into a pool on Streamswap.\n\nThe Swap Process: After the initial deposit period, $OSMO was converted into $LAB tokens over an additional hour, allowing for a smooth transition and fair distribution.",
       "denom_units": [
         {
           "denom": "factory/osmo17fel472lgzs87ekt9dvk0zqyh5gl80sqp4sk4n/LAB",
@@ -15268,7 +15252,7 @@
         }
       ],
       "keywords": [
-        "osmosis-unlisted"
+        "osmosis_unlisted"
       ]
     },
     {
@@ -15326,7 +15310,7 @@
         }
       ],
       "keywords": [
-        "osmosis-unlisted"
+        "osmosis_unlisted"
       ]
     },
     {
@@ -15489,7 +15473,7 @@
         }
       ],
       "keywords": [
-        "osmosis-unlisted"
+        "osmosis_unlisted"
       ]
     },
     {
@@ -15542,7 +15526,7 @@
       "keywords": [
         "gaming",
         "staking",
-        "osmosis-unlisted"
+        "osmosis_unlisted"
       ]
     },
     {
@@ -15691,7 +15675,7 @@
         }
       ],
       "keywords": [
-        "osmosis-unlisted"
+        "osmosis_unlisted"
       ]
     },
     {
@@ -15739,7 +15723,7 @@
         }
       ],
       "keywords": [
-        "osmosis-unlisted"
+        "osmosis_unlisted"
       ]
     },
     {
@@ -15812,8 +15796,12 @@
       ],
       "keywords": [
         "memecoin",
-        "osmosis-unlisted"
-      ]
+        "osmosis_unlisted"
+      ],
+      "socails": {
+        "webiste": "https://www.ibcmeme.wtf",
+        "twitter": "https://twitter.com/IBCmemecoin"
+      }
     },
     {
       "description": "Astroport is a neutral marketplace where anyone, from anywhere in the galaxy, can dock to trade their wares.",
@@ -15916,7 +15904,7 @@
         }
       ],
       "keywords": [
-        "osmosis-unlisted"
+        "osmosis_unlisted"
       ]
     },
     {

--- a/osmosis/assetlist.json
+++ b/osmosis/assetlist.json
@@ -34,7 +34,7 @@
         "dex",
         "staking"
       ],
-      "socails": {
+      "socials": {
         "website": "https://osmosis.zone",
         "twitter": "https://twitter.com/osmosiszone"
       }
@@ -70,7 +70,7 @@
         "memecoin",
         "defi"
       ],
-      "socails": {
+      "socials": {
         "website": "https://ion.wtf",
         "twitter": "https://twitter.com/_IONDAO"
       }
@@ -14814,7 +14814,7 @@
           "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/osmosis/images/sail.png"
         }
       ],
-      "socails": {
+      "socials": {
         "website": "https://daodao.zone/dao/osmo106tvcj58rvdn9k36m9m3xcmcwk2c3fgft3ldcst9lgy05gcmjanqexru3h/home",
         "twitter": "https://twitter.com/Sail_DAO_"
       }
@@ -15798,7 +15798,7 @@
         "memecoin",
         "osmosis_unlisted"
       ],
-      "socails": {
+      "socials": {
         "webiste": "https://www.ibcmeme.wtf",
         "twitter": "https://twitter.com/IBCmemecoin"
       }


### PR DESCRIPTION
Update Osmosis' Assetlist
As generated from its assetlists repo

Issues noticed:
Existing socials should not be removed (e.g., OSMO's)
Existing extended_descriptions should not be removed.
See if we can merge similar keywords like 'osmosis-unlisted' and 'osmosis_unlisted'
Double check NSTK ibc denom: Confirmed, proposed change is correct. Should be ibc/F7...
Why is heart-dark-mode logoURIs only png, but the image is both png and svg? 