### PR TITLE
Update Odin chain.json after successful upgrade

### DIFF
--- a/odin/chain.json
+++ b/odin/chain.json
@@ -34,16 +34,16 @@
   },
   "codebase": {
     "git_repo": "https://github.com/ODIN-PROTOCOL/odin-core",
-    "recommended_version": "v0.7.12",
+    "recommended_version": "v0.8.3",
     "compatible_versions": [
-      "v0.7.12"
+      "v0.8.3"
     ],
-    "cosmos_sdk_version": "v0.47.7",
+    "cosmos_sdk_version": "v0.50.7",
     "consensus": {
       "type": "cometbft",
-      "version": "v0.37.4"
+      "version": "v0.38.7"
     },
-    "ibc_go_version": "v7.3.0",
+    "ibc_go_version": "v8.2.0",
     "genesis": {
       "genesis_url": "https://snapshots.polkachu.com/genesis/odin/genesis.json"
     },
@@ -92,6 +92,22 @@
           "version": "v0.37.4"
         },
         "ibc_go_version": "v7.3.0",
+        "next_version_name": "v0.8.3"
+      },
+      {
+        "name": "v0.8.3",
+        "proposal": 25,
+        "height": 15076000,
+        "recommended_version": "v0.8.3",
+        "compatible_versions": [
+          "v0.8.3"
+        ],
+        "cosmos_sdk_version": "v0.50.7",
+        "consensus": {
+          "type": "cometbft",
+          "version": "v0.38.7"
+        },
+        "ibc_go_version": "v8.2.0",
         "next_version_name": ""
       }
     ]


### PR DESCRIPTION
We have upgraded our mainnet to core v0.8.3 which is based on CosmosSDK 0.50.7 and CometBFT 0.38.7 and want to reflect updated versions in chain.json