### PR TITLE
Remove logo_URIs from Onomy

### DIFF
--- a/onomy/chain.json
+++ b/onomy/chain.json
@@ -122,9 +122,6 @@
       }
     ]
   },
-  "logo_URIs": {
-    "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/onomy/images/nom.png"
-  },
   "peers": {
     "seeds": [
       {
@@ -208,7 +205,8 @@
   ],
   "images": [
     {
-      "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/onomy/images/nom.png"
+      "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/onomy/images/nom.png",
+      "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/onomy/images/nom.svg"
     }
   ]
 }


### PR DESCRIPTION
Remove logo_URIs from Onomy
There were two duplicate properties for logo_URIs.
We should use `images`. Added svg to images