### PR TITLE
Update Racoon RAC traces

### DIFF
--- a/juno/assetlist.json
+++ b/juno/assetlist.json
@@ -200,6 +200,16 @@
       "name": "Racoon",
       "display": "rac",
       "symbol": "RAC",
+      "traces": [
+        {
+          "type": "additional-mintage",
+          "counterparty": {
+            "chain_name": "migaloo",
+            "base_denom": "factory/migaloo1eqntnl6tzcj9h86psg4y4h6hh05g2h9nj8e09l/urac"
+          },
+          "provider": "Racoon"
+        }
+      ],
       "logo_URIs": {
         "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/juno/images/rac.png",
         "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/juno/images/rac.svg"

--- a/migaloo/assetlist.json
+++ b/migaloo/assetlist.json
@@ -172,7 +172,7 @@
         }
       ],
       "base": "factory/migaloo1eqntnl6tzcj9h86psg4y4h6hh05g2h9nj8e09l/urac",
-      "name": "RAC",
+      "name": "Racoon",
       "display": "RAC",
       "symbol": "RAC",
       "logo_URIs": {


### PR DESCRIPTION
Update Racoon RAC traces
Juno racoon is an additional-mintage of magaloo rac (actualy it's a legacy mintage)