### PR TITLE
Remove Noble mintscan testnet subdomain

### DIFF
--- a/testnets/nobletestnet/chain.json
+++ b/testnets/nobletestnet/chain.json
@@ -184,8 +184,8 @@
   "explorers": [
     {
       "kind": "mintscan",
-      "url": "https://testnet.mintscan.io/noble-testnet",
-      "tx_page": "https://testnet.mintscan.io/noble-testnet/txs/${txHash}"
+      "url": "https://mintscan.io/noble-testnet",
+      "tx_page": "https://mintscan.io/noble-testnet/txs/${txHash}"
     },
     {
       "kind": "ping.pub",


### PR DESCRIPTION
- Mintscan no longer uses the testnet subdomain and has noble-testnet in the main domain. This PR updates the entry to reflect this.