### PR TITLE
Update archway osmosis testnet IBC channels with active channels

### DIFF
--- a/testnets/_IBC/archwaytestnet-osmosistestnet.json
+++ b/testnets/_IBC/archwaytestnet-osmosistestnet.json
@@ -2,26 +2,56 @@
   "$schema": "../ibc_data.schema.json",
   "chain_1": {
     "chain_name": "archwaytestnet",
-    "client_id": "07-tendermint-77",
-    "connection_id": "connection-73"
+    "client_id": "07-tendermint-121",
+    "connection_id": "connection-120"
   },
   "chain_2": {
     "chain_name": "osmosistestnet",
-    "client_id": "07-tendermint-1195",
-    "connection_id": "connection-1101"
+    "client_id": "07-tendermint-3459",
+    "connection_id": "connection-3027"
   },
   "channels": [
     {
       "chain_1": {
-        "channel_id": "channel-58",
+        "channel_id": "channel-225",
         "port_id": "transfer"
       },
       "chain_2": {
-        "channel_id": "channel-3938",
+        "channel_id": "channel-7779",
         "port_id": "transfer"
       },
       "ordering": "unordered",
       "version": "ics20-1",
+      "tags": {
+        "status": "live"
+      }
+    },
+    {
+      "chain_1": {
+        "channel_id": "*",
+        "port_id": "wasm.*"
+      },
+      "chain_2": {
+        "channel_id": "*",
+        "port_id": "icahost"
+      },
+      "ordering": "ordered",
+      "version": "ics27-1",
+      "tags": {
+        "status": "live"
+      }
+    },
+    {
+      "chain_1": {
+        "channel_id": "*",
+        "port_id": "wasm.*"
+      },
+      "chain_2": {
+        "channel_id": "*",
+        "port_id": "icqhost"
+      },
+      "ordering": "unordered",
+      "version": "icq-1",
       "tags": {
         "status": "live"
       }

--- a/testnets/archwaytestnet/assetlist.json
+++ b/testnets/archwaytestnet/assetlist.json
@@ -22,31 +22,15 @@
       "name": "Archway",
       "display": "const",
       "symbol": "CONST",
-      "traces": [
-        {
-          "type": "test-mintage",
-          "counterparty": {
-            "chain_name": "archway",
-            "base_denom": "aconst"
-          },
-          "provider": "Archway Testnet"
-        }
-      ],
       "logo_URIs": {
         "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/archway/images/archway.png",
         "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/archway/images/archway.svg"
       },
+      "coingecko_id": "archway",
       "images": [
-        {
-          "image_sync": {
-            "chain_name": "archway",
-            "base_denom": "aconst"
-          },
+        {     
           "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/archway/images/archway.png",
-          "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/archway/images/archway.svg",
-          "theme": {
-            "primary_color_hex": "#fc4c04"
-          }
+          "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/archway/images/archway.svg"
         }
       ],
       "socials": {

--- a/testnets/archwaytestnet/assetlist.json
+++ b/testnets/archwaytestnet/assetlist.json
@@ -22,15 +22,31 @@
       "name": "Archway",
       "display": "const",
       "symbol": "CONST",
+      "traces": [
+        {
+          "type": "test-mintage",
+          "counterparty": {
+            "chain_name": "archway",
+            "base_denom": "aarch"
+          },
+          "provider": "Archway Testnet"
+        }
+      ],
       "logo_URIs": {
         "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/archway/images/archway.png",
         "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/archway/images/archway.svg"
       },
-      "coingecko_id": "archway",
       "images": [
-        {     
+        {
+          "image_sync": {
+            "chain_name": "archway",
+            "base_denom": "aarch"
+          },
           "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/archway/images/archway.png",
-          "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/archway/images/archway.svg"
+          "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/archway/images/archway.svg",
+          "theme": {
+            "primary_color_hex": "#fc4c04"
+          }
         }
       ],
       "socials": {

--- a/testnets/archwaytestnet/assetlist.json
+++ b/testnets/archwaytestnet/assetlist.json
@@ -27,7 +27,7 @@
           "type": "test-mintage",
           "counterparty": {
             "chain_name": "archway",
-            "base_denom": "aarch"
+            "base_denom": "aconst"
           },
           "provider": "Archway Testnet"
         }
@@ -40,7 +40,7 @@
         {
           "image_sync": {
             "chain_name": "archway",
-            "base_denom": "aarch"
+            "base_denom": "aconst"
           },
           "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/archway/images/archway.png",
           "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/archway/images/archway.svg",


### PR DESCRIPTION
- Update connections
- Update channels
- Update port id
- Replace wrong base_denom aarch with aconst

Reason: 
The archway testnet channels on cosmos chain registry not active anymore, so I update to "active" ones