### PR TITLE
remove mintscan explorer for deprecated networks

### DIFF
--- a/canto/chain.json
+++ b/canto/chain.json
@@ -221,12 +221,6 @@
       "tx_page": "https://cosmos-explorers.neobase.one/canto/tx/${txHash}"
     },
     {
-      "kind": "mintscan",
-      "url": "https://www.mintscan.io/canto",
-      "tx_page": "https://www.mintscan.io/canto/transactions/${txHash}",
-      "account_page": "https://www.mintscan.io/canto/accounts/${accountAddress}"
-    },
-    {
       "kind": "TC Network",
       "url": "https://explorer.tcnetwork.io/canto",
       "tx_page": "https://explorer.tcnetwork.io/canto/transaction/${txHash}"

--- a/crescent/chain.json
+++ b/crescent/chain.json
@@ -282,12 +282,6 @@
   },
   "explorers": [
     {
-      "kind": "mintscan",
-      "url": "https://www.mintscan.io/crescent",
-      "tx_page": "https://www.mintscan.io/crescent/transactions/${txHash}",
-      "account_page": "https://www.mintscan.io/crescent/accounts/${accountAddress}"
-    },
-    {
       "kind": "ezstaking",
       "url": "https://ezstaking.app/crescent",
       "tx_page": "https://ezstaking.app/crescent/txs/${txHash}",

--- a/emoney/chain.json
+++ b/emoney/chain.json
@@ -171,12 +171,6 @@
       "account_page": "https://ezstaking.app/emoney/account/${accountAddress}"
     },
     {
-      "kind": "mintscan",
-      "url": "https://www.mintscan.io/emoney",
-      "tx_page": "https://www.mintscan.io/emoney/transactions/${txHash}",
-      "account_page": "https://www.mintscan.io/emoney/accounts/${accountAddress}"
-    },
-    {
       "kind": "ping.pub",
       "url": "https://ping.pub/e-money",
       "tx_page": "https://ping.pub/e-money/tx/${txHash}"

--- a/regen/chain.json
+++ b/regen/chain.json
@@ -230,12 +230,6 @@
   },
   "explorers": [
     {
-      "kind": "mintscan",
-      "url": "https://www.mintscan.io/regen",
-      "tx_page": "https://www.mintscan.io/regen/transactions/${txHash}",
-      "account_page": "https://www.mintscan.io/regen/accounts/${accountAddress}"
-    },
-    {
       "kind": "ezstaking",
       "url": "https://ezstaking.app/regen",
       "tx_page": "https://ezstaking.app/regen/txs/${txHash}",


### PR DESCRIPTION
Removes mintscan as explorer for canto, crescent, emoney, and regen networks since support has been deprecated