### PR TITLE
Update CVN ibc token in osmosis

### DIFF
--- a/_IBC/conscious-osmosis.json
+++ b/_IBC/conscious-osmosis.json
@@ -2,22 +2,22 @@
     "$schema": "../ibc_data.schema.json",
     "chain_1": {
       "chain_name": "conscious",
-      "client_id": "07-tendermint-11",
-      "connection_id": "connection-8"
+      "client_id": "07-tendermint-12",
+      "connection_id": "connection-9"
     },
     "chain_2": {
       "chain_name": "osmosis",
-      "client_id": "07-tendermint-3138",
-      "connection_id": "connection-2606"
+      "client_id": "07-tendermint-3199",
+      "connection_id": "connection-2656"
     },
     "channels": [
       {
         "chain_1": {
-          "channel_id": "channel-5",
+          "channel_id": "channel-6",
           "port_id": "transfer"
         },
         "chain_2": {
-          "channel_id": "channel-35264",
+          "channel_id": "channel-73971",
           "port_id": "transfer"
         },
         "ordering": "unordered",

--- a/osmosis/assetlist.json
+++ b/osmosis/assetlist.json
@@ -15070,7 +15070,7 @@
       "description": "Cvn is a Layer-1 blockchain built to deliver on the promise of DeFi",
       "denom_units": [
         {
-          "denom": "ibc/D3FAF77F5DE21C18413B164751239BA7D521A9D8EA53BFE553AADF338A721480",
+          "denom": "ibc/044B7B28AFE93CEC769CF529ADC626DA09EA0EFA3E0E3284D540E9E00E01E24A",
           "exponent": 0,
           "aliases": [
             "acvnt"
@@ -15082,7 +15082,7 @@
         }
       ],
       "type_asset": "ics20",
-      "base": "ibc/D3FAF77F5DE21C18413B164751239BA7D521A9D8EA53BFE553AADF338A721480",
+      "base": "ibc/044B7B28AFE93CEC769CF529ADC626DA09EA0EFA3E0E3284D540E9E00E01E24A",
       "name": "ConsciousDAO",
       "display": "cvnt",
       "symbol": "CVN",
@@ -15092,11 +15092,11 @@
           "counterparty": {
             "chain_name": "conscious",
             "base_denom": "acvnt",
-            "channel_id": "channel-5"
+            "channel_id": "channel-6"
           },
           "chain": {
-            "channel_id": "channel-35264",
-            "path": "transfer/channel-35264/acvnt"
+            "channel_id": "channel-73971",
+            "path": "transfer/channel-73971/acvnt"
           }
         }
       ],


### PR DESCRIPTION
Hi, due to a problem with the synchronization block of the deployed osmosis node, the tendermint client expired, so we created a new ibc channel.