### PR TITLE
Add explorer links to chain schema + added Cosmos Hub explorer links

### DIFF
--- a/chain.schema.json
+++ b/chain.schema.json
@@ -585,6 +585,15 @@
         },
         "account_page": {
           "type": "string"
+        },
+        "validator_page": {
+          "type": "string"
+        },
+        "proposal_page": {
+          "type": "string"
+        },
+        "block_page": {
+          "type": "string"
         }
       },
       "additionalProperties": false

--- a/cosmoshub/chain.json
+++ b/cosmoshub/chain.json
@@ -688,24 +688,37 @@
       "kind": "mintscan",
       "url": "https://www.mintscan.io/cosmos",
       "tx_page": "https://www.mintscan.io/cosmos/transactions/${txHash}",
-      "account_page": "https://www.mintscan.io/cosmos/accounts/${accountAddress}"
+      "account_page": "https://www.mintscan.io/cosmos/accounts/${accountAddress}",
+      "validator_page": "https://www.mintscan.io/cosmos/validators/${validatorAddress}",
+      "proposal_page": "https://www.mintscan.io/cosmos/proposals/${proposalId}",
+      "block_page": "https://www.mintscan.io/cosmos/blocks/${blockHeight}"
     },
     {
       "kind": "ezstaking",
       "url": "https://ezstaking.app/cosmoshub",
       "tx_page": "https://ezstaking.app/cosmoshub/txs/${txHash}",
-      "account_page": "https://ezstaking.app/cosmoshub/account/${accountAddress}"
+      "account_page": "https://ezstaking.app/cosmoshub/account/${accountAddress}",
+      "validator_page": "https://ezstaking.app/cosmoshub/validators/${validatorAddress}",
+      "proposal_page": "https://ezstaking.app/cosmoshub/proposals/${proposalId}",
+      "block_page": "https://ezstaking.app/cosmoshub/blocks/${blockHeight}"
     },
     {
       "kind": "ping.pub",
       "url": "https://ping.pub/cosmos",
-      "tx_page": "https://ping.pub/cosmos/tx/${txHash}"
+      "tx_page": "https://ping.pub/cosmos/tx/${txHash}",
+      "account_page": "https://ping.pub/cosmos/account/${accountAddress}",
+      "validator_page": "https://ping.pub/cosmos/staking/${validatorAddress}",
+      "proposal_page": "https://ping.pub/cosmos/gov/${proposalId}",
+      "block_page": "https://ping.pub/cosmos/block/${blockHeight}"
     },
     {
       "kind": "atomscan",
       "url": "https://atomscan.com",
       "tx_page": "https://atomscan.com/transactions/${txHash}",
-      "account_page": "https://atomscan.com/accounts/${accountAddress}"
+      "account_page": "https://atomscan.com/accounts/${accountAddress}",
+      "validator_page": "https://atomscan.com/validators/${validatorAddress}",
+      "proposal_page": "https://atomscan.com/votes/${proposalId}",
+      "block_page": "https://atomscan.com/blocks/${blockHeight}"
     },
     {
       "kind": "unichain",
@@ -715,29 +728,39 @@
     {
       "kind": "TC Network",
       "url": "https://explorer.tcnetwork.io/cosmoshub",
-      "tx_page": "https://explorer.tcnetwork.io/cosmoshub/transaction/${txHash}"
+      "tx_page": "https://explorer.tcnetwork.io/cosmoshub/transaction/${txHash}",
+      "account_page": "https://explorer.tcnetwork.io/cosmoshub/account/${accountAddress}",
+      "validator_page": "https://explorer.tcnetwork.io/cosmoshub/validator/${validatorAddress}",
+      "proposal_page": "https://explorer.tcnetwork.io/cosmoshub/proposal/${proposalId}",
+      "block_page": "https://explorer.tcnetwork.io/cosmoshub/block/${blockHeight}"
     },
     {
       "kind": "Stakeflow",
       "url": "https://stakeflow.io/cosmos",
-      "account_page": "https://stakeflow.io/cosmos/accounts/${accountAddress}"
+      "account_page": "https://stakeflow.io/cosmos/accounts/${accountAddress}",
+      "validator_page": "https://stakeflow.io/cosmos/validators/${validatorAddress}"
     },
     {
       "kind": "Nodeist Explorer",
-      "url": "https://exp.nodeist.net/cosmos",
-      "tx_page": "https://exp.nodeist.net/cosmos/tx/${txHash}"
+      "url": "https://exp.nodeist.net/cosmos"
     },
     {
       "kind": "Inbloc",
       "url": "https://inbloc.org",
       "tx_page": "https://inbloc.org/transactions/${txHash}",
-      "account_page": "https://inbloc.org/account/${accountAddress}"
+      "account_page": "https://inbloc.org/account/${accountAddress}",
+      "validator_page": "https://inbloc.org/cosmos/validator/${validatorAddress}",
+      "proposal_page": "https://inbloc.org/cosmos/proposal/${proposalId}",
+      "block_page": "https://inbloc.org/cosmos/blocks/${blockHeight}"
     },
     {
       "kind": "WhisperNode 🤐",
       "url": "https://mainnet.whispernode.com/cosmos",
       "tx_page": "https://mainnet.whispernode.com/cosmos/tx/${txHash}",
-      "account_page": "https://mainnet.whispernode.com/cosmos/account/${accountAddress}"
+      "account_page": "https://mainnet.whispernode.com/cosmos/account/${accountAddress}",
+      "validator_page": "https://mainnet.whispernode.com/cosmos/staking/${validatorAddress}",
+      "proposal_page": "https://mainnet.whispernode.com/cosmos/gov/${proposalId}",
+      "block_page": "https://mainnet.whispernode.com/cosmos/block/${blockHeight}"
     }
   ],
   "images": [


### PR DESCRIPTION
Fixes #3983.

Added validator_page, proposal_page and block_page into explorer schema, also added these links to all Cosmos Hub pages as a proof of concept.