### PR TITLE
update titles of schema definitions

### DIFF
--- a/assetlist.schema.json
+++ b/assetlist.schema.json
@@ -1,7 +1,7 @@
 {
   "$id": "https://osmosis.zone/assetlists.schema.json",
   "$schema": "https://json-schema.org/draft-07/schema",
-  "title": "Asset Lists",
+  "title": "AssetList",
   "description": "Asset lists are a similar mechanism to allow frontends and other UIs to fetch metadata associated with Cosmos SDK denoms, especially for assets sent over IBC.",
   "type": "object",
   "required": [

--- a/chain.schema.json
+++ b/chain.schema.json
@@ -1,8 +1,8 @@
 {
   "$id": "https://sikka.tech/chain.schema.json",
   "$schema": "https://json-schema.org/draft-07/schema",
-  "title": "Cosmos Chain",
-  "description": "Cosmos Chain.json is a metadata file that contains information about a cosmos sdk based chain.",
+  "title": "Chain",
+  "description": "Chain.json is a metadata file that contains information about a blockchain.",
   "type": "object",
   "required": [
     "chain_name",

--- a/ibc_data.schema.json
+++ b/ibc_data.schema.json
@@ -1,5 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-04/schema#",
+  "title": "IBCData",
   "type": "object",
   "required": [
     "chain_1",

--- a/memo_keys.schema.json
+++ b/memo_keys.schema.json
@@ -1,5 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema",
+  "title": "MemoKeys",
   "type": "object",
   "required": [
     "memo_keys"

--- a/versions.schema.json
+++ b/versions.schema.json
@@ -1,8 +1,8 @@
 {
   "$id": "https://sikka.tech/chain.schema.json",
   "$schema": "https://json-schema.org/draft-07/schema",
-  "title": "Cosmos Chain",
-  "description": "Cosmos Chain Versions.json is a metadata file that contains information about a cosmos sdk based chain's current and historical versions.",
+  "title": "Versions",
+  "description": "Versions.json is a metadata file that contains information about a cosmos sdk based chain's current and historical versions.",
   "type": "object",
   "required": [
     "chain_name",


### PR DESCRIPTION
The current names break codegen, and are seemingly unmaintained. This upgrade adds/updates schema titles and descriptions to reflect current chain-registry.