### PR TITLE
Mintscan testnet domain update

### DIFF
--- a/testnets/axelartestnet/chain.json
+++ b/testnets/axelartestnet/chain.json
@@ -80,9 +80,9 @@
     },
     {
       "kind": "mintscan",
-      "url": "https://testnet.mintscan.io/axelar-testnet",
-      "tx_page": "https://testnet.mintscan.io/axelar-testnet/txs/${txHash}",
-      "account_page": "https://testnet.mintscan.io/axelar-testnet/account/${accountAddress}"
+      "url": "https://mintscan.io/axelar-testnet",
+      "tx_page": "https://mintscan.io/axelar-testnet/txs/${txHash}",
+      "account_page": "https://mintscan.io/axelar-testnet/account/${accountAddress}"
     }
   ]
 }

--- a/testnets/celestiatestnet/chain.json
+++ b/testnets/celestiatestnet/chain.json
@@ -65,8 +65,8 @@
   "explorers": [
     {
       "kind": "Mintscan",
-      "url": "https://testnet.mintscan.io/celestia-incentivized-testnet",
-      "tx_page": "https://testnet.mintscan.io/celestia-incentivized-testnet/txs/${txHash}"
+      "url": "https://mintscan.io/celestia-incentivized-testnet",
+      "tx_page": "https://mintscan.io/celestia-incentivized-testnet/txs/${txHash}"
     }
   ]
 }

--- a/testnets/celestiatestnet3/chain.json
+++ b/testnets/celestiatestnet3/chain.json
@@ -115,8 +115,8 @@
   "explorers": [
     {
       "kind": "Mintscan",
-      "url": "https://testnet.mintscan.io/celestia-testnet",
-      "tx_page": "https://testnet.mintscan.io/celestia-testnet/txs/${txHash}"
+      "url": "https://mintscan.io/celestia-testnet",
+      "tx_page": "https://mintscan.io/celestia-testnet/txs/${txHash}"
     },
     {
       "kind": "🚀ITRocket🚀",

--- a/testnets/cosmoshubtestnet/chain.json
+++ b/testnets/cosmoshubtestnet/chain.json
@@ -232,8 +232,8 @@
   "explorers": [
     {
       "kind": "Mintscan",
-      "url": "https://testnet.mintscan.io/cosmoshub-testnet",
-      "tx_page": "https://testnet.mintscan.io/cosmoshub-testnet/txs/${txHash}"
+      "url": "https://mintscan.io/cosmoshub-testnet",
+      "tx_page": "https://mintscan.io/cosmoshub-testnet/txs/${txHash}"
     },
     {
       "kind": "Big Dipper",

--- a/testnets/evmostestnet/chain.json
+++ b/testnets/evmostestnet/chain.json
@@ -140,8 +140,8 @@
   "explorers": [
     {
       "kind": "Mintscan",
-      "url": "https://testnet.mintscan.io/evmos-testnet",
-      "tx_page": "https://testnet.mintscan.io/evmos-testnet/txs/${txHash}"
+      "url": "https://mintscan.io/evmos-testnet",
+      "tx_page": "https://mintscan.io/evmos-testnet/txs/${txHash}"
     },
     {
       "kind": "NodesGuru",

--- a/testnets/kyvetestnet/chain.json
+++ b/testnets/kyvetestnet/chain.json
@@ -121,9 +121,9 @@
   "explorers": [
     {
       "kind": "mintscan",
-      "url": "https://testnet.mintscan.io/kyve-testnet",
-      "tx_page": "https://testnet.mintscan.io/kyve-testnet/txs/${txHash}",
-      "account_page": "https://testnet.mintscan.io/kyve-testnet/account/${accountAddress}"
+      "url": "https://mintscan.io/kyve-testnet",
+      "tx_page": "https://mintscan.io/kyve-testnet/txs/${txHash}",
+      "account_page": "https://mintscan.io/kyve-testnet/account/${accountAddress}"
     }
   ]
 }

--- a/testnets/neutrontestnet/chain.json
+++ b/testnets/neutrontestnet/chain.json
@@ -176,9 +176,9 @@
     },
     {
       "kind": "Mintscan",
-      "url": "https://testnet.mintscan.io/neutron-testnet",
-      "tx_page": "https://testnet.mintscan.io/neutron-testnet/txs/${txHash}",
-      "account_page": "https://testnet.mintscan.io/neutron-testnet/account/${accountAddress}"
+      "url": "https://mintscan.io/neutron-testnet",
+      "tx_page": "https://mintscan.io/neutron-testnet/txs/${txHash}",
+      "account_page": "https://mintscan.io/neutron-testnet/account/${accountAddress}"
     }
   ],
   "images": [

--- a/testnets/osmosistestnet/chain.json
+++ b/testnets/osmosistestnet/chain.json
@@ -143,9 +143,9 @@
   "explorers": [
     {
       "kind": "mintscan",
-      "url": "https://testnet.mintscan.io/osmosis-testnet",
-      "tx_page": "https://testnet.mintscan.io/osmosis-testnet/txs/${txHash}",
-      "account_page": "https://testnet.mintscan.io/osmosis-testnet/account/${accountAddress}"
+      "url": "https://mintscan.io/osmosis-testnet",
+      "tx_page": "https://mintscan.io/osmosis-testnet/txs/${txHash}",
+      "account_page": "https://mintscan.io/osmosis-testnet/account/${accountAddress}"
     },
     {
       "kind": "ping.pub",

--- a/testnets/persistencetestnet/chain.json
+++ b/testnets/persistencetestnet/chain.json
@@ -159,9 +159,9 @@
     },
     {
       "kind": "mintscan",
-      "url": "https://testnet.mintscan.io/persistence-testnet",
-      "tx_page": "https://testnet.mintscan.io/persistence-testnet/txs/${txHash}",
-      "account_page": "https://testnet.mintscan.io/persistence-testnet/account/${accountAddress}"
+      "url": "https://mintscan.io/persistence-testnet",
+      "tx_page": "https://mintscan.io/persistence-testnet/txs/${txHash}",
+      "account_page": "https://mintscan.io/persistence-testnet/account/${accountAddress}"
     }
   ]
 }

--- a/testnets/persistencetestnet2/chain.json
+++ b/testnets/persistencetestnet2/chain.json
@@ -241,9 +241,9 @@
   "explorers": [
     {
       "kind": "mintscan",
-      "url": "https://testnet.mintscan.io/persistence-testnet",
-      "tx_page": "https://testnet.mintscan.io/persistence-testnet/txs/${txHash}",
-      "account_page": "https://testnet.mintscan.io/persistence-testnet/account/${accountAddress}"
+      "url": "https://mintscan.io/persistence-testnet",
+      "tx_page": "https://mintscan.io/persistence-testnet/txs/${txHash}",
+      "account_page": "https://mintscan.io/persistence-testnet/account/${accountAddress}"
     },
     {
       "kind": "StakeFlow",

--- a/testnets/rsprovidertestnet/chain.json
+++ b/testnets/rsprovidertestnet/chain.json
@@ -170,8 +170,8 @@
   "explorers": [
     {
       "kind": "Mintscan",
-      "url": "https://testnet.mintscan.io/ics-testnet-provider",
-      "tx_page": "https://testnet.mintscan.io/ics-testnet-provider/txs/${txHash}"
+      "url": "https://mintscan.io/ics-testnet-provider",
+      "tx_page": "https://mintscan.io/ics-testnet-provider/txs/${txHash}"
     },
     {
       "kind": "Ping.pub",


### PR DESCRIPTION
Mintscan has changed their domain so that `testnet.` is no longer included