### PR TITLE
deprecate BERLIN

### DIFF
--- a/evmos/assetlist.json
+++ b/evmos/assetlist.json
@@ -111,21 +111,21 @@
       }
     },
     {
-      "description": "The token of Teledisko DAO.",
+      "description": "The legacy token of Teledisko DAO.",
       "denom_units": [
         {
           "denom": "erc20/0x1cFc8f1FE8D5668BAFF2724547EcDbd6f013a280",
           "exponent": 0
         },
         {
-          "denom": "berlin",
+          "denom": "berlin-legacy",
           "exponent": 18
         }
       ],
       "base": "erc20/0x1cFc8f1FE8D5668BAFF2724547EcDbd6f013a280",
-      "name": "Teledisko DAO",
-      "display": "berlin",
-      "symbol": "BERLIN",
+      "name": "Teledisko DAO - Legacy",
+      "display": "berlin-legacy",
+      "symbol": "BERLIN-legacy",
       "type_asset": "erc20",
       "address": "0x1cFc8f1FE8D5668BAFF2724547EcDbd6f013a280",
       "logo_URIs": {


### PR DESCRIPTION
We are going to transition to a new type of token on the EVMOS chain which will allow us to have a native IBC BERLIN token in the future. Reason why we are deprecating the current BERLIN token into a legacy token.