### PR TITLE
Remove OSL RPC from Osmosis Testnet

### DIFF
--- a/testnets/osmosistestnet/chain.json
+++ b/testnets/osmosistestnet/chain.json
@@ -122,10 +122,6 @@
       {
         "address": "https://rpc.osmotest5.osmosis.zone/",
         "provider": "Osmosis"
-      },
-      {
-        "address": "https://rpc.testnet.osl.zone/",
-        "provider": "OSL"
       }
     ],
     "rest": [


### PR DESCRIPTION
Remove OSL RPC from Osmosis Testnet
it's offline