### PR TITLE
Add 'unknown' type_asset option

### DIFF
--- a/_non-cosmos/0l/assetlist.json
+++ b/_non-cosmos/0l/assetlist.json
@@ -15,7 +15,7 @@
           "exponent": 6
         }
       ],
-      "type_asset": "evm-base",
+      "type_asset": "unknown",
       "base": "uLibra",
       "name": "Libra Coin",
       "display": "libra",

--- a/_non-cosmos/aptos/assetlist.json
+++ b/_non-cosmos/aptos/assetlist.json
@@ -17,7 +17,7 @@
           "exponent": 8
         }
       ],
-      "type_asset": "evm-base",
+      "type_asset": "unknown",
       "base": "0x1::aptos_coin::AptosCoin",
       "name": "Aptos Coin",
       "display": "APT",

--- a/_non-cosmos/sui/assetlist.json
+++ b/_non-cosmos/sui/assetlist.json
@@ -17,7 +17,7 @@
           "exponent": 9
         }
       ],
-      "type_asset": "evm-base",
+      "type_asset": "unknown",
       "base": "0x2::sui::SUI",
       "name": "Sui",
       "display": "SUI",

--- a/_non-cosmos/xrpl/assetlist.json
+++ b/_non-cosmos/xrpl/assetlist.json
@@ -15,7 +15,7 @@
           "exponent": 6
         }
       ],
-      "type_asset": "evm-base",
+      "type_asset": "unknown",
       "base": "drop",
       "name": "Ripple",
       "display": "xrp",

--- a/assetlist.schema.json
+++ b/assetlist.schema.json
@@ -57,7 +57,7 @@
         },
         "type_asset": {
           "type": "string",
-          "enum": ["sdk.coin", "cw20", "erc20", "ics20", "snip20", "snip25", "bitcoin-like", "evm-base", "svm-base", "substrate"],
+          "enum": ["sdk.coin", "cw20", "erc20", "ics20", "snip20", "snip25", "bitcoin-like", "evm-base", "svm-base", "substrate", "unknown"],
           "default": "sdk.coin",
           "description": "[OPTIONAL] The potential options for type of asset. By default, assumes sdk.coin"
         },


### PR DESCRIPTION
Add 'unknown' type_asset option for 0l, xrpl, aptos, sui
Meant to be a 'catch-all' type asset classification