### PR TITLE
Fix missing h in https typo in Lava guru explorer

### DIFF
--- a/lava/chain.json
+++ b/lava/chain.json
@@ -344,7 +344,7 @@
     {
       "kind": "guru",
       "url": "https://lava.explorers.guru/",
-      "tx_page": "ttps://lava.explorers.guru/transaction/${txHash}",
+      "tx_page": "https://lava.explorers.guru/transaction/${txHash}",
       "account_page": "https://lava.explorers.guru/account/${accountAddress}"
     },
     {


### PR DESCRIPTION
Small typo in Lava's guru explorer, the `tx_page` url is missing the `h` in `https`.