### PR TITLE
Add dYdX v4.1.2

### DIFF
--- a/dydx/chain.json
+++ b/dydx/chain.json
@@ -122,9 +122,10 @@
         "name": "v4.1.0",
         "proposal": 53,
         "height": 14404200,
-        "recommended_version": "protocol/v4.1.0",
+        "recommended_version": "protocol/v4.1.2",
         "compatible_versions": [
-          "protocol/v4.1.0"
+          "protocol/v4.1.0",
+          "protocol/v4.1.2"
         ],
         "binaries": {
           "linux/amd64": "https://github.com/dydxprotocol/v4-chain/releases/download/protocol%2Fv4.1.0/dydxprotocold-v4.1.0-linux-amd64.tar.gz",


### PR DESCRIPTION
v4.1.2 is a recommended non-state breaking upgrade: [release notes](https://github.com/dydxprotocol/v4-chain/releases/tag/protocol%2Fv4.1.2)