### PR TITLE
Upgrade Evmos to v18.1.0 and update version history

### DIFF
--- a/evmos/chain.json
+++ b/evmos/chain.json
@@ -36,9 +36,9 @@
   },
   "codebase": {
     "git_repo": "https://github.com/evmos/evmos",
-    "recommended_version": "v17.0.0",
+    "recommended_version": "v18.1.0",
     "compatible_versions": [
-      "v17.0.0"
+      "v18.1.0"
     ],
     "cosmos_sdk_version": "evmos/cosmos-sdk v0.47.5-evmos.2",
     "consensus": {
@@ -47,11 +47,11 @@
     },
     "ibc_go_version": "7.4.0",
     "binaries": {
-      "linux/amd64": "https://github.com/evmos/evmos/releases/download/v17.0.0/evmos_17.0.0_Linux_amd64.tar.gz",
-      "linux/arm64": "https://github.com/evmos/evmos/releases/download/v17.0.0/evmos_17.0.0_Linux_arm64.tar.gz",
-      "darwin/amd64": "https://github.com/evmos/evmos/releases/download/v17.0.0/evmos_17.0.0_Darwin_amd64.tar.gz",
-      "darwin/arm64": "https://github.com/evmos/evmos/releases/download/v17.0.0/evmos_17.0.0_Darwin_arm64.tar.gz",
-      "windows/amd64": "https://github.com/evmos/evmos/releases/download/v17.0.0/evmos_17.0.0_Windows_amd64.zip"
+      "linux/amd64": "https://github.com/evmos/evmos/releases/download/v18.1.0/evmos_18.1.0_Linux_amd64.tar.gz",
+      "linux/arm64": "https://github.com/evmos/evmos/releases/download/v18.1.0/evmos_18.1.0_Linux_arm64.tar.gz",
+      "darwin/amd64": "https://github.com/evmos/evmos/releases/download/v18.1.0/evmos_18.1.0_Darwin_amd64.tar.gz",
+      "darwin/arm64": "https://github.com/evmos/evmos/releases/download/v18.1.0/evmos_18.1.0_Darwin_arm64.tar.gz",
+      "windows/amd64": "https://github.com/evmos/evmos/releases/download/v18.1.0/evmos_18.1.0_Windows_amd64.zip"
     },
     "genesis": {
       "genesis_url": "https://archive.evmos.org/mainnet/genesis.json"
@@ -183,11 +183,11 @@
       },
       {
         "name": "v17.0.0",
-        "tag": "v17.0.0",
+        "tag": "v17.0.1",
         "height": 20101000,
-        "recommended_version": "v17.0.0",
+        "recommended_version": "v17.0.1",
         "compatible_versions": [
-          "v17.0.0"
+          "v17.0.1"
         ],
         "cosmos_sdk_version": "evmos/cosmos-sdk v0.47.5-evmos.2",
         "consensus": {
@@ -201,6 +201,52 @@
           "darwin/amd64": "https://github.com/evmos/evmos/releases/download/v17.0.0/evmos_17.0.0_Darwin_amd64.tar.gz",
           "darwin/arm64": "https://github.com/evmos/evmos/releases/download/v17.0.0/evmos_17.0.0_Darwin_arm64.tar.gz",
           "windows/amd64": "https://github.com/evmos/evmos/releases/download/v17.0.0/evmos_17.0.0_Windows_amd64.zip"
+        },
+        "next_version_name": "v18.0.0"
+      },
+      {
+        "name": "v18.0.0",
+        "tag": "v18.0.1",
+        "height": 20396852,
+        "recommended_version": "v17.0.0",
+        "compatible_versions": [
+          "v18.0.1"
+        ],
+        "cosmos_sdk_version": "evmos/cosmos-sdk v0.47.5-evmos.2",
+        "consensus": {
+          "type": "cometbft",
+          "version": "v0.37.4"
+        },
+        "ibc_go_version": "7.4.0",
+        "binaries": {
+          "linux/amd64": "https://github.com/evmos/evmos/releases/download/v18.0.1/evmos_18.0.1_Linux_amd64.tar.gz",
+          "linux/arm64": "https://github.com/evmos/evmos/releases/download/v18.0.1/evmos_18.0.1_Linux_arm64.tar.gz",
+          "darwin/amd64": "https://github.com/evmos/evmos/releases/download/v18.0.1/evmos_18.0.1_Darwin_amd64.tar.gz",
+          "darwin/arm64": "https://github.com/evmos/evmos/releases/download/v18.0.1/evmos_18.0.1_Darwin_arm64.tar.gz",
+          "windows/amd64": "https://github.com/evmos/evmos/releases/download/v18.0.1/evmos_18.0.1_Windows_amd64.zip"
+        },
+        "next_version_name": "v18.1.0"
+      },
+      {
+        "name": "v18.1.0",
+        "tag": "v18.1.0",
+        "height": 21209000,
+        "recommended_version": "v18.1.0",
+        "compatible_versions": [
+          "v18.1.0"
+        ],
+        "cosmos_sdk_version": "evmos/cosmos-sdk v0.47.5-evmos.2",
+        "consensus": {
+          "type": "cometbft",
+          "version": "v0.37.4"
+        },
+        "ibc_go_version": "7.4.0",
+        "binaries": {
+          "linux/amd64": "https://github.com/evmos/evmos/releases/download/v18.1.0/evmos_18.1.0_Linux_amd64.tar.gz",
+          "linux/arm64": "https://github.com/evmos/evmos/releases/download/v18.1.0/evmos_18.1.0_Linux_arm64.tar.gz",
+          "darwin/amd64": "https://github.com/evmos/evmos/releases/download/v18.1.0/evmos_18.1.0_Darwin_amd64.tar.gz",
+          "darwin/arm64": "https://github.com/evmos/evmos/releases/download/v18.1.0/evmos_18.1.0_Darwin_arm64.tar.gz",
+          "windows/amd64": "https://github.com/evmos/evmos/releases/download/v18.1.0/evmos_18.1.0_Windows_amd64.zip"
         },
         "next_version_name": ""
       }

--- a/evmos/chain.json
+++ b/evmos/chain.json
@@ -196,11 +196,11 @@
         },
         "ibc_go_version": "7.4.0",
         "binaries": {
-          "linux/amd64": "https://github.com/evmos/evmos/releases/download/v17.0.0/evmos_17.0.0_Linux_amd64.tar.gz",
-          "linux/arm64": "https://github.com/evmos/evmos/releases/download/v17.0.0/evmos_17.0.0_Linux_arm64.tar.gz",
-          "darwin/amd64": "https://github.com/evmos/evmos/releases/download/v17.0.0/evmos_17.0.0_Darwin_amd64.tar.gz",
-          "darwin/arm64": "https://github.com/evmos/evmos/releases/download/v17.0.0/evmos_17.0.0_Darwin_arm64.tar.gz",
-          "windows/amd64": "https://github.com/evmos/evmos/releases/download/v17.0.0/evmos_17.0.0_Windows_amd64.zip"
+          "linux/amd64": "https://github.com/evmos/evmos/releases/download/v17.0.1/evmos_17.0.1_Linux_amd64.tar.gz",
+          "linux/arm64": "https://github.com/evmos/evmos/releases/download/v17.0.1/evmos_17.0.1_Linux_arm64.tar.gz",
+          "darwin/amd64": "https://github.com/evmos/evmos/releases/download/v17.0.1/evmos_17.0.1_Darwin_amd64.tar.gz",
+          "darwin/arm64": "https://github.com/evmos/evmos/releases/download/v17.0.1/evmos_17.0.1_Darwin_arm64.tar.gz",
+          "windows/amd64": "https://github.com/evmos/evmos/releases/download/v17.0.1/evmos_17.0.1_Windows_amd64.zip"
         },
         "next_version_name": "v18.0.0"
       },

--- a/evmos/chain.json
+++ b/evmos/chain.json
@@ -208,7 +208,7 @@
         "name": "v18.0.0",
         "tag": "v18.0.1",
         "height": 20396852,
-        "recommended_version": "v17.0.0",
+        "recommended_version": "v18.0.1",
         "compatible_versions": [
           "v18.0.1"
         ],


### PR DESCRIPTION
This is a non-prop hardfork upgrade. The upgrade_handler for 18.1.0 is staged via the v18.0.1 patch for v18.0.0. Same situation for v17.0.0 to v18.0.0. Old binaries have been removed as the "patched binaries" are required to detect the upgrade_handler.