### PR TITLE
Fix Penumbra logo paths, clean up token denoms

### DIFF
--- a/_non-cosmos/penumbra/assetlist.json
+++ b/_non-cosmos/penumbra/assetlist.json
@@ -7,16 +7,12 @@
       "extended_description": "A fully private, cross-chain proof-of-stake network and decentralized exchange for the Cosmos and beyond.",
       "denom_units": [
         {
-          "denom": "penumbra",
-          "exponent": 6
-        },
-        {
-          "denom": "mpenumbra",
-          "exponent": 3
-        },
-        {
           "denom": "upenumbra",
           "exponent": 0
+        },
+        {
+          "denom": "penumbra",
+          "exponent": 6
         }
       ],
       "type_asset": "unknown",
@@ -27,9 +23,12 @@
       "images": [
         {
           "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/penumbra/images/um.png",
-          "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/penumbra/images/um.svg"
-        }
-      ],
+          "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/penumbra/images/um.svg",
+      "theme": {
+          "circle": true
+      }
+    }
+  ],
       "socials": {
         "website": "https://penumbra.zone/",
         "twitter": "https://twitter.com/penumbrazone"

--- a/_non-cosmos/penumbra/assetlist.json
+++ b/_non-cosmos/penumbra/assetlist.json
@@ -24,11 +24,11 @@
         {
           "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/_non-cosmos/penumbra/images/um.png",
           "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/_non-cosmos/penumbra/images/um.svg",
-      "theme": {
-          "circle": true
-      }
-    }
-  ],
+          "theme": {
+            "circle": true
+          }
+        }
+      ],
       "socials": {
         "website": "https://penumbra.zone/",
         "twitter": "https://twitter.com/penumbrazone"

--- a/_non-cosmos/penumbra/assetlist.json
+++ b/_non-cosmos/penumbra/assetlist.json
@@ -22,8 +22,8 @@
       "name": "Penumbra",
       "images": [
         {
-          "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/penumbra/images/um.png",
-          "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/penumbra/images/um.svg",
+          "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/_non-cosmos/penumbra/images/um.png",
+          "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/_non-cosmos/penumbra/images/um.svg",
       "theme": {
           "circle": true
       }


### PR DESCRIPTION
## Minor fixes

 - Remove 'exponent 3' denom
 - Re-order denoms [base >> 'exponent 6']
 - Add 'circle' property
 - Fix logo image URLs