### PR TITLE
Update cronos's chain.json for v1.2 upgrade

### DIFF
--- a/cronos/chain.json
+++ b/cronos/chain.json
@@ -25,37 +25,30 @@
   },
   "codebase": {
     "git_repo": "https://github.com/crypto-org-chain/cronos",
-    "recommended_version": "v1.0.4",
-    "compatible_versions": [
-      "v1.0.2",
-      "v1.0.3",
-      "v1.0.4"
-    ],
+    "recommended_version": "v1.2.0",
+    "compatible_versions": [],
     "binaries": {
-      "linux/amd64": "https://github.com/crypto-org-chain/cronos/releases/download/v1.0.4/cronos_1.0.4_Linux_x86_64.tar.gz",
-      "linux/arm64": "https://github.com/crypto-org-chain/cronos/releases/download/v1.0.4/cronos_1.0.4_Linux_arm64.tar.gz",
-      "darwin/amd64": "https://github.com/crypto-org-chain/cronos/releases/download/v1.0.4/cronos_1.0.4_Darwin_x86_64.tar.gz",
-      "darwin/arm64": "https://github.com/crypto-org-chain/cronos/releases/download/v1.0.4/cronos_1.0.4_Darwin_arm64.tar.gz",
-      "windows/amd64": "https://github.com/crypto-org-chain/cronos/releases/download/v1.0.4/cronos_1.0.4_Windows_x86_64.zip"
+      "linux/amd64": "https://github.com/crypto-org-chain/cronos/releases/download/v1.2.0/cronos_1.2.0_Linux_x86_64.tar.gz",
+      "linux/arm64": "https://github.com/crypto-org-chain/cronos/releases/download/v1.2.0/cronos_1.2.0_Linux_arm64.tar.gz",
+      "darwin/amd64": "https://github.com/crypto-org-chain/cronos/releases/download/v1.2.0/cronos_1.2.0_Darwin_x86_64.tar.gz",
+      "darwin/arm64": "https://github.com/crypto-org-chain/cronos/releases/download/v1.2.0/cronos_1.2.0_Darwin_arm64.tar.gz",
+      "windows/amd64": "https://github.com/crypto-org-chain/cronos/releases/download/v1.2.0/cronos_1.2.0_Windows_x86_64.zip"
     },
     "genesis": {
       "genesis_url": "https://raw.githubusercontent.com/crypto-org-chain/cronos-mainnet/master/cronosmainnet_25-1/genesis.json"
     },
     "versions": [
       {
-        "name": "v1.0.4",
-        "recommended_version": "v1.0.4",
+        "name": "v1.2.0",
+        "recommended_version": "v1.2.0",
         "compatible_versions": [
-          "v1.0.2",
-          "v1.0.3",
-          "v1.0.4"
         ],
         "binaries": {
-          "linux/amd64": "https://github.com/crypto-org-chain/cronos/releases/download/v1.0.4/cronos_1.0.4_Linux_x86_64.tar.gz",
-          "linux/arm64": "https://github.com/crypto-org-chain/cronos/releases/download/v1.0.4/cronos_1.0.4_Linux_arm64.tar.gz",
-          "darwin/amd64": "https://github.com/crypto-org-chain/cronos/releases/download/v1.0.4/cronos_1.0.4_Darwin_x86_64.tar.gz",
-          "darwin/arm64": "https://github.com/crypto-org-chain/cronos/releases/download/v1.0.4/cronos_1.0.4_Darwin_arm64.tar.gz",
-          "windows/amd64": "https://github.com/crypto-org-chain/cronos/releases/download/v1.0.4/cronos_1.0.4_Windows_x86_64.zip"
+          "linux/amd64": "https://github.com/crypto-org-chain/cronos/releases/download/v1.2.0/cronos_1.2.0_Linux_x86_64.tar.gz",
+          "linux/arm64": "https://github.com/crypto-org-chain/cronos/releases/download/v1.2.0/cronos_1.2.0_Linux_arm64.tar.gz",
+          "darwin/amd64": "https://github.com/crypto-org-chain/cronos/releases/download/v1.2.0/cronos_1.2.0_Darwin_x86_64.tar.gz",
+          "darwin/arm64": "https://github.com/crypto-org-chain/cronos/releases/download/v1.2.0/cronos_1.2.0_Darwin_arm64.tar.gz",
+          "windows/amd64": "https://github.com/crypto-org-chain/cronos/releases/download/v1.2.0/cronos_1.2.0_Windows_x86_64.zip"
         }
       }
     ]


### PR DESCRIPTION
Updating Cronos's chain info after the `v1.2` breaking upgrade.
More details can be found [here](https://blog.cronos.org/p/cronos-mainnet-v12-upgrade-announcing)