### PR TITLE
Add socials, memecoin keyword, and extended description per Osmosis

### DIFF
--- a/osmosis/assetlist.json
+++ b/osmosis/assetlist.json
@@ -18094,7 +18094,8 @@
       ]
     },
     {
-      "description": "Like cosmos, but shit",
+      "description": "The Cosmos Network's premier self-hatred memecoin.",
+      "extended_description": "Shitmos is a fair launched token deployed via the start.cooking liquidity bootstrapping protocol (LBP) on the Osmosis blockchain. It is powered by the Shitmos Economic Zone (SEZ), and it has been designed with the goal of uniting the Cosmos Network and interchain-at-large ecosystems by making crypto fun. The SEZ is a federation of nft collections on Stargaze that supports Shitmos by providing at least 2% of royalties towards open market purchases of Shitmos.",
       "denom_units": [
         {
           "denom": "factory/osmo1q77cw0mmlluxu0wr29fcdd0tdnh78gzhkvhe4n6ulal9qvrtu43qtd0nh8/shitmos",
@@ -18120,7 +18121,14 @@
           "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/osmosis/images/shitmos.png",
           "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/osmosis/images/shitmos.svg"
         }
-      ]
+      ],
+      "keywords": [
+        "memecoin"
+      ],
+      "socials":{
+        "website": "https://shitmos.wtf",
+        "twitter": "https://twitter.com/shitoncosmos"
+      }
     },
     {
       "description": "Quicksilver Liquid Staked JUNO",


### PR DESCRIPTION
To get the shitmos asset as a verified asset on osmosis, the following new objects have been added to the cosmos chain-restistry entry for shitmos on the Osmosis blockchain:
- extended description
- socials
- keywords

Thank you!