### PR TITLE
Patch Juno to v22.0.1

### DIFF
--- a/juno/chain.json
+++ b/juno/chain.json
@@ -40,12 +40,12 @@
   },
   "codebase": {
     "git_repo": "https://github.com/CosmosContracts/juno",
-    "recommended_version": "v22.0.0",
+    "recommended_version": "v22.0.1",
     "compatible_versions": [
-      "v22.0.0"
+      "v22.0.1"
     ],
     "binaries": {
-      "linux/amd64": "https://github.com/CosmosContracts/juno/releases/download/v22.0.0/junod"
+      "linux/amd64": "https://github.com/CosmosContracts/juno/releases/download/v22.0.1/junod"
     },
     "cosmos_sdk_version": "v0.47.11-0.20240417094812-f556fd956fb1",
     "consensus": {
@@ -234,12 +234,12 @@
         "name": "v22",
         "proposal": 347,
         "height": 15873890,
-        "recommended_version": "v22.0.0",
+        "recommended_version": "v22.0.1",
         "compatible_versions": [
-          "v22.0.0"
+          "v22.0.1"
         ],
         "binaries": {
-          "linux/amd64": "https://github.com/CosmosContracts/juno/releases/download/v22.0.0/junod"
+          "linux/amd64": "https://github.com/CosmosContracts/juno/releases/download/v22.0.1/junod"
         },
         "cosmos_sdk_version": "v0.47.11-0.20240417094812-f556fd956fb1",
         "consensus": {


### PR DESCRIPTION
v22.0.1 is the only compatible version, validators who did not patch led to a chain halt.