### PR TITLE
Use correct urls for Archway testnet

### DIFF
--- a/testnets/archwaytestnet/chain.json
+++ b/testnets/archwaytestnet/chain.json
@@ -40,7 +40,7 @@
   "apis": {
     "rpc": [
       {
-        "address": "rpc.constantine.archway.io",
+        "address": "https://rpc.constantine.archway.io",
         "provider": "Archway"
       },
       {
@@ -50,7 +50,7 @@
     ],
     "rest": [
       {
-        "address": "https://api.constantine.archway.tech",
+        "address": "https://api.constantine.archway.io",
         "provider": "Archway"
       }
     ]


### PR DESCRIPTION
Use correct urls from https://github.com/archway-network/networks/blob/main/testnets/archwaytestnet/chain.json