### PR TITLE
add back logo uri objects for shitmos so skip protocol works

### DIFF
--- a/migaloo/assetlist.json
+++ b/migaloo/assetlist.json
@@ -690,7 +690,11 @@
           "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/osmosis/images/shitmos.png",
           "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/osmosis/images/shitmos.svg"
         }
-      ]
+      ],
+      "logo_URIs": {
+        "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/osmosis/images/shitmos.png",
+        "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/osmosis/images/shitmos.svg"
+      }
     }
   ]
 }

--- a/osmosis/assetlist.json
+++ b/osmosis/assetlist.json
@@ -18111,6 +18111,10 @@
       "name": "Shitmos",
       "display": "SHITMOS",
       "symbol": "SHITMOS",
+      "logo_URIs":{
+        "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/osmosis/images/shitmos.png",
+        "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/osmosis/images/shitmos.svg"
+      },
       "images": [
         {
           "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/osmosis/images/shitmos.png",


### PR DESCRIPTION
Previously pushed assetlist.json code for shitmos on Migaloo chain, and was asked to remove the "logo_URIs" object because it had been deprecated. I was confused because I could see that many assets use that object. I complied, but this PR reverses that change. The removal of the logo URI object from the osmosis side and migaloo side has made shitmos no longer compatible with skip protocol's IBC Fun, which is crucial infrastructure for shitmos users.

See screenshot of conversation with Skip Protocol dev:
![Screenshot 2024-06-08 214625](https://github.com/cosmos/chain-registry/assets/80084774/3e304937-685c-445d-9a25-8e373d294ef0)
