### PR TITLE
Sei Testnet (atlantic-2): Update Global min gas price

### DIFF
--- a/testnets/seitestnet2/chain.json
+++ b/testnets/seitestnet2/chain.json
@@ -16,7 +16,7 @@
     "fee_tokens": [
       {
         "denom": "usei",
-        "fixed_min_gas_price": 0
+        "fixed_min_gas_price": 0.08
       }
     ]
   },


### PR DESCRIPTION
In accordance with the latest Sei governance proposal and to match the other Cosmos chain registries this PR updates the Global Min Gas Price to 0.08 as outlined in the Sei Chain.

https://github.com/sei-protocol/chain-registry/pull/58/files