### PR TITLE
Add Data Validation for Deprecated and Replacement Version Properties

### DIFF
--- a/.github/workflows/utility/validate_data.mjs
+++ b/.github/workflows/utility/validate_data.mjs
@@ -173,7 +173,7 @@ function checkVersionForReplacementProperties(chain_name, versionObject) {
     ["cosmwasm_version", "cosmwasm"]
   ]);
 
-  const splitRegexPattern = /^([^@]+)@(.+)$/;
+  const splitRegexPattern = /^(?:([^ \@]*)[ \@])?(.*)$/;
   const repoRegexPattern = /(?:.*\/)?([^\/]+\/[^\/]+)$/;
   const tagRegexPattern = /^(?=.*-).+$/;
   const versionRegexPattern = /^([^ -]+)/;
@@ -207,6 +207,9 @@ function checkVersionForReplacementProperties(chain_name, versionObject) {
       let tag = deprecatedValue;
       tag = tag.match(splitRegexPattern)?.[2];
       let version = tag;
+      if (chain_name === "nibirudevnet3") {
+        console.log(version);
+      }
       tag = tag?.match(tagRegexPattern)?.[1];
       if (tag) {
         //console.log(tag);
@@ -216,8 +219,16 @@ function checkVersionForReplacementProperties(chain_name, versionObject) {
       }
 
       version = version?.match(versionRegexPattern)?.[1];
+      if(chain_name === "nibirudevnet3") {
+        console.log(version);
+        console.log(deprecatedValue);
+        console.log(replacementValue);
+      }
       if (version) {
         //console.log(version);
+        if (chain_name === "nibirudevnet3") {
+          console.log(version);
+        }
         if (version != replacementValue.version) {
           throw new Error(`Replacement property (${replacement}.version) value (${replacementValue.version}) does not match computed value (${version}) in deprecated property (${deprecatedValue}) for: ${chain_name}::${name}`);
         }

--- a/.github/workflows/utility/validate_data.mjs
+++ b/.github/workflows/utility/validate_data.mjs
@@ -159,7 +159,7 @@ function checkReplacementVersionProperties(chain_name) {
     versions?.forEach((version) => {
       checkVersionForReplacementProperties(chain_name, version);
     });
-    //checkVersionForReplacementProperties(codebase);
+    checkVersionForReplacementProperties(chain_name, codebase);
   }
 
 }

--- a/.github/workflows/utility/validate_data.mjs
+++ b/.github/workflows/utility/validate_data.mjs
@@ -178,11 +178,13 @@ function checkVersionForReplacementProperties(chain_name, versionObject) {
   const tagRegexPattern = /^(?=.*-).+$/;
   const versionRegexPattern = /^([^ -]+)/;
 
+  const name = versionObject.name;
+
   for (const [deprecated, replacement] of replacementPropertiesMap) {
 
     const deprecatedValue = versionObject[deprecated];
     const replacementValue = versionObject[replacement];
-    const name = versionObject.name;
+    
 
     if (deprecatedValue) {
 
@@ -191,9 +193,7 @@ function checkVersionForReplacementProperties(chain_name, versionObject) {
         throw new Error(`Missing replacement property (${replacement}) for deprecated proerty (${deprecated}) for: ${chain_name}::${name}`);
       }
 
-      //replacement value must match
-      //split the value into repo, version, and tag
-
+      //split the value into repo, version, and tag, then check that they match
       let repo = deprecatedValue;
       repo = repo.match(splitRegexPattern)?.[1];
       repo = repo?.match(repoRegexPattern)?.[1];
@@ -207,9 +207,6 @@ function checkVersionForReplacementProperties(chain_name, versionObject) {
       let tag = deprecatedValue;
       tag = tag.match(splitRegexPattern)?.[2];
       let version = tag;
-      if (chain_name === "nibirudevnet3") {
-        console.log(version);
-      }
       tag = tag?.match(tagRegexPattern)?.[1];
       if (tag) {
         //console.log(tag);
@@ -219,27 +216,66 @@ function checkVersionForReplacementProperties(chain_name, versionObject) {
       }
 
       version = version?.match(versionRegexPattern)?.[1];
-      if(chain_name === "nibirudevnet3") {
-        console.log(version);
-        console.log(deprecatedValue);
-        console.log(replacementValue);
-      }
       if (version) {
         //console.log(version);
-        if (chain_name === "nibirudevnet3") {
-          console.log(version);
-        }
         if (version != replacementValue.version) {
           throw new Error(`Replacement property (${replacement}.version) value (${replacementValue.version}) does not match computed value (${version}) in deprecated property (${deprecatedValue}) for: ${chain_name}::${name}`);
         }
       }
 
-      //check that repo, version, and tag, are all correct in the replacement
+      if (deprecated === "ibc_go_version") {
+        const expectedValue = "go";
+        if (!replacementValue.type || (replacementValue.type !== expectedValue)) {
+          throw new Error(`Replacement property (${replacement}.type) value (${replacementValue.type}) does not match expected value (${expectedValue}) in deprecated property (${deprecatedValue}) for: ${chain_name}::${name}`);
+        }
+      }
+
+      if (deprecated === "go_version") {
+        const expectedValue = "go";
+        if (!replacementValue.type || (replacementValue.type !== expectedValue)) {
+          throw new Error(`Replacement property (${replacement}.type) value (${replacementValue.type}) does not match expected value (${expectedValue}) in deprecated property (${deprecatedValue}) for: ${chain_name}::${name}`);
+        }
+      }
+
+      if (deprecated === "cosmos_sdk_version") {
+        const expectedValue = "cosmos";
+        if (!replacementValue.type || (replacementValue.type !== expectedValue)) {
+          throw new Error(`Replacement property (${replacement}.type) value (${replacementValue.type}) does not match expected value (${expectedValue}) in deprecated property (${deprecatedValue}) for: ${chain_name}::${name}`);
+        }
+      }
 
     }
 
   }
 
+  if (versionObject.cosmwasm_enabled) {
+    if (versionObject.cosmwasm_enabled != versionObject.cosmwasm.enabled) {
+      throw new Error(`Replacement property (versionObject.cosmwasm.enabled) value (${versionObject.cosmwasm.enabled}) does not match deprecated property (versionObject.cosmwasm_enabled) value (${versionObject.cosmwasm_enabled}) for: ${chain_name}::${name}`);
+    }
+  }
+
+  if (versionObject.cosmwasm_path) {
+    if (versionObject.cosmwasm_path != versionObject.cosmwasm.path) {
+      throw new Error(`Replacement property (versionObject.cosmwasm.path) value (${versionObject.cosmwasm.path}) does not match deprecated proerty (versionObject.cosmwasm_path) value (${versionObject.cosmwasm_path}) for: ${chain_name}::${name}`);
+    }
+  }
+
+  if (versionObject.ics_enabled) {
+    if (!(arraysEqual(versionObject.ics_enabled, versionObject.ibc.ics_enabled))) {
+      throw new Error(`Replacement property (versionObject.ibc.ics_enabled) value (${versionObject.ibc.ics_enabled}) does not match deprecated property (versionObject.ics_enabled) value (${versionObject.ics_enabled}) for: ${chain_name}::${name}`);
+    }
+  }
+
+}
+
+function arraysEqual(arr1, arr2) {
+  if (arr1.length !== arr2.length) return false;
+
+  for (let i = 0; i < arr1.length; i++) {
+    if (arr1[i] !== arr2[i]) return false;
+  }
+
+  return true;
 }
 
 

--- a/aura/chain.json
+++ b/aura/chain.json
@@ -99,6 +99,7 @@
         "next_version_name": "v0.9.3",
         "sdk": {
           "type": "cosmos",
+          "repo": "https://github.com/evmos/cosmos-sdk",
           "version": "v0.47.8",
           "tag": "v0.47.8-evmos"
         },
@@ -128,6 +129,7 @@
         "next_version_name": "",
         "sdk": {
           "type": "cosmos",
+          "repo": "https://github.com/evmos/cosmos-sdk",
           "version": "v0.47.12",
           "tag": "v0.47.12-evmos"
         },

--- a/aura/chain.json
+++ b/aura/chain.json
@@ -151,7 +151,7 @@
     },
     "ibc": {
       "type": "go",
-      "version": "v7.6.1"
+      "version": "v7.6.0"
     },
     "cosmwasm": {
       "version": "v0.42.0",

--- a/axelar/chain.json
+++ b/axelar/chain.json
@@ -99,6 +99,7 @@
         "next_version_name": "",
         "sdk": {
           "type": "cosmos",
+          "repo": "https://github.com/axelarnetwork/cosmos-sdk",
           "version": "v0.45.17",
           "tag": "v0.45.17-0.20230904150332-37fb903a6c62"
         },

--- a/celestia/chain.json
+++ b/celestia/chain.json
@@ -73,6 +73,7 @@
         "next_version_name": "",
         "sdk": {
           "type": "cosmos",
+          "repo": "https://github.com/celestiaorg/cosmos-sdk",
           "version": "v1.23.0",
           "tag": "v1.23.0-sdk-v0.46.16"
         },

--- a/cheqd/chain.json
+++ b/cheqd/chain.json
@@ -99,6 +99,7 @@
         "next_version_name": "v0.5",
         "sdk": {
           "type": "cosmos",
+          "repo": "https://github.com/cheqd/cosmos-sdk",
           "version": "v0.44.5",
           "tag": "v0.44.5-cheqd"
         },
@@ -128,6 +129,7 @@
         "next_version_name": "v0.6",
         "sdk": {
           "type": "cosmos",
+          "repo": "https://github.com/cheqd/cosmos-sdk",
           "version": "v0.44.5",
           "tag": "v0.44.5-cheqd"
         },
@@ -162,6 +164,7 @@
         "next_version_name": "v1",
         "sdk": {
           "type": "cosmos",
+          "repo": "https://github.com/cheqd/cosmos-sdk",
           "version": "v0.45.9",
           "tag": "v0.45.9-cheqd-tag"
         },
@@ -199,6 +202,7 @@
         "next_version_name": "v2",
         "sdk": {
           "type": "cosmos",
+          "repo": "https://github.com/cheqd/cosmos-sdk",
           "version": "v0.46.10",
           "tag": "v0.46.10-barberry"
         },
@@ -232,6 +236,7 @@
         "next_version_name": "",
         "sdk": {
           "type": "cosmos",
+          "repo": "https://github.com/cheqd/cosmos-sdk",
           "version": "v0.47.10",
           "tag": "v0.47.10-height-mismatch"
         },

--- a/composable/chain.json
+++ b/composable/chain.json
@@ -39,7 +39,7 @@
       "v6.5.3"
     ],
     "cosmos_sdk_version": "rust-ninja/cosmos-sdk v0.47.5-patch-validators-trim-tag",
-    "ibc_go_version": "notional-labs/ibc-go/v7 v7.2.1-0.20231010040541-6cf43006971f",
+    "ibc_go_version": "notional-labs/ibc-go v7.2.1-0.20231010040541-6cf43006971f",
     "consensus": {
       "type": "cometbft",
       "version": "composablefi/cometbft v0.37.2-fixed-len-vote-time-tag"
@@ -214,7 +214,7 @@
           "v6.4.3"
         ],
         "cosmos_sdk_version": "v0.47.5",
-        "ibc_go_version": "notional-labs/ibc-go/v7 v7.2.1-0.20231010040541-6cf43006971f",
+        "ibc_go_version": "notional-labs/ibc-go v7.2.1-0.20231010040541-6cf43006971f",
         "consensus": {
           "type": "cometbft",
           "version": "composablefi/cometbft v0.37.2-fixed-len-vote-time-tag"
@@ -228,7 +228,7 @@
         },
         "ibc": {
           "type": "go",
-          "repo": "https://github.com/notional-labs/ibc-go/v7",
+          "repo": "https://github.com/notional-labs/ibc-go",
           "version": "v7.2.1",
           "tag": "v7.2.1-0.20231010040541-6cf43006971f"
         }
@@ -243,7 +243,7 @@
           "v6.5.2"
         ],
         "cosmos_sdk_version": "v0.47.6",
-        "ibc_go_version": "notional-labs/ibc-go/v7 v7.2.1-0.20231010040541-6cf43006971f",
+        "ibc_go_version": "notional-labs/ibc-go v7.2.1-0.20231010040541-6cf43006971f",
         "consensus": {
           "type": "cometbft",
           "version": "v0.37.2"
@@ -255,7 +255,7 @@
         },
         "ibc": {
           "type": "go",
-          "repo": "https://github.com/notional-labs/ibc-go/v7",
+          "repo": "https://github.com/notional-labs/ibc-go",
           "version": "v7.2.1",
           "tag": "v7.2.1-0.20231010040541-6cf43006971f"
         }
@@ -270,7 +270,7 @@
           "v6.5.3"
         ],
         "cosmos_sdk_version": "rust-ninja/cosmos-sdk v0.47.5-patch-validators-trim-tag",
-        "ibc_go_version": "notional-labs/ibc-go/v7 v7.2.1-0.20231010040541-6cf43006971f",
+        "ibc_go_version": "notional-labs/ibc-go v7.2.1-0.20231010040541-6cf43006971f",
         "consensus": {
           "type": "cometbft",
           "version": "composablefi/cometbft v0.37.2-fixed-len-vote-time-tag"
@@ -278,12 +278,13 @@
         "next_version_name": "",
         "sdk": {
           "type": "cosmos",
+          "repo": "https://github.com/rust-ninja/cosmos-sdk",
           "version": "v0.47.5",
           "tag": "v0.47.5-patch-validators-trim-tag"
         },
         "ibc": {
           "type": "go",
-          "repo": "https://github.com/notional-labs/ibc-go/v7",
+          "repo": "https://github.com/notional-labs/ibc-go",
           "version": "v7.2.1",
           "tag": "v7.2.1-0.20231010040541-6cf43006971f"
         }
@@ -297,7 +298,7 @@
     },
     "ibc": {
       "type": "go",
-      "repo": "https://github.com/notional-labs/ibc-go/v7",
+      "repo": "https://github.com/notional-labs/ibc-go",
       "version": "v7.2.1",
       "tag": "v7.2.1-0.20231010040541-6cf43006971f"
     }

--- a/desmos/chain.json
+++ b/desmos/chain.json
@@ -142,6 +142,7 @@
         "next_version_name": "v7.1.0",
         "sdk": {
           "type": "cosmos",
+          "repo": "https://github.com/desmos-labs/cosmos-sdk",
           "version": "v0.47.9",
           "tag": "v0.47.9-desmos"
         },
@@ -178,6 +179,7 @@
         "next_version_name": "",
         "sdk": {
           "type": "cosmos",
+          "repo": "https://github.com/desmos-labs/cosmos-sdk",
           "version": "v0.47.10",
           "tag": "v0.47.10-desmos"
         },

--- a/dhealth/chain.json
+++ b/dhealth/chain.json
@@ -75,6 +75,7 @@
         "next_version_name": "",
         "sdk": {
           "type": "cosmos",
+          "repo": "https://github.com/cosmos/cosmos-sdk",
           "version": "v0.47.4"
         },
         "cosmwasm": {

--- a/evmos/chain.json
+++ b/evmos/chain.json
@@ -361,12 +361,12 @@
     "sdk": {
       "type": "cosmos",
       "repo": "https://github.com/evmos/cosmos-sdk",
-      "version": "v0.47.5",
+      "version": "v0.47.12",
       "tag": "v0.47.5-evmos.2"
     },
     "ibc": {
       "type": "go",
-      "version": "7.4.0"
+      "version": "7.6.0"
     }
   },
   "logo_URIs": {

--- a/finschia/chain.json
+++ b/finschia/chain.json
@@ -166,6 +166,7 @@
     },
     "sdk": {
       "type": "cosmos",
+      "repo": "https://github.com/Finschia/finschia-sdk",
       "version": "v0.48.1"
     },
     "ibc": {

--- a/gateway/chain.json
+++ b/gateway/chain.json
@@ -45,6 +45,7 @@
     },
     "sdk": {
       "type": "cosmos",
+      "repo": "https://github.com/wormhole-foundation/cosmos-sdk",
       "version": "v0.45.9",
       "tag": "v0.45.9-wormhole-2"
     },

--- a/haqq/chain.json
+++ b/haqq/chain.json
@@ -464,6 +464,7 @@
         "next_version_name": "v1.7.1",
         "sdk": {
           "type": "cosmos",
+          "repo": "https://github.com/evmos/cosmos-sdk",
           "version": "v0.47.5",
           "tag": "v0.47.5-evmos"
         },
@@ -497,6 +498,7 @@
         "next_version_name": "v1.7.2",
         "sdk": {
           "type": "cosmos",
+          "repo": "https://github.com/evmos/cosmos-sdk",
           "version": "v0.47.5",
           "tag": "v0.47.5-evmos"
         },
@@ -530,6 +532,7 @@
         "next_version_name": "v1.7.3",
         "sdk": {
           "type": "cosmos",
+          "repo": "https://github.com/evmos/cosmos-sdk",
           "version": "v0.47.5",
           "tag": "v0.47.5-evmos"
         },
@@ -563,6 +566,7 @@
         "next_version_name": "v1.7.4",
         "sdk": {
           "type": "cosmos",
+          "repo": "https://github.com/evmos/cosmos-sdk",
           "version": "v0.47.5",
           "tag": "v0.47.5-evmos"
         },
@@ -596,6 +600,7 @@
         "next_version_name": "v1.7.5",
         "sdk": {
           "type": "cosmos",
+          "repo": "https://github.com/evmos/cosmos-sdk",
           "version": "v0.47.5",
           "tag": "v0.47.5-evmos"
         },
@@ -629,6 +634,7 @@
         "next_version_name": "v1.7.6",
         "sdk": {
           "type": "cosmos",
+          "repo": "https://github.com/evmos/cosmos-sdk",
           "version": "v0.47.5",
           "tag": "v0.47.5-evmos"
         },
@@ -662,6 +668,7 @@
         "next_version_name": "v1.7.7",
         "sdk": {
           "type": "cosmos",
+          "repo": "https://github.com/evmos/cosmos-sdk",
           "version": "v0.47.8",
           "tag": "v0.47.8-evmos"
         },
@@ -695,6 +702,7 @@
         "next_version_name": "",
         "sdk": {
           "type": "cosmos",
+          "repo": "https://github.com/evmos/cosmos-sdk",
           "version": "v0.47.8",
           "tag": "v0.47.8-evmos"
         },

--- a/lava/chain.json
+++ b/lava/chain.json
@@ -81,6 +81,7 @@
         "next_version_name": "",
         "sdk": {
           "type": "cosmos",
+          "repo": "https://github.com/lavanet/cosmos-sdk",
           "version": "v0.47.7",
           "tag": "v0.47.7-0.20231211141641-2a9ea55b724d"
         },
@@ -125,6 +126,7 @@
         "next_version_name": "v0.35.0",
         "sdk": {
           "type": "cosmos",
+          "repo": "https://github.com/lavanet/cosmos-sdk",
           "version": "v0.47.7",
           "tag": "v0.47.7-0.20231211141641-2a9ea55b724d"
         },
@@ -169,6 +171,7 @@
         "next_version_name": "v1.0.1",
         "sdk": {
           "type": "cosmos",
+          "repo": "https://github.com/lavanet/cosmos-sdk",
           "version": "v0.47.7",
           "tag": "v0.47.7-0.20231211141641-2a9ea55b724d"
         },
@@ -213,6 +216,7 @@
         "next_version_name": "v2.2.0",
         "sdk": {
           "type": "cosmos",
+          "repo": "https://github.com/lavanet/cosmos-sdk",
           "version": "v0.47.7",
           "tag": "v0.47.7-0.20231211141641-2a9ea55b724d"
         },
@@ -257,6 +261,7 @@
         "next_version_name": "",
         "sdk": {
           "type": "cosmos",
+          "repo": "https://github.com/lavanet/cosmos-sdk",
           "version": "v0.47.10",
           "tag": "v0.47.10-lava-cosmos"
         },

--- a/neutron/chain.json
+++ b/neutron/chain.json
@@ -166,6 +166,7 @@
         "next_version_name": "v3.0.5",
         "sdk": {
           "type": "cosmos",
+          "repo": "https://github.com/neutron-org/cosmos-sdk",
           "version": "v0.47.10",
           "tag": "v0.47.10-neutron"
         },
@@ -201,6 +202,7 @@
         "next_version_name": "v4.0.1",
         "sdk": {
           "type": "cosmos",
+          "repo": "https://github.com/neutron-org/cosmos-sdk",
           "version": "v0.47.10",
           "tag": "v0.47.10-neutron"
         },
@@ -236,6 +238,7 @@
         "next_version_name": "",
         "sdk": {
           "type": "cosmos",
+          "repo": "https://github.com/neutron-org/cosmos-sdk",
           "version": "v0.50.7",
           "tag": "v0.50.7-neutron"
         },

--- a/noble/chain.json
+++ b/noble/chain.json
@@ -279,6 +279,7 @@
         "next_version_name": "",
         "sdk": {
           "type": "cosmos",
+          "repo": "https://github.com/noble-assets/cosmos-sdk",
           "version": "v0.45.16",
           "tag": "v0.45.16-send-restrictions"
         },

--- a/nolus/chain.json
+++ b/nolus/chain.json
@@ -263,6 +263,7 @@
         "next_version_name": "v0.5.2",
         "sdk": {
           "type": "cosmos",
+          "repo": "https://github.com/nolus-protocol/cosmos-sdk",
           "version": "v0.47.6",
           "tag": "v0.47.6-nolus"
         },
@@ -303,6 +304,7 @@
         "next_version_name": "v0.5.3",
         "sdk": {
           "type": "cosmos",
+          "repo": "https://github.com/nolus-protocol/cosmos-sdk",
           "version": "v0.47.6",
           "tag": "v0.47.6-nolus"
         },
@@ -343,6 +345,7 @@
         "next_version_name": "",
         "sdk": {
           "type": "cosmos",
+          "repo": "https://github.com/nolus-protocol/cosmos-sdk",
           "version": "v0.47.8",
           "tag": "v0.47.8-nolus"
         },
@@ -383,6 +386,7 @@
         "next_version_name": "",
         "sdk": {
           "type": "cosmos",
+          "repo": "https://github.com/nolus-protocol/cosmos-sdk",
           "version": "v0.50.7",
           "tag": "v0.50.7-nolus-rc1"
         },

--- a/onomy/chain.json
+++ b/onomy/chain.json
@@ -67,6 +67,7 @@
         "next_version_name": "v1.0.3",
         "sdk": {
           "type": "cosmos",
+          "repo": "https://github.com/onomyprotocol/onomy-sdk",
           "version": "v0.44.6",
           "tag": "v0.44.6-0.20221103153534-77ffa1c3fab2"
         },
@@ -93,6 +94,7 @@
         "next_version_name": "v1.0.3",
         "sdk": {
           "type": "cosmos",
+          "repo": "https://github.com/onomyprotocol/onomy-sdk",
           "version": "v0.44.6",
           "tag": "v0.44.6-0.20230418124728-9c1be80b05bd"
         },
@@ -119,6 +121,7 @@
         "next_version_name": "v1.1.4",
         "sdk": {
           "type": "cosmos",
+          "repo": "https://github.com/onomyprotocol/onomy-sdk",
           "version": "v0.45.16",
           "tag": "v0.45.16-onomy-dev"
         },
@@ -149,6 +152,7 @@
         "next_version_name": "",
         "sdk": {
           "type": "cosmos",
+          "repo": "https://github.com/onomyprotocol/onomy-sdk",
           "version": "v0.45.16",
           "tag": "v0.45.16-onomy-dev"
         },

--- a/persistence/chain.json
+++ b/persistence/chain.json
@@ -196,7 +196,7 @@
           "v10.3.0"
         ],
         "cosmos_sdk_version": "persistenceOne/cosmos-sdk v0.47.3-lsm5",
-        "ibc_go_version": "persistenceOne/ibc-go/v7 v7.2.0-lsm3",
+        "ibc_go_version": "persistenceOne/ibc-go v7.2.0-lsm3",
         "ics_enabled": [
           "ics20-1",
           "ics27-1"
@@ -214,6 +214,7 @@
         "next_version_name": "v10.4.0",
         "sdk": {
           "type": "cosmos",
+          "repo": "https://github.com/persistenceOne/cosmos-sdk",
           "version": "v0.47.3",
           "tag": "v0.47.3-lsm5"
         },
@@ -226,7 +227,7 @@
         },
         "ibc": {
           "type": "go",
-          "repo": "https://github.com/persistenceOne/ibc-go/v7",
+          "repo": "https://github.com/persistenceOne/ibc-go",
           "version": "v7.2.0",
           "tag": "v7.2.0-lsm3",
           "ics_enabled": [
@@ -245,7 +246,7 @@
           "v10.4.0"
         ],
         "cosmos_sdk_version": "persistenceOne/cosmos-sdk v0.47.3-lsm5",
-        "ibc_go_version": "persistenceOne/ibc-go/v7 v7.2.0-lsm3",
+        "ibc_go_version": "persistenceOne/ibc-go v7.2.0-lsm3",
         "ics_enabled": [
           "ics20-1",
           "ics27-1"
@@ -263,6 +264,7 @@
         "next_version_name": "v10.4.1",
         "sdk": {
           "type": "cosmos",
+          "repo": "https://github.com/persistenceOne/cosmos-sdk",
           "version": "v0.47.3",
           "tag": "v0.47.3-lsm5"
         },
@@ -275,7 +277,7 @@
         },
         "ibc": {
           "type": "go",
-          "repo": "https://github.com/persistenceOne/ibc-go/v7",
+          "repo": "https://github.com/persistenceOne/ibc-go",
           "version": "v7.2.0",
           "tag": "v7.2.0-lsm3",
           "ics_enabled": [
@@ -294,7 +296,7 @@
           "v10.5.0"
         ],
         "cosmos_sdk_version": "persistenceOne/cosmos-sdk v0.47.3-lsm5",
-        "ibc_go_version": "persistenceOne/ibc-go/v7 v7.2.0-lsm3",
+        "ibc_go_version": "persistenceOne/ibc-go v7.2.0-lsm3",
         "ics_enabled": [
           "ics20-1",
           "ics27-1"
@@ -312,6 +314,7 @@
         "next_version_name": "v11",
         "sdk": {
           "type": "cosmos",
+          "repo": "https://github.com/persistenceOne/cosmos-sdk",
           "version": "v0.47.3",
           "tag": "v0.47.3-lsm5"
         },
@@ -324,7 +327,7 @@
         },
         "ibc": {
           "type": "go",
-          "repo": "https://github.com/persistenceOne/ibc-go/v7",
+          "repo": "https://github.com/persistenceOne/ibc-go",
           "version": "v7.2.0",
           "tag": "v7.2.0-lsm3",
           "ics_enabled": [
@@ -343,7 +346,7 @@
           "v11.8.1"
         ],
         "cosmos_sdk_version": "persistenceOne/cosmos-sdk v0.47.3-lsm5",
-        "ibc_go_version": "persistenceOne/ibc-go/v7 v7.2.0-lsm3",
+        "ibc_go_version": "persistenceOne/ibc-go v7.2.0-lsm3",
         "ics_enabled": [
           "ics20-1",
           "ics27-1"
@@ -361,6 +364,7 @@
         "next_version_name": "v11.9.0",
         "sdk": {
           "type": "cosmos",
+          "repo": "https://github.com/persistenceOne/cosmos-sdk",
           "version": "v0.47.3",
           "tag": "v0.47.3-lsm5"
         },
@@ -373,7 +377,7 @@
         },
         "ibc": {
           "type": "go",
-          "repo": "https://github.com/persistenceOne/ibc-go/v7",
+          "repo": "https://github.com/persistenceOne/ibc-go",
           "version": "v7.2.0",
           "tag": "v7.2.0-lsm3",
           "ics_enabled": [
@@ -410,6 +414,7 @@
         "next_version_name": "v11.10.0",
         "sdk": {
           "type": "cosmos",
+          "repo": "https://github.com/persistenceOne/cosmos-sdk",
           "version": "v0.47.10",
           "tag": "v0.47.10-lsm-rc0"
         },
@@ -455,6 +460,7 @@
         "next_version_name": "v11.11.0",
         "sdk": {
           "type": "cosmos",
+          "repo": "https://github.com/persistenceOne/cosmos-sdk",
           "version": "v0.47.10",
           "tag": "v0.47.10-lsm-rc0"
         },
@@ -500,6 +506,7 @@
         "next_version_name": "v11.12.0",
         "sdk": {
           "type": "cosmos",
+          "repo": "https://github.com/persistenceOne/cosmos-sdk",
           "version": "v0.47.10",
           "tag": "v0.47.10-lsm-rc0"
         },
@@ -545,6 +552,7 @@
         "next_version_name": "v11.13.0",
         "sdk": {
           "type": "cosmos",
+          "repo": "https://github.com/persistenceOne/cosmos-sdk",
           "version": "v0.47.10",
           "tag": "v0.47.10-lsm-rc0"
         },
@@ -590,6 +598,7 @@
         "next_version_name": "v11.14.0",
         "sdk": {
           "type": "cosmos",
+          "repo": "https://github.com/persistenceOne/cosmos-sdk",
           "version": "v0.47.10",
           "tag": "v0.47.10-lsm-rc0"
         },
@@ -635,6 +644,7 @@
         "next_version_name": "",
         "sdk": {
           "type": "cosmos",
+          "repo": "https://github.com/persistenceOne/cosmos-sdk",
           "version": "v0.47.10",
           "tag": "v0.47.10-lsm-rc0"
         },

--- a/sge/chain.json
+++ b/sge/chain.json
@@ -183,6 +183,7 @@
         "next_version_name": "v1.5.3",
         "sdk": {
           "type": "cosmos",
+          "repo": "https://github.com/sge-network/cosmos-sdk",
           "version": "v0.46.17",
           "tag": "v0.46.17-0.20240223100624-2a2661276cb4"
         },
@@ -208,6 +209,7 @@
         "next_version_name": "v1.6.2",
         "sdk": {
           "type": "cosmos",
+          "repo": "https://github.com/sge-network/cosmos-sdk",
           "version": "v0.46.17",
           "tag": "v0.46.17-0.20240223100624-2a2661276cb4"
         },
@@ -233,6 +235,7 @@
         "next_version_name": "v1.7.0",
         "sdk": {
           "type": "cosmos",
+          "repo": "https://github.com/sge-network/cosmos-sdk",
           "version": "v0.46.17",
           "tag": "v0.46.17-0.20240430064306-1b044d03d56c"
         },
@@ -258,6 +261,7 @@
         "next_version_name": "v1.7.2",
         "sdk": {
           "type": "cosmos",
+          "repo": "https://github.com/sge-network/cosmos-sdk",
           "version": "v0.47.9",
           "tag": "v0.47.9-0.20240409081440-054c8c413d45"
         },
@@ -283,6 +287,7 @@
         "next_version_name": "",
         "sdk": {
           "type": "cosmos",
+          "repo": "https://github.com/sge-network/cosmos-sdk",
           "version": "v0.47.9",
           "tag": "v0.47.9-0.20240409081440-054c8c413d45"
         },

--- a/stride/chain.json
+++ b/stride/chain.json
@@ -360,6 +360,7 @@
         "next_version_name": "v19",
         "sdk": {
           "type": "cosmos",
+          "repo": "https://github.com/Stride-Labs/cosmos-sdk",
           "version": "v0.47.5",
           "tag": "v0.47.5-stride-distribution-fix-0"
         },
@@ -386,6 +387,7 @@
         "next_version_name": "v20",
         "sdk": {
           "type": "cosmos",
+          "repo": "https://github.com/Stride-Labs/cosmos-sdk",
           "version": "v0.47.5",
           "tag": "v0.47.5-stride-distribution-fix-0"
         },
@@ -412,6 +414,7 @@
         "next_version_name": "v21",
         "sdk": {
           "type": "cosmos",
+          "repo": "https://github.com/Stride-Labs/cosmos-sdk",
           "version": "v0.47.10",
           "tag": "v0.47.10-stride-distribution-fix-0"
         },
@@ -438,6 +441,7 @@
         "next_version_name": "v22",
         "sdk": {
           "type": "cosmos",
+          "repo": "https://github.com/Stride-Labs/cosmos-sdk",
           "version": "v0.47.10",
           "tag": "v0.47.10-stride-distribution-fix-0"
         },
@@ -464,6 +468,7 @@
         "next_version_name": "v23",
         "sdk": {
           "type": "cosmos",
+          "repo": "https://github.com/Stride-Labs/cosmos-sdk",
           "version": "v0.47.10",
           "tag": "v0.47.10-stride-distribution-fix-0"
         },
@@ -490,6 +495,7 @@
         "next_version_name": "",
         "sdk": {
           "type": "cosmos",
+          "repo": "https://github.com/Stride-Labs/cosmos-sdk",
           "version": "v0.47.10",
           "tag": "v0.47.10-stride-distribution-fix-0"
         },

--- a/terra2/chain.json
+++ b/terra2/chain.json
@@ -365,7 +365,7 @@
         "cosmos_sdk_version": "terra-money/cosmos-sdk v0.47.6-terra.0",
         "cosmwasm_enabled": true,
         "cosmwasm_version": "v0.45.0",
-        "ibc_go_version": "terra-money/ibc-go/v7 v7.3.1-terra.0",
+        "ibc_go_version": "terra-money/ibc-go v7.3.1-terra.0",
         "consensus": {
           "type": "cometbft",
           "version": "v0.37.2"
@@ -377,6 +377,7 @@
         "next_version_name": "",
         "sdk": {
           "type": "cosmos",
+          "repo": "https://github.com/terra-money/cosmos-sdk",
           "version": "v0.47.6",
           "tag": "v0.47.6-terra.0"
         },
@@ -386,7 +387,7 @@
         },
         "ibc": {
           "type": "go",
-          "repo": "https://github.com/terra-money/ibc-go/v7",
+          "repo": "https://github.com/terra-money/ibc-go",
           "version": "v7.3.1",
           "tag": "v7.3.1-terra.0"
         }

--- a/testnets/cheqdtestnet/chain.json
+++ b/testnets/cheqdtestnet/chain.json
@@ -69,6 +69,7 @@
         "next_version_name": "v1",
         "sdk": {
           "type": "cosmos",
+          "repo": "https://github.com/cheqd/cosmos-sdk",
           "version": "v0.45.9",
           "tag": "v0.45.9-cheqd-tag"
         },
@@ -104,6 +105,7 @@
         "next_version_name": "v2",
         "sdk": {
           "type": "cosmos",
+          "repo": "https://github.com/cheqd/cosmos-sdk",
           "version": "v0.46.10",
           "tag": "v0.46.10-barberry"
         },
@@ -137,6 +139,7 @@
         "next_version_name": "",
         "sdk": {
           "type": "cosmos",
+          "repo": "https://github.com/cheqd/cosmos-sdk",
           "version": "v0.47.10",
           "tag": "v0.47.10-height-mismatch"
         },

--- a/testnets/finschiatestnet/chain.json
+++ b/testnets/finschiatestnet/chain.json
@@ -166,6 +166,7 @@
     },
     "sdk": {
       "type": "cosmos",
+      "repo": "https://github.com/Finschia/finschia-sdk",
       "version": "v0.48.1"
     },
     "ibc": {

--- a/testnets/neutrontestnet/chain.json
+++ b/testnets/neutrontestnet/chain.json
@@ -219,7 +219,7 @@
       "version": "8.2.1"
     },
     "cosmwasm": {
-      "version": "0.51",
+      "version": "0.52",
       "enabled": true
     }
   },

--- a/testnets/nibirudevnet3/chain.json
+++ b/testnets/nibirudevnet3/chain.json
@@ -125,7 +125,7 @@
         "ibc_go_version": "v7.3.1",
         "sdk": {
           "type": "cosmos",
-          "version": "v0.47.6"
+          "version": "v0.47.7"
         },
         "cosmwasm": {
           "version": "v0.44.0",

--- a/testnets/nibirudevnet3/chain.json
+++ b/testnets/nibirudevnet3/chain.json
@@ -36,7 +36,7 @@
   "codebase": {
     "git_repo": "https://github.com/NibiruChain/nibiru",
     "recommended_version": "v1.0.1",
-    "compatible_versions": ["v1.0.1"],
+    "compatible_versions": [ "v1.0.1" ],
     "binaries": {
       "linux/amd64": "https://github.com/NibiruChain/nibiru/releases/download/v1.0.1/nibid_1.0.1_linux_amd64.tar.gz",
       "linux/arm64": "https://github.com/NibiruChain/nibiru/releases/download/v1.0.1/nibid_1.0.1_linux_arm64.tar.gz",
@@ -51,6 +51,19 @@
     "cosmwasm_version": "v0.44.0",
     "cosmwasm_enabled": true,
     "ibc_go_version": "v7.3.1",
+    "sdk": {
+      "type": "cosmos",
+      "version": "v0.45.5"
+    },
+    "cosmwasm": {
+      "version": "v0.44.0",
+      "path": "$HOME/.nibid/data/wasm",
+      "enabled": true
+    },
+    "ibc": {
+      "type": "go",
+      "version": "v7.3.1"
+    },
     "genesis": {
       "genesis_url": "https://raw.githubusercontent.com/NibiruChain/Networks/main/Testnet/nibiru-devnet-2/genesis.json"
     },
@@ -58,7 +71,7 @@
       {
         "name": "v1.0.0",
         "recommended_version": "v1.0.0",
-        "compatible_versions": ["v1.0.0"],
+        "compatible_versions": [ "v1.0.0" ],
         "tag": "v1.0.0",
         "height": 1,
         "consensus": {
@@ -74,12 +87,25 @@
           "linux/amd64": "https://github.com/NibiruChain/nibiru/releases/download/v1.0.0/nibid_1.0.0_linux_amd64.tar.gz",
           "linux/arm64": "https://github.com/NibiruChain/nibiru/releases/download/v1.0.0/nibid_1.0.0_linux_arm64.tar.gz"
         },
+        "sdk": {
+          "type": "cosmos",
+          "version": "v0.45.5"
+        },
+        "cosmwasm": {
+          "version": "v0.44.0",
+          "path": "$HOME/.nibid/data/wasm",
+          "enabled": true
+        },
+        "ibc": {
+          "type": "go",
+          "version": "v7.3.1"
+        },
         "next_version_name": "v1.0.1"
       },
       {
         "name": "v1.0.1",
         "recommended_version": "v1.0.1",
-        "compatible_versions": ["v1.0.1"],
+        "compatible_versions": [ "v1.0.1" ],
         "tag": "v1.0.1",
         "binaries": {
           "linux/amd64": "https://github.com/NibiruChain/nibiru/releases/download/v1.0.1/nibid_1.0.1_linux_amd64.tar.gz",
@@ -97,6 +123,19 @@
         "cosmwasm_version": "v0.44.0",
         "cosmwasm_enabled": true,
         "ibc_go_version": "v7.3.1",
+        "sdk": {
+          "type": "cosmos",
+          "version": "v0.47.6"
+        },
+        "cosmwasm": {
+          "version": "v0.44.0",
+          "path": "$HOME/.nibid/data/wasm",
+          "enabled": true
+        },
+        "ibc": {
+          "type": "go",
+          "version": "v7.3.1"
+        },
         "next_version_name": ""
       }
     ]

--- a/testnets/nibirudevnet3/chain.json
+++ b/testnets/nibirudevnet3/chain.json
@@ -53,7 +53,7 @@
     "ibc_go_version": "v7.3.1",
     "sdk": {
       "type": "cosmos",
-      "version": "v0.45.5"
+      "version": "v0.47.7"
     },
     "cosmwasm": {
       "version": "v0.44.0",

--- a/testnets/nibirudevnet4/chain.json
+++ b/testnets/nibirudevnet4/chain.json
@@ -36,7 +36,7 @@
   "codebase": {
     "git_repo": "https://github.com/NibiruChain/nibiru",
     "recommended_version": "v1.0.1",
-    "compatible_versions": ["v1.0.1"],
+    "compatible_versions": [ "v1.0.1" ],
     "binaries": {
       "linux/amd64": "https://github.com/NibiruChain/nibiru/releases/download/v1.0.1/nibid_1.0.1_linux_amd64.tar.gz",
       "linux/arm64": "https://github.com/NibiruChain/nibiru/releases/download/v1.0.1/nibid_1.0.1_linux_arm64.tar.gz",
@@ -51,6 +51,19 @@
     "cosmwasm_version": "v0.44.0",
     "cosmwasm_enabled": true,
     "ibc_go_version": "v7.3.1",
+    "sdk": {
+      "type": "cosmos",
+      "version": "v0.47.7"
+    },
+    "cosmwasm": {
+      "version": "v0.44.0",
+      "path": "$HOME/.nibid/data/wasm",
+      "enabled": true
+    },
+    "ibc": {
+      "type": "go",
+      "version": "v7.3.1"
+    },
     "genesis": {
       "genesis_url": "https://raw.githubusercontent.com/NibiruChain/Networks/main/Testnet/nibiru-devnet-2/genesis.json"
     },
@@ -58,7 +71,7 @@
       {
         "name": "v1.0.0",
         "recommended_version": "v1.0.0",
-        "compatible_versions": ["v1.0.0"],
+        "compatible_versions": [ "v1.0.0" ],
         "tag": "v1.0.0",
         "height": 1,
         "consensus": {
@@ -70,6 +83,19 @@
         "cosmwasm_enabled": true,
         "ibc_go_version": "v7.3.1",
         "cosmwasm_path": "$HOME/.nibid/data/wasm",
+        "sdk": {
+          "type": "cosmos",
+          "version": "v0.45.5"
+        },
+        "cosmwasm": {
+          "version": "v0.44.0",
+          "path": "$HOME/.nibid/data/wasm",
+          "enabled": true
+        },
+        "ibc": {
+          "type": "go",
+          "version": "v7.3.1"
+        },
         "binaries": {
           "linux/amd64": "https://github.com/NibiruChain/nibiru/releases/download/v1.0.0/nibid_1.0.0_linux_amd64.tar.gz",
           "linux/arm64": "https://github.com/NibiruChain/nibiru/releases/download/v1.0.0/nibid_1.0.0_linux_arm64.tar.gz"
@@ -79,7 +105,7 @@
       {
         "name": "v1.0.1",
         "recommended_version": "v1.0.1",
-        "compatible_versions": ["v1.0.1"],
+        "compatible_versions": [ "v1.0.1" ],
         "tag": "v1.0.1",
         "binaries": {
           "linux/amd64": "https://github.com/NibiruChain/nibiru/releases/download/v1.0.1/nibid_1.0.1_linux_amd64.tar.gz",
@@ -97,6 +123,19 @@
         "cosmwasm_version": "v0.44.0",
         "cosmwasm_enabled": true,
         "ibc_go_version": "v7.3.1",
+        "sdk": {
+          "type": "cosmos",
+          "version": "v0.47.7"
+        },
+        "cosmwasm": {
+          "version": "v0.44.0",
+          "path": "$HOME/.nibid/data/wasm",
+          "enabled": true
+        },
+        "ibc": {
+          "type": "go",
+          "version": "v7.3.1"
+        },
         "next_version_name": ""
       }
     ]

--- a/testnets/nobletestnet/chain.json
+++ b/testnets/nobletestnet/chain.json
@@ -117,7 +117,7 @@
           "version": "0.34"
         },
         "cosmwasm_enabled": false,
-        "ibc_go_version": "v3.4.0 (fork)",
+        "ibc_go_version": "v3.4.0",
         "ics_enabled": [
           "ics20-1"
         ],
@@ -133,8 +133,7 @@
           "version": "v3.4.0",
           "ics_enabled": [
             "ics20-1"
-          ],
-          "tag": "v3.4.0(fork)"
+          ]
         }
       },
       {
@@ -148,7 +147,7 @@
           "version": "0.34"
         },
         "cosmwasm_enabled": false,
-        "ibc_go_version": "v3.4.0 (fork)",
+        "ibc_go_version": "v3.4.0",
         "ics_enabled": [
           "ics20-1"
         ],
@@ -164,8 +163,7 @@
           "version": "v3.4.0",
           "ics_enabled": [
             "ics20-1"
-          ],
-          "tag": "v3.4.0(fork)"
+          ]
         }
       }
     ],

--- a/testnets/persistencetestnet2/chain.json
+++ b/testnets/persistencetestnet2/chain.json
@@ -175,7 +175,7 @@
         },
         "sdk": {
           "type": "cosmos",
-          "version": "v0.47",
+          "version": "v0.47.x",
           "tag": "v0.47.x-lsm"
         },
         "cosmwasm": {

--- a/ununifi/chain.json
+++ b/ununifi/chain.json
@@ -442,6 +442,7 @@
         "next_version_name": "",
         "sdk": {
           "type": "cosmos",
+          "repo": "https://github.com/ununifi/cosmos-sdk",
           "version": "v0.47.3",
           "tag": "v0.47.3-custom-bank-1"
         },

--- a/xpla/chain.json
+++ b/xpla/chain.json
@@ -107,6 +107,7 @@
         "next_version_name": "",
         "sdk": {
           "type": "cosmos",
+          "repo": "https://github.com/xpladev/cosmos-sdk",
           "version": "v0.45.20",
           "tag": "v0.45.20-xpla"
         },


### PR DESCRIPTION
```
const replacementPropertiesMap = new Map([
    ["cosmos_sdk_version", "sdk"],
    ["ibc_go_version", "ibc"],
    ["go_version", "language"],
    ["cosmwasm_version", "cosmwasm"]
  ]);
```

if cosmos_sdk_version is defined, then the replacement sdk object must exists, with type: cosmos, and version tag, and repo, expacted from the value.