### PR TITLE
Symphony testnet: update to testnet-2

### DIFF
--- a/testnets/symphonytestnet/chain.json
+++ b/testnets/symphonytestnet/chain.json
@@ -5,7 +5,7 @@
   "network_type": "testnet",
   "pretty_name": "Symphony Testnet",
   "chain_type": "cosmos",
-  "chain_id": "symphony-testnet-1",
+  "chain_id": "symphony-testnet-2",
   "bech32_prefix": "symphony",
   "daemon_name": "symphonyd",
   "node_home": "$HOME/.symphonyd",
@@ -62,13 +62,13 @@
     "seeds": [
       {
         "id": "10838131d11f546751178df1e1045597aad6366d",
-        "address": "34.41.169.77:26656"
+        "address": "34.46.94.25:26656"
       }
     ],
     "persistent_peers": [
       {
         "id": "8df964c61393d33d11f7c821aba1a72f428c0d24",
-        "address": "34.41.129.120:26656"
+        "address": "34.28.113.153:26656"
       },
       {
         "id": "eea2dc7e9abfd18787d4cc2c728689ad658cd3a2",
@@ -76,43 +76,31 @@
       },
       {
         "id": "785f5e73e26623214269909c0be2df3f767fbe50",
-        "address": "35.225.73.240:26656"
+        "address": "35.184.29.196:26656"
       },
       {
         "id": "adc09b9238bc582916abda954b081220d6f9cbc2",
-        "address": "34.172.132.224:26656"
+        "address": "34.28.131.240:26656"
       }
     ]
   },
   "apis": {
     "rpc": [
       {
-        "address": "https://rpc.testnet.symphonychain.org/",
-        "provider": "Orchestra Labs"
-      },
-      {
-        "address": "https://symphony-testnet-rpc.cogwheel.zone",
-        "provider": "Cogwheel ⚙️ "
+        "address": "https://symphony-rpc.kleomedes.network",
+        "provider": "Kleomedes"
       }
     ],
     "rest": [
       {
-        "address": "https://lcd.testnet.symphonychain.org/",
-        "provider": "Orchestra Labs"
-      },
-      {
-        "address": "https://symphony-testnet-api.cogwheel.zone",
-        "provider": "Cogwheel ⚙️ "
+        "address": "https://symphony-api.kleomedes.network",
+        "provider": "Kleomedes"
       }
     ],
     "grpc": [
       {
-        "address": "grpc.testnet.symphonychain.org:9090",
-        "provider": "Orchestra Labs"
-      },
-      {
-        "address": "symphony-testnet-grpc.cogwheel.zone:443",
-        "provider": "Cogwheel ⚙️ "
+        "address": "symphony-grpc.kleomedes.network",
+        "provider": "Kleomedes"
       }
     ]
   },


### PR DESCRIPTION
- add new endpoints from more reliable nodes
- update IPs for persistent peers
- update chain ID to v2