### PR TITLE
Update README: fix cosmos coin-metadata link

### DIFF
--- a/README.md
+++ b/README.md
@@ -260,7 +260,7 @@ Asset Lists are inspired by the [Token Lists](https://tokenlists.org/) project o
 
 Asset lists are a similar mechanism to allow frontends and other UIs to fetch metadata associated with Cosmos SDK denoms, especially for assets sent over IBC.
 
-This standard is a work in progress.  You'll notice that the format of `assets` in the assetlist.json structure is a strict superset json representation of the [`banktypes.DenomMetadata`](https://docs.cosmos.network/master/architecture/adr-024-coin-metadata.html) from the Cosmos SDK.  This is purposefully done so that this standard may eventually be migrated into a Cosmos SDK module in the future, so it can be easily maintained on chain instead of on Github.
+This standard is a work in progress.  You'll notice that the format of `assets` in the assetlist.json structure is a strict superset json representation of the [`banktypes.DenomMetadata`](https://docs.cosmos.network/main/build/architecture/adr-024-coin-metadata) from the Cosmos SDK.  This is purposefully done so that this standard may eventually be migrated into a Cosmos SDK module in the future, so it can be easily maintained on chain instead of on Github.
 
 The assetlist JSON Schema can be found [here](/assetlist.schema.json).
 


### PR DESCRIPTION
Updated the link to `DenomMetadata` in cosmos docs 

The link that came before is no longer available

<img width="450" alt="image" src="https://github.com/cosmos/chain-registry/assets/25391690/53064e95-280b-47b7-ba74-eeaaec771456">
