### PR TITLE
[FIX] Properly capitalize Initia image URLs

### DIFF
--- a/initia/assetlist.json
+++ b/initia/assetlist.json
@@ -20,8 +20,8 @@
       "symbol": "INIT",
       "images": [
         {
-          "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/initia/images/init.png",
-          "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/initia/images/init.svg",
+          "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/initia/images/INIT.png",
+          "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/initia/images/INIT.svg",
           "theme": {
             "circle": true,
             "primary_color_hex": "#040404"


### PR DESCRIPTION
- There was an issue in rendering the Initia INIT image URLs when they were lowercase, this PR fixes them to specify the correct URLs in the chain registry