### PR TITLE
Correct CoinGecko IDs for USDC.grv and USDT.axl

### DIFF
--- a/axelar/assetlist.json
+++ b/axelar/assetlist.json
@@ -160,7 +160,7 @@
       "name": "Tether USD",
       "display": "usdt",
       "symbol": "USDT",
-      "coingecko_id": "bridged-tether-axelar",
+      "coingecko_id": "axelar-usdt",
       "traces": [
         {
           "type": "bridge",

--- a/gravitybridge/assetlist.json
+++ b/gravitybridge/assetlist.json
@@ -142,7 +142,7 @@
       "name": "USD Coin",
       "display": "gusdc",
       "symbol": "USDC",
-      "coingecko_id": "bridged-usd-coin-gravity-bridge",
+      "coingecko_id": "gravity-bridge-usdc",
       "logo_URIs": {
         "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/_non-cosmos/ethereum/images/usdc.svg"
       },


### PR DESCRIPTION
This PR simply corrects the CoinGecko IDs for two assets, which were accidentally set to the slug URLs rather than the API IDs.