### PR TITLE
Update wstETH Trace Relationship to Liquid Stake

### DIFF
--- a/_non-cosmos/ethereum/assetlist.json
+++ b/_non-cosmos/ethereum/assetlist.json
@@ -467,7 +467,7 @@
       "symbol": "wstETH",
       "traces": [
         {
-          "type": "wrapped",
+          "type": "liquid-stake",
           "counterparty": {
             "chain_name": "ethereum",
             "base_denom": "0xae7ab96520de3a18e5e111b5eaab095312d7fe84"


### PR DESCRIPTION
Update wstETH Trace Relationship to Liquid Stake instead of wrapped. Although it's sort of a wrapped stETH, it isn't 1:1 with stETH, but it accumulates value, which is why I think this is better described as a liquid staking relationship. I.E., wstETH is a liquid-staked version of stETH (with 0 unlock duration).