### PR TITLE
Update `ibc` archway-doravota

### DIFF
--- a/_IBC/archway-doravota.json
+++ b/_IBC/archway-doravota.json
@@ -2,22 +2,22 @@
   "$schema": "../ibc_data.schema.json",
   "chain_1": {
     "chain_name": "archway",
-    "client_id": "07-tendermint-66",
-    "connection_id": "connection-72"
+    "client_id": "07-tendermint-113",
+    "connection_id": "connection-106"
   },
   "chain_2": {
     "chain_name": "doravota",
-    "client_id": "07-tendermint-20",
-    "connection_id": "connection-24"
+    "client_id": "07-tendermint-22",
+    "connection_id": "connection-28"
   },
   "channels": [
     {
       "chain_1": {
-        "channel_id": "channel-101",
+        "channel_id": "channel-146",
         "port_id": "transfer"
       },
       "chain_2": {
-        "channel_id": "channel-10",
+        "channel_id": "channel-13",
         "port_id": "transfer"
       },
       "ordering": "unordered",


### PR DESCRIPTION
Previous channels between archway and doravota weren't used in production, the clients have timed out. CryptoCrew is maintaining the new channels