### PR TITLE
Update Crono POS chain binary version to `4.2.9`

### DIFF
--- a/cryptoorgchain/chain.json
+++ b/cryptoorgchain/chain.json
@@ -32,33 +32,33 @@
   },
   "codebase": {
     "git_repo": "https://github.com/crypto-org-chain/chain-main",
-    "recommended_version": "v4.2.2",
+    "recommended_version": "v4.2.9",
     "compatible_versions": [
-      "v4.2.2"
+      "v4.2.9"
     ],
     "binaries": {
-      "linux/amd64": "https://github.com/crypto-org-chain/chain-main/releases/download/v4.2.2/chain-main_4.2.2_Linux_x86_64.tar.gz",
-      "linux/arm64": "https://github.com/crypto-org-chain/chain-main/releases/download/v4.2.2/chain-main_4.2.2_Linux_arm64.tar.gz",
-      "darwin/amd64": "https://github.com/crypto-org-chain/chain-main/releases/download/v4.2.2/chain-main_4.2.2_Darwin_x86_64.tar.gz",
-      "darwin/arm64": "https://github.com/crypto-org-chain/chain-main/releases/download/v4.2.2/chain-main_4.2.2_Darwin_arm64.tar.gz",
-      "windows/amd64": "https://github.com/crypto-org-chain/chain-main/releases/download/v4.2.2/chain-main_4.2.2_Windows_x86_64.zip"
+      "linux/amd64": "https://github.com/crypto-org-chain/chain-main/releases/download/v4.2.9/chain-main_4.2.9_Linux_x86_64.tar.gz",
+      "linux/arm64": "https://github.com/crypto-org-chain/chain-main/releases/download/v4.2.9/chain-main_4.2.9_Linux_arm64.tar.gz",
+      "darwin/amd64": "https://github.com/crypto-org-chain/chain-main/releases/download/v4.2.9/chain-main_4.2.9_Darwin_x86_64.tar.gz",
+      "darwin/arm64": "https://github.com/crypto-org-chain/chain-main/releases/download/v4.2.9/chain-main_4.2.9_Darwin_arm64.tar.gz",
+      "windows/amd64": "https://github.com/crypto-org-chain/chain-main/releases/download/v4.2.9/chain-main_4.2.9_Windows_x86_64.zip"
     },
     "genesis": {
       "genesis_url": "https://github.com/crypto-org-chain/mainnet/raw/main/crypto-org-chain-mainnet-1/genesis.json"
     },
     "versions": [
       {
-        "name": "v4.2.2",
-        "recommended_version": "v4.2.2",
+        "name": "v4.2.9",
+        "recommended_version": "v4.2.9",
         "compatible_versions": [
-          "v4.2.2"
+          "v4.2.9"
         ],
         "binaries": {
-          "linux/amd64": "https://github.com/crypto-org-chain/chain-main/releases/download/v4.2.2/chain-main_4.2.2_Linux_x86_64.tar.gz",
-          "linux/arm64": "https://github.com/crypto-org-chain/chain-main/releases/download/v4.2.2/chain-main_4.2.2_Linux_arm64.tar.gz",
-          "darwin/amd64": "https://github.com/crypto-org-chain/chain-main/releases/download/v4.2.2/chain-main_4.2.2_Darwin_x86_64.tar.gz",
-          "darwin/arm64": "https://github.com/crypto-org-chain/chain-main/releases/download/v4.2.2/chain-main_4.2.2_Darwin_arm64.tar.gz",
-          "windows/amd64": "https://github.com/crypto-org-chain/chain-main/releases/download/v4.2.2/chain-main_4.2.2_Windows_x86_64.zip"
+          "linux/amd64": "https://github.com/crypto-org-chain/chain-main/releases/download/v4.2.9/chain-main_4.2.9_Linux_x86_64.tar.gz",
+          "linux/arm64": "https://github.com/crypto-org-chain/chain-main/releases/download/v4.2.9/chain-main_4.2.9_Linux_arm64.tar.gz",
+          "darwin/amd64": "https://github.com/crypto-org-chain/chain-main/releases/download/v4.2.9/chain-main_4.2.9_Darwin_x86_64.tar.gz",
+          "darwin/arm64": "https://github.com/crypto-org-chain/chain-main/releases/download/v4.2.9/chain-main_4.2.9_Darwin_arm64.tar.gz",
+          "windows/amd64": "https://github.com/crypto-org-chain/chain-main/releases/download/v4.2.9/chain-main_4.2.9_Windows_x86_64.zip"
         }
       }
     ]


### PR DESCRIPTION
Hello Cosmos team, this PR updates the Cronos POS chain (`crypto-org-chain-mainnet-1`) to `v4.2.9`.

Background: 
A soft fork occurred at height `16978800` and `v4.2.9` is the current version.

Reference:
https://github.com/crypto-org-chain/chain-main/releases/tag/v4.2.9