### PR TITLE
Add non-cosmos chain Schema and Ethereum

### DIFF
--- a/_non-cosmos/ethereum/chain.json
+++ b/_non-cosmos/ethereum/chain.json
@@ -1,0 +1,45 @@
+{
+    "$schema": "../../non-cosmos_chain.schema.json",
+    "chain_name": "ethereum",
+    "status": "live",
+    "website": "https://ethereum.org/",
+    "network_type": "mainnet",
+    "pretty_name": "Ethereum Mainnet",
+    "chain_id": "0x1",
+    "slip44": 60,
+    "fees": {
+      "fee_tokens": [
+        {
+          "denom": "wei",
+          "fixed_min_gas_price": 0
+        }
+      ]
+    },
+    "staking": {
+      "staking_tokens": [
+        {
+          "denom": "wei"
+        }
+      ]
+    },
+    "explorers": [
+      {
+        "kind": "Etherscan",
+        "url": "https://etherscan.io/",
+        "tx_page": "https://etherscan.io/tx/${txHash}"
+      }
+    ],
+    "images": [
+      {
+        "image_sync": {
+          "chain_name": "ethereum",
+          "base_denom": "wei"
+        },
+        "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/_non-cosmos/ethereum/images/eth-white.png",
+        "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/_non-cosmos/ethereum/images/eth-white.svg",
+        "theme": {
+          "primary_color_hex": "#303030"
+        }
+      }
+    ]
+  }

--- a/_non-cosmos/solana/chain.json
+++ b/_non-cosmos/solana/chain.json
@@ -1,0 +1,40 @@
+{
+    "$schema": "../../non-cosmos_chain.schema.json",
+    "chain_name": "solana",
+    "status": "live",
+    "website": "https://solana.com/",
+    "network_type": "mainnet",
+    "pretty_name": "Solana Mainnet Beta",
+    "slip44": 501,
+    "fees": {
+      "fee_tokens": [
+        {
+          "denom": "Lamport",
+          "fixed_min_gas_price": 0
+        }
+      ]
+    },
+    "staking": {
+      "staking_tokens": [
+        {
+          "denom": "Lamport"
+        }
+      ]
+    },
+    "explorers": [
+      {
+        "kind": "Solana Explorer",
+        "url": "https://explorer.solana.com/",
+        "tx_page": "https://explorer.solana.com/tx/${txHash}"
+      }
+    ],
+    "images": [
+      {
+        "image_sync": {
+          "chain_name": "solana",
+          "base_denom": "Lamport"
+        },
+        "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/_non-cosmos/solana/images/sol.svg"
+      }
+    ]
+  }

--- a/non-cosmos_chain.schema.json
+++ b/non-cosmos_chain.schema.json
@@ -1,0 +1,733 @@
+{
+  "$id": "https://sikka.tech/chain.schema.json",
+  "$schema": "https://json-schema.org/draft-07/schema",
+  "title": "Non-cosmos Chain",
+  "description": "non-comsos_chain.json is a metadata file that contains information about a blockchain.",
+  "type": "object",
+  "required": ["chain_name"],
+  "properties": {
+    "$schema": {
+      "type": "string",
+      "minLength": 1,
+      "pattern": "^(\\.\\./)+non-cosmos_chain\\.schema\\.json$"
+    },
+    "chain_name": {
+      "type": "string",
+      "minLength": 1,
+      "pattern": "[a-z0-9]+"
+    },
+    "chain_id": {
+      "type": "string",
+      "minLength": 1
+    },
+    "pre_fork_chain_name": {
+      "type": "string",
+      "minLength": 1,
+      "pattern": "[a-z0-9]+"
+    },
+    "pretty_name": {
+      "type": "string",
+      "minLength": 1
+    },
+    "website": {
+      "type": "string",
+      "minLength": 1,
+      "format": "uri"
+    },
+    "update_link": {
+      "type": "string",
+      "minLength": 1,
+      "format": "uri"
+    },
+    "status": {
+      "enum": ["live", "upcoming", "killed"]
+    },
+    "network_type": {
+      "enum": ["mainnet", "testnet", "devnet"]
+    },
+    "bech32_prefix": {
+      "type": "string",
+      "minLength": 1,
+      "description": "The default prefix for the human-readable part of addresses that identifies the coin type. Must be registered with SLIP-0173. E.g., 'cosmos'"
+    },
+    "bech32_config": {
+      "type": "object",
+      "description": "Used to override the bech32_prefix for specific uses.",
+      "properties": {
+        "bech32PrefixAccAddr": {
+          "type": "string",
+          "minLength": 1,
+          "description": "e.g., 'cosmos'"
+        },
+        "bech32PrefixAccPub": {
+          "type": "string",
+          "minLength": 1,
+          "description": "e.g., 'cosmospub'"
+        },
+        "bech32PrefixValAddr": {
+          "type": "string",
+          "minLength": 1,
+          "description": "e.g., 'cosmosvaloper'"
+        },
+        "bech32PrefixValPub": {
+          "type": "string",
+          "minLength": 1,
+          "description": "e.g., 'cosmosvaloperpub'"
+        },
+        "bech32PrefixConsAddr": {
+          "type": "string",
+          "minLength": 1,
+          "description": "e.g., 'cosmosvalcons'"
+        },
+        "bech32PrefixConsPub": {
+          "type": "string",
+          "minLength": 1,
+          "description": "e.g., 'cosmosvalconspub'"
+        }
+      },
+      "additionalProperties": false,
+      "minProperties": 1
+    },
+    "daemon_name": {
+      "type": "string",
+      "minLength": 1
+    },
+    "node_home": {
+      "type": "string",
+      "minLength": 1
+    },
+    "key_algos": {
+      "type": "array",
+      "items": {
+        "type": "string",
+        "enum": ["secp256k1", "ethsecp256k1", "ed25519", "sr25519", "bn254"],
+        "uniqueItems": true
+      }
+    },
+    "slip44": {
+      "type": "number"
+    },
+    "alternative_slip44s": {
+      "type": "array",
+      "items": {
+        "type": "number"
+      }
+    },
+    "fees": {
+      "type": "object",
+      "required": ["fee_tokens"],
+      "properties": {
+        "fee_tokens": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/fee_token"
+          }
+        }
+      },
+      "additionalProperties": false
+    },
+    "staking": {
+      "type": "object",
+      "required": ["staking_tokens"],
+      "properties": {
+        "staking_tokens": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/staking_token"
+          }
+        },
+        "lock_duration": {
+          "type": "object",
+          "properties": {
+            "blocks": {
+              "type": "number",
+              "description": "The number of blocks for which the staked tokens are locked."
+            },
+            "time": {
+              "type": "string",
+              "minLength": 1,
+              "description": "The approximate time for which the staked tokens are locked."
+            }
+          },
+          "additionalProperties": false,
+          "minProperties": 1
+        }
+      },
+      "additionalProperties": false
+    },
+    "codebase": {
+      "type": "object",
+      "properties": {
+        "git_repo": {
+          "type": "string",
+          "minLength": 1,
+          "format": "uri"
+        },
+        "recommended_version": {
+          "type": "string",
+          "minLength": 1
+        },
+        "go_version": {
+          "type": "string",
+          "minLength": 1,
+          "pattern": "^[0-9]+\\.[0-9]+(\\.[0-9]+)?$",
+          "description": "Minimum accepted go version to build the binary."
+        },
+        "compatible_versions": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "minLength": 1
+          }
+        },
+        "binaries": {
+          "type": "object",
+          "properties": {
+            "linux/amd64": {
+              "type": "string",
+              "minLength": 1,
+              "format": "uri"
+            },
+            "linux/arm64": {
+              "type": "string",
+              "minLength": 1,
+              "format": "uri"
+            },
+            "darwin/amd64": {
+              "type": "string",
+              "minLength": 1,
+              "format": "uri"
+            },
+            "darwin/arm64": {
+              "type": "string",
+              "minLength": 1,
+              "format": "uri"
+            },
+            "windows/amd64": {
+              "type": "string",
+              "minLength": 1,
+              "format": "uri"
+            },
+            "windows/arm64": {
+              "type": "string",
+              "minLength": 1,
+              "format": "uri"
+            }
+          },
+          "additionalProperties": false
+        },
+        "cosmos_sdk_version": {
+          "type": "string",
+          "minLength": 1
+        },
+        "consensus": {
+          "type": "object",
+          "required": ["type"],
+          "properties": {
+            "type": {
+              "type": "string",
+              "minLength": 1,
+              "enum": ["tendermint", "cometbft", "sei-tendermint"]
+            },
+            "version": {
+              "type": "string",
+              "minLength": 1
+            }
+          },
+          "additionalProperties": false
+        },
+        "cosmwasm_version": {
+          "type": "string",
+          "minLength": 1
+        },
+        "cosmwasm_enabled": {
+          "type": "boolean"
+        },
+        "cosmwasm_path": {
+          "type": "string",
+          "minLength": 1,
+          "description": "Relative path to the cosmwasm directory. ex. $HOME/.juno/data/wasm",
+          "pattern": "^\\$HOME.*$"
+        },
+        "ibc_go_version": {
+          "type": "string",
+          "minLength": 1
+        },
+        "ics_enabled": {
+          "type": "array",
+          "description": "List of IBC apps (usually corresponding to a ICS standard) which have been enabled on the network.",
+          "items": {
+            "type": "string",
+            "minLength": 1,
+            "description": "IBC app or ICS standard.",
+            "enum": ["ics20-1", "ics27-1", "mauth"]
+          }
+        },
+        "genesis": {
+          "type": "object",
+          "required": ["genesis_url"],
+          "properties": {
+            "name": {
+              "type": "string",
+              "minLength": 1
+            },
+            "genesis_url": {
+              "type": "string",
+              "minLength": 1,
+              "format": "uri"
+            },
+            "ics_ccv_url": {
+              "type": "string",
+              "minLength": 1,
+              "format": "uri"
+            }
+          },
+          "additionalProperties": false
+        },
+        "versions": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "required": ["name"],
+            "properties": {
+              "name": {
+                "type": "string",
+                "minLength": 1,
+                "description": "Official Upgrade Name"
+              },
+              "tag": {
+                "type": "string",
+                "minLength": 1,
+                "description": "Git Upgrade Tag"
+              },
+              "height": {
+                "type": "number",
+                "description": "Block Height"
+              },
+              "proposal": {
+                "type": "number",
+                "description": "Proposal that will officially signal community acceptance of the upgrade."
+              },
+              "previous_version_name": {
+                "type": "string",
+                "minLength": 1,
+                "description": "[Optional] Name of the previous version"
+              },
+              "next_version_name": {
+                "type": "string",
+                "minLength": 0,
+                "description": "[Optional] Name of the following version"
+              },
+              "recommended_version": {
+                "type": "string",
+                "minLength": 1
+              },
+              "go_version": {
+                "type": "string",
+                "minLength": 1,
+                "pattern": "^[0-9]+\\.[0-9]+(\\.[0-9]+)?$",
+                "description": "Minimum accepted go version to build the binary."
+              },
+              "compatible_versions": {
+                "type": "array",
+                "items": {
+                  "type": "string",
+                  "minLength": 1
+                }
+              },
+              "cosmos_sdk_version": {
+                "type": "string",
+                "minLength": 1
+              },
+              "consensus": {
+                "type": "object",
+                "required": ["type"],
+                "properties": {
+                  "type": {
+                    "type": "string",
+                    "minLength": 1,
+                    "enum": ["tendermint", "cometbft", "sei-tendermint"]
+                  },
+                  "version": {
+                    "type": "string",
+                    "minLength": 1
+                  }
+                },
+                "additionalProperties": false
+              },
+              "cosmwasm_version": {
+                "type": "string",
+                "minLength": 1
+              },
+              "cosmwasm_enabled": {
+                "type": "boolean"
+              },
+              "cosmwasm_path": {
+                "type": "string",
+                "minLength": 1,
+                "description": "Relative path to the cosmwasm directory. ex. $HOME/.juno/data/wasm",
+                "pattern": "^\\$HOME.*$"
+              },
+              "ibc_go_version": {
+                "type": "string",
+                "minLength": 1
+              },
+              "ics_enabled": {
+                "type": "array",
+                "description": "List of IBC apps (usually corresponding to a ICS standard) which have been enabled on the network.",
+                "items": {
+                  "type": "string",
+                  "minLength": 1,
+                  "description": "IBC app or ICS standard.",
+                  "enum": ["ics20-1", "ics27-1", "mauth"]
+                }
+              },
+              "binaries": {
+                "type": "object",
+                "properties": {
+                  "linux/amd64": {
+                    "type": "string",
+                    "minLength": 1,
+                    "format": "uri"
+                  },
+                  "linux/arm64": {
+                    "type": "string",
+                    "minLength": 1,
+                    "format": "uri"
+                  },
+                  "darwin/amd64": {
+                    "type": "string",
+                    "minLength": 1,
+                    "format": "uri"
+                  },
+                  "darwin/arm64": {
+                    "type": "string",
+                    "minLength": 1,
+                    "format": "uri"
+                  },
+                  "windows/amd64": {
+                    "type": "string",
+                    "minLength": 1,
+                    "format": "uri"
+                  },
+                  "windows/arm64": {
+                    "type": "string",
+                    "minLength": 1,
+                    "format": "uri"
+                  }
+                },
+                "additionalProperties": false
+              }
+            },
+            "additionalProperties": false
+          }
+        }
+      },
+      "additionalProperties": false
+    },
+    "images": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "image_sync": {
+            "$ref": "#/$defs/pointer"
+          },
+          "png": {
+            "type": "string",
+            "minLength": 1,
+            "format": "uri-reference",
+            "pattern": "^https://raw\\.githubusercontent\\.com/cosmos/chain-registry/master/(|testnets/|_non-cosmos/)[a-z0-9]+/images/.+\\.png$"
+          },
+          "svg": {
+            "type": "string",
+            "minLength": 1,
+            "format": "uri-reference",
+            "pattern": "^https://raw\\.githubusercontent\\.com/cosmos/chain-registry/master/(|testnets/|_non-cosmos/)[a-z0-9]+/images/.+\\.svg$"
+          },
+          "theme": {
+            "type": "object",
+            "properties": {
+              "primary_color_hex": {
+                "type": "string",
+                "minLength": 1,
+                "pattern": "^#([0-9a-fA-F]{6}|[0-9a-fA-F]{8})$"
+              },
+              "background_color_hex": {
+                "type": "string",
+                "minLength": 1,
+                "pattern": "^(#([0-9a-fA-F]{6}|[0-9a-fA-F]{8})|none)$"
+              },
+              "circle": {
+                "type": "boolean"
+              },
+              "dark_mode": {
+                "type": "boolean"
+              },
+              "monochrome": {
+                "type": "boolean"
+              }
+            },
+            "minProperties": 1,
+            "additionalProperties": false
+          }
+        },
+        "anyOf": [
+          {
+            "required": ["png"]
+          },
+          {
+            "required": ["svg"]
+          }
+        ],
+        "additionalProperties": false
+      }
+    },
+    "logo_URIs": {
+      "type": "object",
+      "properties": {
+        "png": {
+          "type": "string",
+          "minLength": 1,
+          "format": "uri-reference",
+          "pattern": "^https://raw\\.githubusercontent\\.com/cosmos/chain-registry/master/(|testnets/|_non-cosmos/)[a-z0-9]+/images/.+\\.png$"
+        },
+        "svg": {
+          "type": "string",
+          "minLength": 1,
+          "format": "uri-reference",
+          "pattern": "^https://raw\\.githubusercontent\\.com/cosmos/chain-registry/master/(|testnets/|_non-cosmos/)[a-z0-9]+/images/.+\\.svg$"
+        }
+      },
+      "additionalProperties": false
+    },
+    "description": {
+      "type": "string",
+      "minLength": 1,
+      "maxLength": 3000
+    },
+    "peers": {
+      "type": "object",
+      "properties": {
+        "seeds": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/peer"
+          }
+        },
+        "persistent_peers": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/peer"
+          }
+        }
+      },
+      "additionalProperties": false
+    },
+    "apis": {
+      "type": "object",
+      "properties": {
+        "rpc": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/endpoint"
+          }
+        },
+        "rest": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/endpoint"
+          }
+        },
+        "grpc": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/endpoint"
+          }
+        },
+        "wss": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/endpoint"
+          }
+        },
+        "grpc-web": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/endpoint"
+          }
+        },
+        "evm-http-jsonrpc": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/endpoint"
+          }
+        }
+      },
+      "additionalProperties": false
+    },
+    "explorers": {
+      "type": "array",
+      "items": {
+        "$ref": "#/$defs/explorer"
+      }
+    },
+    "keywords": {
+      "type": "array",
+      "maxContains": 20,
+      "items": {
+        "type": "string",
+        "minLength": 1
+      }
+    },
+    "extra_codecs": {
+      "type": "array",
+      "items": {
+        "type": "string",
+        "minLength": 1,
+        "enum": ["ethermint", "injective"],
+        "uniqueItems": true
+      }
+    }
+  },
+  "additionalProperties": false,
+  "$defs": {
+    "peer": {
+      "type": "object",
+      "required": ["id", "address"],
+      "properties": {
+        "id": {
+          "type": "string",
+          "minLength": 1
+        },
+        "address": {
+          "type": "string",
+          "minLength": 1
+        },
+        "provider": {
+          "type": "string",
+          "minLength": 1
+        }
+      },
+      "additionalProperties": false
+    },
+    "endpoint": {
+      "type": "object",
+      "required": ["address"],
+      "properties": {
+        "address": {
+          "type": "string",
+          "minLength": 1
+        },
+        "provider": {
+          "type": "string",
+          "minLength": 1
+        },
+        "archive": {
+          "type": "boolean",
+          "default": false
+        }
+      },
+      "additionalProperties": false
+    },
+    "explorer": {
+      "type": "object",
+      "properties": {
+        "kind": {
+          "type": "string",
+          "minLength": 1
+        },
+        "url": {
+          "type": "string",
+          "minLength": 1
+        },
+        "tx_page": {
+          "type": "string",
+          "minLength": 1
+        },
+        "account_page": {
+          "type": "string",
+          "minLength": 1
+        },
+        "validator_page": {
+          "type": "string",
+          "minLength": 1
+        },
+        "proposal_page": {
+          "type": "string",
+          "minLength": 1
+        },
+        "block_page": {
+          "type": "string",
+          "minLength": 1
+        }
+      },
+      "additionalProperties": false
+    },
+    "fee_token": {
+      "type": "object",
+      "required": ["denom"],
+      "properties": {
+        "denom": {
+          "type": "string",
+          "minLength": 1
+        },
+        "fixed_min_gas_price": {
+          "type": "number"
+        },
+        "low_gas_price": {
+          "type": "number"
+        },
+        "average_gas_price": {
+          "type": "number"
+        },
+        "high_gas_price": {
+          "type": "number"
+        },
+        "gas_costs": {
+          "type": "object",
+          "properties": {
+            "cosmos_send": {
+              "type": "number"
+            },
+            "ibc_transfer": {
+              "type": "number"
+            }
+          },
+          "additionalProperties": false,
+          "minProperties": 1
+        }
+      },
+      "additionalProperties": false
+    },
+    "staking_token": {
+      "type": "object",
+      "required": ["denom"],
+      "properties": {
+        "denom": {
+          "type": "string",
+          "minLength": 1
+        }
+      },
+      "additionalProperties": false
+    },
+    "pointer": {
+      "type": "object",
+      "description": "The (primary) key used to identify an object within the Chain Registry.",
+      "required": ["chain_name"],
+      "properties": {
+        "chain_name": {
+          "type": "string",
+          "minLength": 1,
+          "description": "The chain name or platform from which the object resides. E.g., 'cosmoshub', 'ethereum', 'forex', or 'nasdaq'"
+        },
+        "base_denom": {
+          "type": "string",
+          "minLength": 1,
+          "description": "The base denom of the asset from which the object originates. E.g., when describing ATOM from Cosmos Hub, specify 'uatom', NOT 'atom' nor 'ATOM'; base units are unique per platform."
+        }
+      },
+      "additionalProperties": false
+    }
+  }
+}


### PR DESCRIPTION
Add non-cosmos chain Schema and Ethereum
Removes requirement for chain_id (which might be able to be retained as a requirement... TBD) and removes requirement for bech32_prefix (required for cosmos chains)