### PR TITLE
Add WhisperNode Mainnet Block Explorer support

### DIFF
--- a/akash/chain.json
+++ b/akash/chain.json
@@ -378,7 +378,7 @@
         "provider": "ValidatorNode"
       },
       {
-        "address": "https://lcd-akash.whispernode.com:443",
+        "address": "https://api-akash.whispernode.com:443",
         "provider": "WhisperNode 🤐"
       },
       {
@@ -426,7 +426,11 @@
       {
         "address": "https://akash.declab.pro:9001",
         "provider": "Decloud Nodes Lab"
-      }
+      },
+      {
+        "address": "grpc-akash.whispernode.com:443",
+        "provider": "WhisperNode 🤐"
+      } 
     ]
   },
   "explorers": [
@@ -472,6 +476,12 @@
       "kind": "Decloud Nodes Lab",
       "url": "https://explorer.declab.pro/Akash",
       "tx_page": "https://explorer.declab.pro/Akash/tx/${txHash}"
+    },
+    {
+      "kind": "WhisperNode 🤐",
+      "url": "https://mainnet.whispernode.com/akash",
+      "tx_page": "https://mainnet.whispernode.com/akash/tx/${txHash}",
+      "account_page": "https://mainnet.whispernode.com/akash/account/${accountAddress}"
     }
   ],
   "images": [

--- a/archway/chain.json
+++ b/archway/chain.json
@@ -641,6 +641,12 @@
       "url": "https://ezstaking.app/archway",
       "tx_page": "https://ezstaking.app/archway/txs/${txHash}",
       "account_page": "https://ezstaking.app/archway/account/${accountAddress}"
+    },
+    {
+      "kind": "WhisperNode 🤐",
+      "url": "https://mainnet.whispernode.com/archway",
+      "tx_page": "https://mainnet.whispernode.com/archway/tx/${txHash}",
+      "account_page": "https://mainnet.whispernode.com/archway/account/${accountAddress}"
     }
   ],
   "images": [

--- a/assetmantle/chain.json
+++ b/assetmantle/chain.json
@@ -258,6 +258,12 @@
       "url": "https://atomscan.com/assetmantle",
       "tx_page": "https://atomscan.com/assetmantle/transactions/${txHash}",
       "account_page": "https://atomscan.com/assetmantle/accounts/${accountAddress}"
+    },
+    {
+      "kind": "WhisperNode 🤐",
+      "url": "https://mainnet.whispernode.com/assetmantle",
+      "tx_page": "https://mainnet.whispernode.com/assetmantle/tx/${txHash}",
+      "account_page": "https://mainnet.whispernode.com/assetmantle/account/${accountAddress}"
     }
   ],
   "images": [

--- a/axelar/chain.json
+++ b/axelar/chain.json
@@ -420,6 +420,12 @@
       "url": "https://ezstaking.app/axelar",
       "tx_page": "https://ezstaking.app/axelar/txs/${txHash}",
       "account_page": "https://ezstaking.app/axelar/account/${accountAddress}"
+    },
+    {
+      "kind": "WhisperNode 🤐",
+      "url": "https://mainnet.whispernode.com/axelar",
+      "tx_page": "https://mainnet.whispernode.com/axelar/tx/${txHash}",
+      "account_page": "https://mainnet.whispernode.com/axelar/account/${accountAddress}"
     }
   ],
   "images": [

--- a/cheqd/chain.json
+++ b/cheqd/chain.json
@@ -331,6 +331,12 @@
       "kind": "ping.pub",
       "url": "https://ping.wildsage.io/cheqd",
       "tx_page": "https://ping.wildsage.io/cheqd/tx/${txHash}"
+    },
+    {
+      "kind": "WhisperNode 🤐",
+      "url": "https://mainnet.whispernode.com/cheqd",
+      "tx_page": "https://mainnet.whispernode.com/cheqd/tx/${txHash}",
+      "account_page": "https://mainnet.whispernode.com/cheqd/account/${accountAddress}"
     }
   ],
   "logo_URIs": {

--- a/comdex/chain.json
+++ b/comdex/chain.json
@@ -396,6 +396,12 @@
       "kind": "ValidatorNode",
       "url": "https://explorer.validatornode.com/comdex",
       "tx_page": "https://explorer.validatornode.com/comdex/tx/${txHash}"
+    },
+    {
+      "kind": "WhisperNode 🤐",
+      "url": "https://mainnet.whispernode.com/comdex",
+      "tx_page": "https://mainnet.whispernode.com/comdex/tx/${txHash}",
+      "account_page": "https://mainnet.whispernode.com/comdex/account/${accountAddress}"
     }
   ],
   "images": [

--- a/composable/chain.json
+++ b/composable/chain.json
@@ -298,7 +298,7 @@
         "provider": "genznodes"
       },
       {
-        "address": "https://rpc-composable.whispernode.com:443",
+        "address": "https://rpc-picasso.whispernode.com:443",
         "provider": "WhisperNode 🤐"
       },
       {
@@ -352,7 +352,7 @@
         "provider": "genznodes"
       },
       {
-        "address": "https://lcd-composable.whispernode.com:443",
+        "address": "https://api-picasso.whispernode.com:443",
         "provider": "WhisperNode 🤐"
       },
       {
@@ -444,7 +444,11 @@
       {
         "address": "composable.grpc.m.stavr.tech:9907",
         "provider": "🔥STAVR🔥"
-      }
+      },
+      {
+        "address": "grpc-picasso.whispernode.com:443",
+        "provider": "WhisperNode 🤐"
+      }      
     ]
   },
   "explorers": [
@@ -468,7 +472,13 @@
       "kind": "🔥STAVR🔥",
       "url": "https://explorer.stavr.tech/Composable-Mainnet",
       "tx_page": "https://explorer.stavr.tech/Composable-Mainnet/tx/${txHash}"
-    }
+    },
+    {
+      "kind": "WhisperNode 🤐",
+      "url": "https://mainnet.whispernode.com/picasso",
+      "tx_page": "https://mainnet.whispernode.com/picasso/tx/${txHash}",
+      "account_page": "https://mainnet.whispernode.com/picasso/account/${accountAddress}"
+    }    
   ],
   "images": [
     {

--- a/cosmoshub/chain.json
+++ b/cosmoshub/chain.json
@@ -728,6 +728,12 @@
       "url": "https://inbloc.org",
       "tx_page": "https://inbloc.org/transactions/${txHash}",
       "account_page": "https://inbloc.org/account/${accountAddress}"
+    },
+    {
+      "kind": "WhisperNode 🤐",
+      "url": "https://mainnet.whispernode.com/cosmos",
+      "tx_page": "https://mainnet.whispernode.com/cosmos/tx/${txHash}",
+      "account_page": "https://mainnet.whispernode.com/cosmos/account/${accountAddress}"
     }
   ],
   "images": [

--- a/dymension/chain.json
+++ b/dymension/chain.json
@@ -542,6 +542,12 @@
       "url": "https://mainnet.explorer.aviaone.com/dymension",
       "tx_page": "https://mainnet.explorer.aviaone.com/dymension/tx/${txHash}",
       "account_page": "https://mainnet.explorer.aviaone.com/dymension/account/${accountAddress}"
+    },
+    {
+      "kind": "WhisperNode 🤐",
+      "url": "https://mainnet.whispernode.com/dymension",
+      "tx_page": "https://mainnet.whispernode.com/dymension/tx/${txHash}",
+      "account_page": "https://mainnet.whispernode.com/dymension/account/${accountAddress}"
     }
   ]
 }

--- a/empowerchain/chain.json
+++ b/empowerchain/chain.json
@@ -312,6 +312,12 @@
       "url": "https://explorer.declab.pro/Empower",
       "tx_page": "https://explorer.declab.pro/Empower/tx/${txHash}",
       "account_page": "https://explorer.declab.pro/Empower/account/{$accountAddress}"
+    },
+    {
+      "kind": "WhisperNode 🤐",
+      "url": "https://mainnet.whispernode.com/empowerchain",
+      "tx_page": "https://mainnet.whispernode.com/empowerchain/tx/${txHash}",
+      "account_page": "https://mainnet.whispernode.com/empowerchain/account/${accountAddress}"
     }
   ]
 }

--- a/gitopia/chain.json
+++ b/gitopia/chain.json
@@ -783,6 +783,12 @@
       "url": "https://explorer.declab.pro/Gitopia",
       "tx_page": "https://explorer.declab.pro/Gitopia/tx/${txHash}",
       "account_page": "https://explorer.declab.pro/Gitopia/account/${accountAddress}"
+    },
+    {
+      "kind": "WhisperNode 🤐",
+      "url": "https://mainnet.whispernode.com/gitopia",
+      "tx_page": "https://mainnet.whispernode.com/gitopia/tx/${txHash}",
+      "account_page": "https://mainnet.whispernode.com/gitopia/account/${accountAddress}"
     }
   ],
   "logo_URIs": {

--- a/injective/chain.json
+++ b/injective/chain.json
@@ -414,6 +414,12 @@
       "kind": "Stakeflow",
       "url": "https://stakeflow.io/injective",
       "account_page": "https://stakeflow.io/injective/accounts/${accountAddress}"
+    },
+    {
+      "kind": "WhisperNode 🤐",
+      "url": "https://mainnet.whispernode.com/injective",
+      "tx_page": "https://mainnet.whispernode.com/injective/tx/${txHash}",
+      "account_page": "https://mainnet.whispernode.com/injective/account/${accountAddress}"
     }
   ],
   "images": [

--- a/jackal/chain.json
+++ b/jackal/chain.json
@@ -449,6 +449,12 @@
       "kind": "Big Dipper",
       "url": "https://bigdipper.live/jackal",
       "tx_page": "https://bigdipper.live/jackal/transactions/${txHash}"
+    },
+    {
+      "kind": "WhisperNode 🤐",
+      "url": "https://mainnet.whispernode.com/jackal",
+      "tx_page": "https://mainnet.whispernode.com/jackal/tx/${txHash}",
+      "account_page": "https://mainnet.whispernode.com/jackal/account/${accountAddress}"
     }
   ],
   "images": [

--- a/juno/chain.json
+++ b/juno/chain.json
@@ -724,6 +724,12 @@
       "url": "https://explorer.nodeshub.online/juno/",
       "tx_page": "https://explorer.nodeshub.online/juno/tx/${txHash}",
       "account_page": "https://explorer.nodeshub.online/juno/accounts/${accountAddress}"
+    },
+    {
+      "kind": "WhisperNode 🤐",
+      "url": "https://mainnet.whispernode.com/juno",
+      "tx_page": "https://mainnet.whispernode.com/juno/tx/${txHash}",
+      "account_page": "https://mainnet.whispernode.com/juno/account/${accountAddress}"
     }
   ],
   "images": [

--- a/kujira/chain.json
+++ b/kujira/chain.json
@@ -536,6 +536,12 @@
       "url": "https://atomscan.com/kujira",
       "tx_page": "https://atomscan.com/kujira/transactions/${txHash}",
       "account_page": "https://atomscan.com/kujira/accounts/${accountAddress}"
+    },
+    {
+      "kind": "WhisperNode 🤐",
+      "url": "https://mainnet.whispernode.com/kujira",
+      "tx_page": "https://mainnet.whispernode.com/kujira/tx/${txHash}",
+      "account_page": "https://mainnet.whispernode.com/kujira/account/${accountAddress}"
     }
   ],
   "logo_URIs": {

--- a/neutron/chain.json
+++ b/neutron/chain.json
@@ -299,6 +299,12 @@
       "url": "https://ezstaking.app/neutron",
       "tx_page": "https://ezstaking.app/neutron/txs/${txHash}",
       "account_page": "https://ezstaking.app/neutron/account/${accountAddress}"
+    },
+    {
+      "kind": "WhisperNode 🤐",
+      "url": "https://mainnet.whispernode.com/neutron",
+      "tx_page": "https://mainnet.whispernode.com/neutron/tx/${txHash}",
+      "account_page": "https://mainnet.whispernode.com/neutron/account/${accountAddress}"
     }
   ],
   "images": [

--- a/nomic/chain.json
+++ b/nomic/chain.json
@@ -144,6 +144,12 @@
       "url": "https://nomic.zenscan.io/index.php",
       "account_page": "https://nomic.zenscan.io/address.php?address=${accountAddress}",
       "tx_page": "https://nomic.zenscan.io/transaction.php?hash=${txHash}"
+    },
+    {
+      "kind": "WhisperNode 🤐",
+      "url": "https://mainnet.whispernode.com/nomic",
+      "tx_page": "https://mainnet.whispernode.com/nomic/tx/${txHash}",
+      "account_page": "https://mainnet.whispernode.com/nomic/account/${accountAddress}"
     }
   ],
   "images": [

--- a/osmosis/chain.json
+++ b/osmosis/chain.json
@@ -533,6 +533,12 @@
       "kind": "Chainscope",
       "url": "https://chainsco.pe/osmosis",
       "tx_page": "https://chainsco.pe/osmosis/tx/${txHash}"
+    },
+    {
+      "kind": "WhisperNode 🤐",
+      "url": "https://mainnet.whispernode.com/osmosis",
+      "tx_page": "https://mainnet.whispernode.com/osmosis/tx/${txHash}",
+      "account_page": "https://mainnet.whispernode.com/osmosis/account/${accountAddress}"
     }
   ],
   "keywords": [

--- a/passage/chain.json
+++ b/passage/chain.json
@@ -397,6 +397,12 @@
       "url": "https://cosmotracker.com/passage",
       "tx_page": "https://cosmotracker.com/passage/tx/${txHash}",
       "account_page": "https://cosmotracker.com/passage/account/${accountAddress}"
+    },
+    {
+      "kind": "WhisperNode 🤐",
+      "url": "https://mainnet.whispernode.com/passage",
+      "tx_page": "https://mainnet.whispernode.com/passage/tx/${txHash}",
+      "account_page": "https://mainnet.whispernode.com/passage/account/${accountAddress}"
     }
   ],
   "logo_URIs": {

--- a/quasar/chain.json
+++ b/quasar/chain.json
@@ -323,6 +323,12 @@
       "url": "https://ezstaking.app/quasar",
       "tx_page": "https://ezstaking.app/quasar/txs/${txHash}",
       "account_page": "https://ezstaking.app/quasar/account/${accountAddress}"
+    },
+    {
+      "kind": "WhisperNode 🤐",
+      "url": "https://mainnet.whispernode.com/quasar",
+      "tx_page": "https://mainnet.whispernode.com/quasar/tx/${txHash}",
+      "account_page": "https://mainnet.whispernode.com/quasar/account/${accountAddress}"
     }
   ],
   "keywords": [

--- a/secretnetwork/chain.json
+++ b/secretnetwork/chain.json
@@ -314,6 +314,12 @@
       "url": "https://atomscan.com/secret-network",
       "tx_page": "https://atomscan.com/secret-network/transactions/${txHash}",
       "account_page": "https://atomscan.com/secret-network/accounts/${accountAddress}"
+    },
+    {
+      "kind": "WhisperNode 🤐",
+      "url": "https://mainnet.whispernode.com/secret",
+      "tx_page": "https://mainnet.whispernode.com/secret/tx/${txHash}",
+      "account_page": "https://mainnet.whispernode.com/secret/account/${accountAddress}"
     }
   ],
   "images": [

--- a/seda/chain.json
+++ b/seda/chain.json
@@ -91,6 +91,11 @@
         "id": "ebc272824924ea1a27ea3183dd0b9ba713494f83",
         "address": "seda-mainnet-seed.autostake.com:26866",
         "provider": "AutoStake 🛡️ Slash Protected"
+      },
+      {
+        "id": "c28827cb96c14c905b127b92065a3fb4cd77d7f6",
+        "address": "seeds.whispernode.com:25856",
+        "provider": "WhisperNode 🤐"
       }
     ],
     "persistent_peers": [
@@ -142,6 +147,10 @@
       {
         "address": "https://rpc.seda.bronbro.io:443",
         "provider": "Bro_n_Bro"
+      },
+      {
+        "address": "https://rpc-seda.whispernode.com:443",
+        "provider": "WhisperNode 🤐"
       }
     ],
     "rest": [
@@ -180,6 +189,10 @@
       {
         "address": "https://lcd.seda.bronbro.io:443",
         "provider": "Bro_n_Bro"
+      },
+      {
+        "address": "https://api-seda.whispernode.com:443",
+        "provider": "WhisperNode 🤐"
       }
     ],
     "grpc": [
@@ -206,6 +219,10 @@
       {
         "address": "https://grpc.seda.bronbro.io:443",
         "provider": "Bro_n_Bro"
+      },
+      {
+        "address": "grpc-seda.whispernode.com:443",
+        "provider": "WhisperNode 🤐"
       }
     ]
   },
@@ -221,6 +238,12 @@
       "url": "https://seda.explorers.guru",
       "tx_page": "https://seda.explorers.guru/transaction/${txHash}",
       "account_page": "https://seda.explorers.guru/account/${accountAddress}"
+    },
+    {
+      "kind": "WhisperNode 🤐",
+      "url": "https://mainnet.whispernode.com/seda",
+      "tx_page": "https://mainnet.whispernode.com/seda/tx/${txHash}",
+      "account_page": "https://mainnet.whispernode.com/seda/account/${accountAddress}"
     }
   ],
   "images": [

--- a/sei/chain.json
+++ b/sei/chain.json
@@ -351,7 +351,7 @@
         "provider": "AutoStake 🛡️ Slash Protected"
       },
       {
-        "address": "https://grpc-sei.whispernode.com:443",
+        "address": "grpc-sei.whispernode.com:443",
         "provider": "WhisperNode 🤐"
       },
       {
@@ -388,6 +388,12 @@
       "url": "https://www.seiscan.app/pacific-1",
       "tx_page": "https://www.seiscan.app/pacific-1/txs/${txHash}",
       "account_page": "https://www.seiscan.app/pacific-1/accounts/${accountAddress}"
+    },
+    {
+      "kind": "WhisperNode 🤐",
+      "url": "https://mainnet.whispernode.com/sei",
+      "tx_page": "https://mainnet.whispernode.com/sei/tx/${txHash}",
+      "account_page": "https://mainnet.whispernode.com/sei/account/${accountAddress}"
     }
   ],
   "images": [

--- a/sentinel/chain.json
+++ b/sentinel/chain.json
@@ -457,6 +457,12 @@
       "url": "https://explorer.nodeshub.online/sentinel/",
       "tx_page": "https://explorer.nodeshub.online/sentinel/tx/${txHash}",
       "account_page": "https://explorer.nodeshub.online/sentinel/accounts/${accountAddress}"
+    },
+    {
+      "kind": "WhisperNode 🤐",
+      "url": "https://mainnet.whispernode.com/sentinel",
+      "tx_page": "https://mainnet.whispernode.com/sentinel/tx/${txHash}",
+      "account_page": "https://mainnet.whispernode.com/sentinel/account/${accountAddress}"
     }
   ],
   "images": [

--- a/stargaze/chain.json
+++ b/stargaze/chain.json
@@ -411,6 +411,12 @@
       "url": "https://starscan.net/",
       "tx_page": "https://starscan.net/stargaze-1/tx/${txHash}",
       "account_page": "https://starscan.net/stargaze-1/address/${accountAddress}"
+    },
+    {
+      "kind": "WhisperNode 🤐",
+      "url": "https://mainnet.whispernode.com/stargaze",
+      "tx_page": "https://mainnet.whispernode.com/stargaze/tx/${txHash}",
+      "account_page": "https://mainnet.whispernode.com/stargaze/account/${accountAddress}"
     }
   ],
   "images": [

--- a/stratos/chain.json
+++ b/stratos/chain.json
@@ -165,6 +165,12 @@
       "url": "https://explorer.tcnetwork.io/stratos",
       "tx_page": "https://explorer.tcnetwork.io/stratos/transaction/${txHash}",
       "account_page": "https://explorer.tcnetwork.io/stratos/account/${accountAddress}"
+    },
+    {
+      "kind": "WhisperNode 🤐",
+      "url": "https://mainnet.whispernode.com/stratos",
+      "tx_page": "https://mainnet.whispernode.com/stratos/tx/${txHash}",
+      "account_page": "https://mainnet.whispernode.com/stratos/account/${accountAddress}"
     }
   ],
   "images": [

--- a/stride/chain.json
+++ b/stride/chain.json
@@ -688,6 +688,12 @@
       "url": "https://explorer.stake-take.com/stride",
       "tx_page": "https://explorer.stake-take.com/stride/tx/${txHash}",
       "account_page": "https://explorer.stake-take.com/stride/account/${accountAddress}"
+    },
+    {
+      "kind": "WhisperNode 🤐",
+      "url": "https://mainnet.whispernode.com/stride",
+      "tx_page": "https://mainnet.whispernode.com/stride/tx/${txHash}",
+      "account_page": "https://mainnet.whispernode.com/stride/account/${accountAddress}"
     }
   ],
   "logo_URIs": {


### PR DESCRIPTION
Added mainnet block explorer support for all chains we validate, as well as updated a few misc endpoint details.