### PR TITLE
Add files for the cosmos ICS testnet

### DIFF
--- a/testnets/cosmosicstestnet/assetlist.json
+++ b/testnets/cosmosicstestnet/assetlist.json
@@ -1,0 +1,38 @@
+{
+  "$schema": "../../assetlist.schema.json",
+  "chain_name": "cosmosicstestnet",
+  "assets": [
+    {
+      "description": "The staking and governance token of the Cosmos ICS testnet.",
+      "denom_units": [
+        {
+          "denom": "uatom",
+          "exponent": 0
+        },
+        {
+          "denom": "atom",
+          "exponent": 6
+        }
+      ],
+      "base": "uatom",
+      "name": "Cosmos ICS Testnet Atom",
+      "display": "atom",
+      "symbol": "ATOM",
+      "logo_URIs": {
+        "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/cosmoshub/images/atom.png",
+        "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/cosmoshub/images/atom.svg"
+      },
+      "coingecko_id": "cosmos",
+      "images": [
+        {
+          "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/cosmoshub/images/atom.png",
+          "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/cosmoshub/images/atom.svg"
+        }
+      ],
+      "socials": {
+        "website": "https://cosmos.network",
+        "twitter": "https://twitter.com/cosmoshub"
+      }
+    }
+  ]
+}

--- a/testnets/cosmosicstestnet/chain.json
+++ b/testnets/cosmosicstestnet/chain.json
@@ -1,0 +1,141 @@
+{
+  "$schema": "../../chain.schema.json",
+  "chain_name": "cosmosicstestnet",
+  "status": "live",
+  "network_type": "testnet",
+  "pretty_name": "Cosmos ICS Testnet",
+  "chain_id": "provider",
+  "bech32_prefix": "cosmos",
+  "daemon_name": "gaiad",
+  "node_home": "$HOME/.gaia",
+  "key_algos": [
+    "secp256k1"
+  ],
+  "slip44": 118,
+  "fees": {
+    "fee_tokens": [
+      {
+        "denom": "uatom",
+        "fixed_min_gas_price": 0.005,
+        "low_gas_price": 0.01,
+        "average_gas_price": 0.025,
+        "high_gas_price": 0.03
+      }
+    ]
+  },
+  "staking": {
+    "staking_tokens": [
+      {
+        "denom": "uatom"
+      }
+    ]
+  },
+  "codebase": {
+    "git_repo": "https://github.com/cosmos/gaia",
+    "recommended_version": "v18.0.0-rc3",
+    "compatible_versions": [
+      "v18.0.0-rc3"
+    ],
+    "cosmos_sdk_version": "v0.47.16-ics-lsm",
+    "ibc_go_version": "v7.6.0",
+    "consensus": {
+      "type": "cometbft",
+      "version": "v0.37.6"
+    },
+    "binaries": {
+      "linux/amd64": "https://github.com/cosmos/gaia/releases/download/v18.0.0-rc3/gaiad-v18.0.0-rc3-linux-amd64",
+      "linux/arm64": "https://github.com/cosmos/gaia/releases/download/v18.0.0-rc3/gaiad-v18.0.0-rc3-linux-arm64",
+      "darwin/amd64": "https://github.com/cosmos/gaia/releases/download/v18.0.0-rc3/gaiad-v18.0.0-rc3-darwin-amd64",
+      "darwin/arm64": "https://github.com/cosmos/gaia/releases/download/v18.0.0-rc3/gaiad-v18.0.0-rc3-darwin-arm64",
+      "windows/amd64": "https://github.com/cosmos/gaia/releases/download/v18.0.0-rc3/gaiad-v18.0.0-rc3-darwin-amd64",
+      "windows/arm64": "https://github.com/cosmos/gaia/releases/download/v18.0.0-rc3/gaiad-v18.0.0-rc3-windows-arm64.exe"
+    },
+    "genesis": {
+      "genesis_url": "https://raw.githubusercontent.com/cosmos/testnets/master/interchain-security/provider/provider-genesis.json"
+    },
+    "versions": [
+      {
+        "name": "v18",
+        "tag": "v18.0.0-rc3",
+        "proposal": 914,
+        "height": 20440500,
+        "recommended_version": "v18.0.0-rc3",
+        "compatible_versions": [
+          "v18.0.0-rc3"
+        ],
+        "cosmos_sdk_version": "v0.47.13-ics-lsm",
+        "ibc_go_version": "v7.4.0",
+        "consensus": {
+          "type": "cometbft",
+          "version": "v0.37.5"
+        },
+        "binaries": {
+          "linux/amd64": "https://github.com/cosmos/gaia/releases/download/v18.0.0-rc3/gaiad-v18.0.0-rc3-linux-amd64",
+          "linux/arm64": "https://github.com/cosmos/gaia/releases/download/v18.0.0-rc3/gaiad-v18.0.0-rc3-linux-arm64",
+          "darwin/amd64": "https://github.com/cosmos/gaia/releases/download/v18.0.0-rc3/gaiad-v18.0.0-rc3-darwin-amd64",
+          "darwin/arm64": "https://github.com/cosmos/gaia/releases/download/v18.0.0-rc3/gaiad-v18.0.0-rc3-darwin-arm64",
+          "windows/amd64": "https://github.com/cosmos/gaia/releases/download/v18.0.0-rc3/gaiad-v18.0.0-rc3-darwin-amd64",
+          "windows/arm64": "https://github.com/cosmos/gaia/releases/download/v18.0.0-rc3/gaiad-v18.0.0-rc3-windows-arm64.exe"
+        },
+        "next_version_name": "v19"
+      }
+    ]
+  },
+  "peers": {
+    "seeds": [
+      {
+        "id": "08ec17e86dac67b9da70deb20177655495a55407",
+        "address": "provider-seed-01.ics-testnet.polypore.xyz:26656"
+      },
+      {
+        "id": "4ea6e56300a2f37b90e58de5ee27d1c9065cf871",
+        "address": "provider-seed-02.ics-testnet.polypore.xyz:26656"
+      }
+    ]
+  },
+  "apis": {
+    "rpc": [
+      {
+        "address": "https://rpc.provider-sentry-01.rs-testnet.polypore.xyz",
+        "provider": "hypha"
+      },
+      {
+        "address": "https://rpc.provider-sentry-02.rs-testnet.polypore.xyz",
+        "provider": "hypha"
+      }
+    ],
+    "rest": [
+      {
+        "address": "https://rest.provider-sentry-01.rs-testnet.polypore.xyz",
+        "provider": "hypha"
+      },
+      {
+        "address": "https://rest.provider-sentry-02.rs-testnet.polypore.xyz",
+        "provider": "hypha"
+      }
+    ],
+    "grpc": [
+      {
+        "address": "https://grpc.provider-sentry-01.rs-testnet.polypore.xyz",
+        "provider": "hypha"
+      },
+      {
+        "address": "https://grpc.provider-sentry-02.rs-testnet.polypore.xyz",
+        "provider": "hypha"
+      }
+    ]
+  },
+  "explorers": [
+    {
+      "url": "https://explorer.polypore.xyz/provider",
+      "tx_page": "$https://explorer.polypore.xyz/provider/tx/{txHash}",
+      "account_page": "https://explorer.polypore.xyz/provider/account/${accountAddress}"
+    }
+  ],
+  "images": [
+    {
+      "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/cosmoshub/images/atom.png",
+      "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/cosmoshub/images/atom.svg"
+    }
+  ]
+}


### PR DESCRIPTION
This is the ICS testnet administered by Hypha worker coop. You can learn more about it [here](https://github.com/cosmos/testnets/tree/master/interchain-security/provider)