### PR TITLE
Fix explorer entries Cronos POS Chain

### DIFF
--- a/cronos/chain.json
+++ b/cronos/chain.json
@@ -174,10 +174,9 @@
       "tx_page": "https://cronos.org/explorer/tx/${txHash}"
     },
     {
-      "kind": "ezstaking",
-      "url": "https://ezstaking.app/cronos",
-      "tx_page": "https://ezstaking.app/cronos/txs/${txHash}",
-      "account_page": "https://ezstaking.app/cronos/account/${accountAddress}"
+      "kind": "ping.pub",
+      "url": "https://ping.pub/cronos",
+      "tx_page": "https://ping.pub/cronos/tx/${txHash}"
     }
   ],
   "images": [

--- a/cryptoorgchain/chain.json
+++ b/cryptoorgchain/chain.json
@@ -223,11 +223,6 @@
       "kind": "ping.pub",
       "url": "https://ping.pub/crypto-com-chain",
       "tx_page": "https://ping.pub/crypto-com-chain/tx/${txHash}"
-    },
-    {
-      "kind": "yummy-explorer",
-      "url": "https://explorer.yummy.capital",
-      "tx_page": "https://explorer.yummy.capital/txs/${txHash}"
     }
   ],
   "images": [


### PR DESCRIPTION
Incorrect explorer entry for EZStaking (was for "Cronos POS Chain", not "Cronos EVM Chain"). Removed Yummy explorer from Cronos POS Chain (no longer available)