### PR TITLE
Remove Echelon CoinGecko ID

### DIFF
--- a/echelon/assetlist.json
+++ b/echelon/assetlist.json
@@ -21,7 +21,6 @@
       "logo_URIs": {
         "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/echelon/images/ech.svg"
       },
-      "coingecko_id": "echelon",
       "images": [
         {
           "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/echelon/images/ech.svg"

--- a/juno/assetlist.json
+++ b/juno/assetlist.json
@@ -131,7 +131,6 @@
         "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/juno/images/marble.png",
         "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/juno/images/marble.svg"
       },
-      "coingecko_id": "marble",
       "images": [
         {
           "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/juno/images/marble.png",
@@ -161,7 +160,6 @@
         "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/juno/images/hope.png",
         "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/juno/images/hope.svg"
       },
-      "coingecko_id": "hope-galaxy",
       "images": [
         {
           "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/juno/images/hope.png",
@@ -278,7 +276,6 @@
         "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/juno/images/raw.png",
         "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/juno/images/raw.svg"
       },
-      "coingecko_id": "junoswap-raw-dao",
       "images": [
         {
           "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/juno/images/raw.png",
@@ -505,7 +502,6 @@
         "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/juno/images/sejuno.png",
         "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/juno/images/sejuno.svg"
       },
-      "coingecko_id": "stakeeasy-juno-derivative",
       "images": [
         {
           "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/juno/images/sejuno.png",
@@ -535,7 +531,6 @@
         "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/juno/images/bjuno.png",
         "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/juno/images/bjuno.svg"
       },
-      "coingecko_id": "stakeeasy-bjuno",
       "images": [
         {
           "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/juno/images/bjuno.png",
@@ -736,7 +731,6 @@
         "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/juno/images/hopers.png",
         "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/juno/images/hopers.svg"
       },
-      "coingecko_id": "hopers-io",
       "images": [
         {
           "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/juno/images/hopers.png",

--- a/secretnetwork/assetlist.json
+++ b/secretnetwork/assetlist.json
@@ -203,7 +203,6 @@
         "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/secretnetwork/images/butt.png",
         "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/secretnetwork/images/butt.svg"
       },
-      "coingecko_id": "buttcoin-2",
       "images": [
         {
           "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/secretnetwork/images/butt.png",


### PR DESCRIPTION
Removing Echelon CGID since it no longer exists
and Secret Network $BUTT
and Juno's: MARBLE, HOPE, HOPERS, RAW, SEJUNO, BJUNO (stakeeasy)