### PR TITLE
chore: Update explorer link for CHEQ

### DIFF
--- a/cheqd/chain.json
+++ b/cheqd/chain.json
@@ -390,9 +390,9 @@
   "explorers": [
     {
       "kind": "bigdipper",
-      "url": "https://bigdipper.live/cheqd",
-      "tx_page": "https://bigdipper.live/cheqd/transactions/${txHash}",
-      "account_page": "https://bigdipper.live/cheqd/accounts/${accountAddress}"
+      "url": "https://explorer.cheqd.io",
+      "tx_page": "https://explorer.cheqd.io/transactions/${txHash}",
+      "account_page": "https://explorer.cheqd.io/accounts/${accountAddress}"
     },
     {
       "kind": "ping.pub",


### PR DESCRIPTION
The explorer for CHEQ mainnet is no longer hosted by Forbole and therefore not present on bigdipper.live. Instead, it 301 redirects to explorer.cheqd.io. This update changes it to the new/correct URL.

Note: I left the "kind" as `bigdipper` since that's the format that a lot of chains still use, but I'm aware there was a brief discussion in the past on this repo on whether that field should be used to denote the host/entity hosting the explorer, vs the type of explorer.