### PR TITLE
Patch Noble to v4.1.3

### DIFF
--- a/noble/chain.json
+++ b/noble/chain.json
@@ -43,9 +43,9 @@
   },
   "codebase": {
     "git_repo": "https://github.com/strangelove-ventures/noble",
-    "recommended_version": "v4.1.2",
+    "recommended_version": "v4.1.3",
     "compatible_versions": [
-      "v4.1.2"
+      "v4.1.3"
     ],
     "cosmos_sdk_version": "v0.45.16",
     "consensus": {
@@ -165,11 +165,11 @@
       },
       {
         "name": "fusion",
-        "tag": "v4.1.2",
+        "tag": "v4.1.3",
         "height": 5797500,
-        "recommended_version": "v4.1.2",
+        "recommended_version": "v4.1.3",
         "compatible_versions": [
-          "v4.1.2"
+          "v4.1.3"
         ],
         "cosmos_sdk_version": "v0.45.16",
         "consensus": {


### PR DESCRIPTION
Halt-height upgrade, old versions no longer compatible