### PR TITLE
remove deprecated canto explorers

### DIFF
--- a/canto/chain.json
+++ b/canto/chain.json
@@ -206,16 +206,6 @@
   },
   "explorers": [
     {
-      "kind": "bigdipper",
-      "url": "https://cosmos.explorer.canto.io",
-      "tx_page": "https://cosmos.explorer.canto.io/transactions/${txHash}"
-    },
-    {
-      "kind": "blockscout",
-      "url": "https://evm.explorer.canto.io/",
-      "tx_page": "https://evm.explorer.canto.io/tx/${txHash}"
-    },
-    {
       "kind": "ping.pub",
       "url": "https://cosmos-explorers.neobase.one/canto",
       "tx_page": "https://cosmos-explorers.neobase.one/canto/tx/${txHash}"


### PR DESCRIPTION
Removes the bigdipper and blockscout explorers for canto which have deprecated support for the chain.