### PR TITLE
Update IBC `neutron-penumbra`

### DIFF
--- a/_IBC/neutron-penumbra.json
+++ b/_IBC/neutron-penumbra.json
@@ -2,22 +2,22 @@
   "$schema": "../ibc_data.schema.json",
   "chain_1": {
     "chain_name": "neutron",
-    "client_id": "07-tendermint-136",
-    "connection_id": "connection-97"
+    "client_id": "07-tendermint-137",
+    "connection_id": "connection-98"
   },
   "chain_2": {
     "chain_name": "penumbra",
-    "client_id": "07-tendermint-6",
-    "connection_id": "connection-6"
+    "client_id": "07-tendermint-9",
+    "connection_id": "connection-7"
   },
   "channels": [
     {
       "chain_1": {
-        "channel_id": "channel-4769",
+        "channel_id": "channel-4886",
         "port_id": "transfer"
       },
       "chain_2": {
-        "channel_id": "channel-5",
+        "channel_id": "channel-6",
         "port_id": "transfer"
       },
       "ordering": "unordered",


### PR DESCRIPTION
Paths for neutron-penumbra have been re-created after the old clients have expired. When penumbra upgrades relayers have to go through the [same procedure as for genesis restarts as per penumbra docs](https://guide.penumbra.zone/relayers#performing-upgrades).

Old channels weren't used at all (weren't integrated in any frontends), this was confirmed with the Neutron team. 