### PR TITLE
Changed mainnet version to v0.9.2 - Realio

### DIFF
--- a/realio/chain.json
+++ b/realio/chain.json
@@ -36,16 +36,16 @@
   },
   "codebase": {
     "git_repo": "https://github.com/realiotech/realio-network",
-    "recommended_version": "v0.9.0",
+    "recommended_version": "v0.9.2",
     "compatible_versions": [
-      "v0.9.0"
+      "v0.9.2"
     ],
     "binaries": {
-      "linux/amd64": "https://github.com/realiotech/realio-network/releases/download/v0.9.0/realio-network_Linux_x86_64.tar.gz",
-      "linux/arm64": "https://github.com/realiotech/realio-network/releases/download/v0.9.0/realio-network_Linux_arm64.tar.gz",
-      "darwin/amd64": "https://github.com/realiotech/realio-network/releases/download/v0.9.0/realio-network_Darwin_x86_64.tar.gz",
-      "darwin/arm64": "https://github.com/realiotech/realio-network/releases/download/v0.9.0/realio-network_Darwin_arm64.tar.gz",
-      "windows/amd64": "https://github.com/realiotech/realio-network/releases/download/v0.9.0/realio-network_Windows_x86_64.zip"
+      "linux/amd64": "https://github.com/realiotech/realio-network/releases/download/v0.9.2/realio-network_Linux_x86_64.tar.gz",
+      "linux/arm64": "https://github.com/realiotech/realio-network/releases/download/v0.9.2/realio-network_Linux_arm64.tar.gz",
+      "darwin/amd64": "https://github.com/realiotech/realio-network/releases/download/v0.9.2/realio-network_Darwin_x86_64.tar.gz",
+      "darwin/arm64": "https://github.com/realiotech/realio-network/releases/download/v0.9.2/realio-network_Darwin_arm64.tar.gz",
+      "windows/amd64": "https://github.com/realiotech/realio-network/releases/download/v0.9.2/realio-network_Windows_x86_64.zip"
     },
     "cosmos_sdk_version": "v0.46.12",
     "consensus": {
@@ -111,9 +111,9 @@
         "name": "multistaking",
         "proposal": 7,
         "height": 5989000,
-        "recommended_version": "v0.9.0",
+        "recommended_version": "v0.9.2",
         "compatible_versions": [
-          "v0.9.0"
+          "v0.9.2"
         ],
         "cosmos_sdk_version": "v0.46.12",
         "consensus": {
@@ -122,11 +122,11 @@
         },
         "ibc_go_version": "v6.1.1",
         "binaries": {
-          "linux/amd64": "https://github.com/realiotech/realio-network/releases/download/v0.9.0/realio-network_Linux_x86_64.tar.gz",
-          "linux/arm64": "https://github.com/realiotech/realio-network/releases/download/v0.9.0/realio-network_Linux_arm64.tar.gz",
-          "darwin/amd64": "https://github.com/realiotech/realio-network/releases/download/v0.9.0/realio-network_Darwin_x86_64.tar.gz",
-          "darwin/arm64": "https://github.com/realiotech/realio-network/releases/download/v0.9.0/realio-network_Darwin_arm64.tar.gz",
-          "windows/amd64": "https://github.com/realiotech/realio-network/releases/download/v0.9.0/realio-network_Windows_x86_64.zip"
+          "linux/amd64": "https://github.com/realiotech/realio-network/releases/download/v0.9.2/realio-network_Linux_x86_64.tar.gz",
+          "linux/arm64": "https://github.com/realiotech/realio-network/releases/download/v0.9.2/realio-network_Linux_arm64.tar.gz",
+          "darwin/amd64": "https://github.com/realiotech/realio-network/releases/download/v0.9.2/realio-network_Darwin_x86_64.tar.gz",
+          "darwin/arm64": "https://github.com/realiotech/realio-network/releases/download/v0.9.2/realio-network_Darwin_arm64.tar.gz",
+          "windows/amd64": "https://github.com/realiotech/realio-network/releases/download/v0.9.2/realio-network_Windows_x86_64.zip"
         },
         "next_version_name": ""
       }


### PR DESCRIPTION
avoid using version **v0.9.0** - node crash.

cc @jiujiteiro