### PR TITLE
Updates Sei chain.json APIs, add explorer, remove unsupported explorer, correct some names

### DIFF
--- a/sei/chain.json
+++ b/sei/chain.json
@@ -574,6 +574,10 @@
   "apis": {
     "rpc": [
       {
+        "address": "https://rpc.sei-apis.com",
+        "provider": "Rhino Stake"
+      },
+      {
         "address": "https://sei-rpc.lavenderfive.com:443",
         "provider": "Lavender.Five Nodes 🐝"
       },
@@ -603,6 +607,10 @@
       }
     ],
     "rest": [
+      {
+        "address": "https://rest.sei-apis.com",
+        "provider": "Rhino Stake"
+      },
       {
         "address": "https://sei-api.lavenderfive.com:443",
         "provider": "Lavender.Five Nodes 🐝"
@@ -634,6 +642,10 @@
     ],
     "grpc": [
       {
+        "address": "https://grpc.sei-apis.com:443",
+        "provider": "Rhino Stake"
+      },
+      {
         "address": "https://sei-grpc.lavenderfive.com:443",
         "provider": "Lavender.Five Nodes 🐝"
       },
@@ -661,7 +673,7 @@
     "evm-http-jsonrpc": [
       {
         "address": "https://evm-rpc.sei-apis.com",
-        "provider": "Rhino"
+        "provider": "Rhino Stake"
       },
       {
         "address": "https://seievm-rpc.polkachu.com",
@@ -675,10 +687,10 @@
   },
   "explorers": [
     {
-      "kind": "ping.pub",
-      "url": "https://ping.pub/sei",
-      "tx_page": "https://ping.pub/sei/tx/${txHash}",
-      "account_page": "https://ping.pub/sei/account/${accountAddress}"
+      "kind": "blockscout",
+      "url": "https://seitrace.com",
+      "tx_page": "https://seitrace.com/tx/${txHash}?chain=pacific-1",
+      "account_page": "https://seitrace.com/address/${accountAddress}?chain=pacific-1"
     },
     {
       "kind": "mintscan",
@@ -693,7 +705,7 @@
       "account_page": "https://ezstaking.app/sei/account/${accountAddress}"
     },
     {
-      "kind": "seiscan",
+      "kind": "celatone",
       "url": "https://www.seiscan.app/pacific-1",
       "tx_page": "https://www.seiscan.app/pacific-1/txs/${txHash}",
       "account_page": "https://www.seiscan.app/pacific-1/accounts/${accountAddress}"


### PR DESCRIPTION
Adds:
 - "Rhino Stake" RPC/REST/GRPC
 - "Seitrace" (blockscout) explorer
 
Updates:
 - Explorer type "seiscan" >> "celatone"
 - EVM RPC provider name "Rhino" >> "Rhino Stake"

Removes:
 - Explorer "ping.pub" [does not support sei]