### PR TITLE
Rename the RS provider testnet to Cosmos ICS Provider testnet

### DIFF
--- a/testnets/cosmosicsprovidertestnet/assetlist.json
+++ b/testnets/cosmosicsprovidertestnet/assetlist.json
@@ -1,9 +1,9 @@
 {
   "$schema": "../../assetlist.schema.json",
-  "chain_name": "rsprovidertestnet",
+  "chain_name": "cosmosicsprovidertestnet",
   "assets": [
     {
-      "description": "The native staking and governance token of the Replicated Security Testnet.",
+      "description": "The native staking and governance token for the Cosmos ICS Provider Testnet.",
       "denom_units": [
         {
           "denom": "uatom",

--- a/testnets/cosmosicsprovidertestnet/chain.json
+++ b/testnets/cosmosicsprovidertestnet/chain.json
@@ -1,8 +1,8 @@
 {
   "$schema": "../../chain.schema.json",
-  "chain_name": "rsprovidertestnet",
+  "chain_name": "cosmosicsprovidertestnet",
   "chain_id": "provider",
-  "pretty_name": "Replicated Security Provider Testnet",
+  "pretty_name": "Cosmos ICS Provider Testnet",
   "status": "live",
   "network_type": "testnet",
   "bech32_prefix": "cosmos",
@@ -29,21 +29,26 @@
   },
   "codebase": {
     "git_repo": "https://github.com/cosmos/gaia",
-    "recommended_version": "v14.1.0",
+    "recommended_version": "v18.0.0-rc3",
     "compatible_versions": [
-      "v14.1.0-rc0",
-      "v14.1.0"
+      "v18.0.0-rc3"
     ],
+    "cosmos_sdk_version": "v0.47.16-ics-lsm",
+    "ibc_go_version": "v7.6.0",
+    "consensus": {
+      "type": "cometbft",
+      "version": "v0.37.6"
+    },
     "binaries": {
-      "linux/amd64": "https://github.com/cosmos/gaia/releases/download/v14.1.0/gaiad-v14.1.0-linux-amd64",
-      "linux/arm64": "https://github.com/cosmos/gaia/releases/download/v14.1.0/gaiad-v14.1.0-linux-arm64",
-      "darwin/amd64": "https://github.com/cosmos/gaia/releases/download/v14.1.0/gaiad-v14.1.0-darwin-amd64",
-      "darwin/arm64": "https://github.com/cosmos/gaia/releases/download/v14.1.0/gaiad-v14.1.0-darwin-arm64",
-      "windows/amd64": "https://github.com/cosmos/gaia/releases/download/v14.1.0/gaiad-v14.1.0-windows-amd64.exe",
-      "windows/arm64": "https://github.com/cosmos/gaia/releases/download/v14.1.0/gaiad-v14.1.0-windows-arm64.exe"
+      "linux/amd64": "https://github.com/cosmos/gaia/releases/download/v18.0.0-rc3/gaiad-v18.0.0-rc3-linux-amd64",
+      "linux/arm64": "https://github.com/cosmos/gaia/releases/download/v18.0.0-rc3/gaiad-v18.0.0-rc3-linux-arm64",
+      "darwin/amd64": "https://github.com/cosmos/gaia/releases/download/v18.0.0-rc3/gaiad-v18.0.0-rc3-darwin-amd64",
+      "darwin/arm64": "https://github.com/cosmos/gaia/releases/download/v18.0.0-rc3/gaiad-v18.0.0-rc3-darwin-arm64",
+      "windows/amd64": "https://github.com/cosmos/gaia/releases/download/v18.0.0-rc3/gaiad-v18.0.0-rc3-darwin-amd64",
+      "windows/arm64": "https://github.com/cosmos/gaia/releases/download/v18.0.0-rc3/gaiad-v18.0.0-rc3-windows-arm64.exe"
     },
     "genesis": {
-      "genesis_url": "https://github.com/cosmos/testnets/raw/master/replicated-security/provider/provider-genesis.json"
+      "genesis_url": "https://raw.githubusercontent.com/cosmos/testnets/master/interchain-security/provider/provider-genesis.json"
     },
     "versions": [
       {
@@ -93,6 +98,77 @@
           "windows/amd64": "https://github.com/cosmos/gaia/releases/download/v14.1.0/gaiad-v14.1.0-windows-amd64.exe",
           "windows/arm64": "https://github.com/cosmos/gaia/releases/download/v14.1.0/gaiad-v14.1.0-windows-arm64.exe"
         }
+      },
+      {
+        "name": "v15",
+        "recommended_version": "v15.2.0",
+        "compatible_versions": [
+          "v15.2.0"
+        ],
+        "binaries": {
+          "linux/amd64": "https://github.com/cosmos/gaia/releases/download/v15.2.0/gaiad-v15.2.0-linux-amd64",
+          "linux/arm64": "https://github.com/cosmos/gaia/releases/download/v15.2.0/gaiad-v15.2.0-linux-arm64",
+          "darwin/amd64": "https://github.com/cosmos/gaia/releases/download/v15.2.0/gaiad-v15.2.0-darwin-amd64",
+          "darwin/arm64": "https://github.com/cosmos/gaia/releases/download/v15.2.0/gaiad-v15.2.0-darwin-arm64",
+          "windows/amd64": "https://github.com/cosmos/gaia/releases/download/v15.2.0/gaiad-v15.2.0-windows-amd64.exe",
+          "windows/arm64": "https://github.com/cosmos/gaia/releases/download/v15.2.0/gaiad-v15.2.0-windows-arm64.exe"
+        },
+        "next_version_name": "v16"
+      },
+      {
+        "name": "v16",
+        "recommended_version": "v16.0.0",
+        "compatible_versions": [
+          "v16.0.0"
+        ],
+        "binaries": {
+          "linux/amd64": "https://github.com/cosmos/gaia/releases/download/v16.0.0/gaiad-v16.0.0-linux-amd64",
+          "linux/arm64": "https://github.com/cosmos/gaia/releases/download/v16.0.0/gaiad-v16.0.0-linux-arm64",
+          "darwin/amd64": "https://github.com/cosmos/gaia/releases/download/v16.0.0/gaiad-v16.0.0-darwin-amd64",
+          "darwin/arm64": "https://github.com/cosmos/gaia/releases/download/v16.0.0/gaiad-v16.0.0-darwin-arm64",
+          "windows/amd64": "https://github.com/cosmos/gaia/releases/download/v16.0.0/gaiad-v16.0.0-windows-amd64.exe",
+          "windows/arm64": "https://github.com/cosmos/gaia/releases/download/v16.0.0/gaiad-v16.0.0-windows-arm64.exe"
+        },
+        "next_version_name": "v17"
+      },
+      {
+        "name": "v17",
+        "recommended_version": "v17.2.0",
+        "compatible_versions": [
+          "v17.2.0"
+        ],
+        "binaries": {
+          "linux/amd64": "https://github.com/cosmos/gaia/releases/download/v17.2.0/gaiad-v17.2.0-linux-amd64",
+          "linux/arm64": "https://github.com/cosmos/gaia/releases/download/v17.2.0/gaiad-v17.2.0-linux-arm64",
+          "darwin/amd64": "https://github.com/cosmos/gaia/releases/download/v17.2.0/gaiad-v17.2.0-darwin-amd64",
+          "darwin/arm64": "https://github.com/cosmos/gaia/releases/download/v17.2.0/gaiad-v17.2.0-darwin-arm64",
+          "windows/amd64": "https://github.com/cosmos/gaia/releases/download/v17.2.0/gaiad-v17.2.0-windows-amd64.exe",
+          "windows/arm64": "https://github.com/cosmos/gaia/releases/download/v17.2.0/gaiad-v17.2.0-windows-arm64.exe"
+        },
+        "next_version_name": "v17"
+      },
+      {
+        "name": "v18",
+        "tag": "v18.0.0-rc3",
+        "recommended_version": "v18.0.0-rc3",
+        "compatible_versions": [
+          "v18.0.0-rc3"
+        ],
+        "cosmos_sdk_version": "v0.47.16-ics-lsm",
+        "ibc_go_version": "v7.6.0",
+        "consensus": {
+          "type": "cometbft",
+          "version": "v0.37.6"
+        },
+        "binaries": {
+          "linux/amd64": "https://github.com/cosmos/gaia/releases/download/v18.0.0-rc3/gaiad-v18.0.0-rc3-linux-amd64",
+          "linux/arm64": "https://github.com/cosmos/gaia/releases/download/v18.0.0-rc3/gaiad-v18.0.0-rc3-linux-arm64",
+          "darwin/amd64": "https://github.com/cosmos/gaia/releases/download/v18.0.0-rc3/gaiad-v18.0.0-rc3-darwin-amd64",
+          "darwin/arm64": "https://github.com/cosmos/gaia/releases/download/v18.0.0-rc3/gaiad-v18.0.0-rc3-darwin-arm64",
+          "windows/amd64": "https://github.com/cosmos/gaia/releases/download/v18.0.0-rc3/gaiad-v18.0.0-rc3-darwin-amd64",
+          "windows/arm64": "https://github.com/cosmos/gaia/releases/download/v18.0.0-rc3/gaiad-v18.0.0-rc3-windows-arm64.exe"
+        },
+        "next_version_name": "v19"
       }
     ]
   },


### PR DESCRIPTION
This reflects is new name as of gaia v17. I also upgraded the gaia versions. You can learn more about this testnet [here](https://github.com/cosmos/testnets/tree/master/interchain-security/provider)