### PR TITLE
Version updates for latest Agoric release

### DIFF
--- a/agoric/chain.json
+++ b/agoric/chain.json
@@ -38,14 +38,24 @@
   },
   "codebase": {
     "git_repo": "https://github.com/Agoric/agoric-sdk/",
+    "genesis": {
+      "genesis_url": "https://main.agoric.net/genesis.json"
+    },
     "recommended_version": "agoric-upgrade-16",
-    "go_version": "1.20.2",
     "compatible_versions": [
       "agoric-upgrade-16"
     ],
-    "genesis": {
-      "genesis_url": "https://main.agoric.net/genesis.json"
-    }
+    "cosmos_sdk_version": "agoric-labs/cosmos-sdk v0.46.16-alpha.agoric.2.4",
+    "consensus": {
+      "type": "cometbft",
+      "version": "agoric-labs/cometbft v0.34.30-alpha.agoric.1"
+    },
+    "cosmwasm_enabled": false,
+    "ibc_go_version": "v7.4.0",
+    "ics_enabled": [
+      "ics20-1"
+    ],
+    "go_version": "1.20.2"
   },
   "logo_URIs": {
     "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/agoric/images/Agoric-logo-color.png",

--- a/agoric/chain.json
+++ b/agoric/chain.json
@@ -38,10 +38,10 @@
   },
   "codebase": {
     "git_repo": "https://github.com/Agoric/agoric-sdk/",
-    "recommended_version": "agoric-upgrade-15",
+    "recommended_version": "agoric-upgrade-16",
     "go_version": "1.20.2",
     "compatible_versions": [
-      "agoric-upgrade-15"
+      "agoric-upgrade-16"
     ],
     "genesis": {
       "genesis_url": "https://main.agoric.net/genesis.json"

--- a/agoric/versions.json
+++ b/agoric/versions.json
@@ -15,6 +15,13 @@
       "height": 15008615,
       "proposal": 74,
       "go_version": "1.20.2"
+    },
+    {
+      "name": "agoric-upgrade-16",
+      "tag": "agoric-upgrade-16",
+      "height": 15959899,
+      "proposal": 75,
+      "go_version": "1.20.2"
     }
   ]
 }

--- a/agoric/versions.json
+++ b/agoric/versions.json
@@ -14,7 +14,8 @@
       "tag": "agoric-upgrade-15",
       "height": 15008615,
       "proposal": 74,
-      "go_version": "1.20.2"
+      "go_version": "1.20.2",
+      "next_version_name": "agoric-upgrade-16"
     },
     {
       "name": "agoric-upgrade-16",

--- a/agoric/versions.json
+++ b/agoric/versions.json
@@ -19,9 +19,24 @@
     {
       "name": "agoric-upgrade-16",
       "tag": "agoric-upgrade-16",
-      "height": 15959899,
       "proposal": 75,
-      "go_version": "1.20.2"
+      "height": 15959899,
+      "recommended_version": "agoric-upgrade-16",
+      "compatible_versions": [
+        "agoric-upgrade-16"
+      ],
+      "cosmos_sdk_version": "agoric-labs/cosmos-sdk v0.46.16-alpha.agoric.2.4",
+      "consensus": {
+        "type": "cometbft",
+        "version": "agoric-labs/cometbft v0.34.30-alpha.agoric.1"
+      },
+      "cosmwasm_enabled": false,
+      "ibc_go_version": "v7.4.0",
+      "ics_enabled": [
+        "ics20-1"
+      ],
+      "go_version": "1.20.2",
+      "previous_version_name": "agoric-upgrade-15"
     }
   ]
 }


### PR DESCRIPTION
Update Agoric chain info with details of the latest version.

- Governance Proposal for Update: https://agoric.explorers.guru/proposal/75
- Tested by pushing JSON files through `jq`