### PR TITLE
Fix Trace types for frxETH and sfrxETH

### DIFF
--- a/_non-cosmos/ethereum/assetlist.json
+++ b/_non-cosmos/ethereum/assetlist.json
@@ -497,7 +497,7 @@
       "symbol": "frxETH",
       "traces": [
         {
-          "type": "liquid-stake",
+          "type": "synthetic",
           "counterparty": {
             "chain_name": "ethereum",
             "base_denom": "wei"
@@ -540,7 +540,7 @@
       "symbol": "sfrxETH",
       "traces": [
         {
-          "type": "wrapped",
+          "type": "liquid-stake",
           "counterparty": {
             "chain_name": "ethereum",
             "base_denom": "0x5e8422345238f34275888049021821e8e08caa1f"


### PR DESCRIPTION
despite the description claiming that frxETH is a liquid staking derivative, it is definitely NOT--but just a synthetic version.
sfrxETH is the liquid-staked version of frxETH.