### PR TITLE
Update 8Ball to Killed

### DIFF
--- a/8ball/chain.json
+++ b/8ball/chain.json
@@ -1,7 +1,7 @@
 {
   "$schema": "../chain.schema.json",
   "chain_name": "8ball",
-  "status": "live",
+  "status": "killed",
   "website": "https://8ball.info/",
   "network_type": "mainnet",
   "pretty_name": "8ball",


### PR DESCRIPTION
Update 8Ball to Killed
All socials are unavailable, all explorers are either unavailable or disconnected, and all RPC/status endpoints are down.
It is reasonable to assume that this chain is killed. 