### PR TITLE
Upgrade likecoin to v4.2.0

### DIFF
--- a/likecoin/chain.json
+++ b/likecoin/chain.json
@@ -36,16 +36,16 @@
   },
   "codebase": {
     "git_repo": "https://github.com/likecoin/likecoin-chain",
-    "recommended_version": "v4.1.1",
+    "recommended_version": "v4.2.0",
     "compatible_versions": [
-      "v4.1.1"
+      "v4.2.0"
     ],
     "binaries": {
-      "linux/amd64": "https://github.com/likecoin/likecoin-chain/releases/download/v4.1.1/likecoin-chain_4.1.1_Linux_x86_64.tar.gz",
-      "linux/arm64": "https://github.com/likecoin/likecoin-chain/releases/download/v4.1.1/likecoin-chain_4.1.1_Linux_arm64.tar.gz",
-      "darwin/amd64": "https://github.com/likecoin/likecoin-chain/releases/download/v4.1.1/likecoin-chain_4.1.1_Darwin_x86_64.tar.gz",
-      "darwin/arm64": "https://github.com/likecoin/likecoin-chain/releases/download/v4.1.1/likecoin-chain_4.1.1_Darwin_arm64.tar.gz",
-      "windows/amd64": "https://github.com/likecoin/likecoin-chain/releases/download/v4.1.1/likecoin-chain_4.1.1_Windows_x86_64.zip"
+      "linux/amd64": "https://github.com/likecoin/likecoin-chain/releases/download/v4.2.0/likecoin-chain_4.2.0_Linux_x86_64.tar.gz",
+      "linux/arm64": "https://github.com/likecoin/likecoin-chain/releases/download/v4.2.0/likecoin-chain_4.2.0_Linux_arm64.tar.gz",
+      "darwin/amd64": "https://github.com/likecoin/likecoin-chain/releases/download/v4.2.0/likecoin-chain_4.2.0_Darwin_x86_64.tar.gz",
+      "darwin/arm64": "https://github.com/likecoin/likecoin-chain/releases/download/v4.2.0/likecoin-chain_4.2.0_Darwin_arm64.tar.gz",
+      "windows/amd64": "https://github.com/likecoin/likecoin-chain/releases/download/v4.2.0/likecoin-chain_4.2.0_Windows_x86_64.zip"
     },
     "cosmos_sdk_version": "0.46",
     "consensus": {
@@ -53,7 +53,7 @@
       "version": "0.34"
     },
     "cosmwasm_enabled": false,
-    "ibc_go_version": "6.2.1",
+    "ibc_go_version": "6.3.0",
     "ics_enabled": [
       "ics20-1"
     ],
@@ -178,6 +178,29 @@
           "darwin/amd64": "https://github.com/likecoin/likecoin-chain/releases/download/v4.1.1/likecoin-chain_4.1.1_Darwin_x86_64.tar.gz",
           "darwin/arm64": "https://github.com/likecoin/likecoin-chain/releases/download/v4.1.1/likecoin-chain_4.1.1_Darwin_arm64.tar.gz",
           "windows/amd64": "https://github.com/likecoin/likecoin-chain/releases/download/v4.1.1/likecoin-chain_4.1.1_Windows_x86_64.zip"
+        },
+        "next_version_name": "v4.2.0"
+      },
+      {
+        "name": "v4.2.0",
+        "tag": "v4.2.0",
+        "height": 14103500,
+        "recommended_version": "v4.2.0",
+        "compatible_versions": [
+          "v4.2.0"
+        ],
+        "cosmos_sdk_version": "0.46",
+        "ibc_go_version": "6.3.0",
+        "consensus": {
+          "type": "tendermint",
+          "version": "0.34"
+        },
+        "binaries": {
+          "linux/amd64": "https://github.com/likecoin/likecoin-chain/releases/download/v4.2.0/likecoin-chain_4.2.0_Linux_x86_64.tar.gz",
+          "linux/arm64": "https://github.com/likecoin/likecoin-chain/releases/download/v4.2.0/likecoin-chain_4.2.0_Linux_arm64.tar.gz",
+          "darwin/amd64": "https://github.com/likecoin/likecoin-chain/releases/download/v4.2.0/likecoin-chain_4.2.0_Darwin_x86_64.tar.gz",
+          "darwin/arm64": "https://github.com/likecoin/likecoin-chain/releases/download/v4.2.0/likecoin-chain_4.2.0_Darwin_arm64.tar.gz",
+          "windows/amd64": "https://github.com/likecoin/likecoin-chain/releases/download/v4.2.0/likecoin-chain_4.2.0_Windows_x86_64.zip"
         },
         "next_version_name": ""
       }


### PR DESCRIPTION
https://www.mintscan.io/likecoin/proposals/81

likecoin chain has just been upgraded to v4.2.0 with ibc 6.3.0