### PR TITLE
feat: update celestia-app versions on Mocha and Arabica

### DIFF
--- a/testnets/celestiatestnet2/chain.json
+++ b/testnets/celestiatestnet2/chain.json
@@ -23,16 +23,30 @@
   },
   "codebase": {
     "git_repo": "https://github.com/celestiaorg/celestia-app",
-    "recommended_version": "v1.6.0",
-    "compatible_versions": ["v1.3.0", "v1.4.0", "v1.5.0", "v1.6.0"],
+    "recommended_version": "v1.11.0",
+    "compatible_versions": [
+      "v1.3.0",
+      "v1.6.0",
+      "v1.7.0",
+      "v1.9.0",
+      "v1.10.1",
+      "v1.11.0"
+    ],
     "genesis": {
       "genesis_url": "https://raw.githubusercontent.com/celestiaorg/networks/master/arabica-11/genesis.json"
     },
     "versions": [
       {
-        "name": "v1.3.0",
-        "recommended_version": "v1.6.0",
-        "compatible_versions": ["v1.3.0", "v1.4.0", "v1.5.0", "v1.6.0"]
+        "name": "v1.11.0",
+        "recommended_version": "v1.11.0",
+        "compatible_versions": [
+          "v1.3.0",
+          "v1.6.0",
+          "v1.7.0",
+          "v1.9.0",
+          "v1.10.1",
+          "v1.11.0"
+        ]
       }
     ]
   },

--- a/testnets/celestiatestnet3/chain.json
+++ b/testnets/celestiatestnet3/chain.json
@@ -23,16 +23,30 @@
   },
   "codebase": {
     "git_repo": "https://github.com/celestiaorg/celestia-app",
-    "recommended_version": "v1.3.0",
-    "compatible_versions": ["v1.3.0"],
+    "recommended_version": "v1.11.0",
+    "compatible_versions": [
+      "v1.3.0",
+      "v1.6.0",
+      "v1.7.0",
+      "v1.9.0",
+      "v1.10.1",
+      "v1.11.0"
+    ],
     "genesis": {
       "genesis_url": "https://raw.githubusercontent.com/celestiaorg/networks/master/mocha-4/genesis.json"
     },
     "versions": [
       {
-        "name": "v1.3.0",
-        "recommended_version": "v1.3.0",
-        "compatible_versions": ["v1.3.0"]
+        "name": "v1.11.0",
+        "recommended_version": "v1.11.0",
+        "compatible_versions": [
+          "v1.3.0",
+          "v1.6.0",
+          "v1.7.0",
+          "v1.9.0",
+          "v1.10.1",
+          "v1.11.0"
+        ]
       }
     ]
   },


### PR DESCRIPTION
Updates to support a range of celestia-app versions on Mocha testnet and Arabica devnet. Based on https://docs.celestia.org/nodes/participate