### PR TITLE
Add Cosmos Hub RPC "dRPC"

### DIFF
--- a/cosmoshub/chain.json
+++ b/cosmoshub/chain.json
@@ -695,6 +695,10 @@
       {
         "address": "https://cosmos-rpc.stakeandrelax.net",
         "provider": "Stake&Relax 🦥"
+      },
+      {
+        "address": "https://cosmos-hub.drpc.org",
+        "provider": "dRPC"
       }
     ],
     "rest": [


### PR DESCRIPTION
added dRPC to the list of RPCs.

https://drpc.org/chainlist/cosmos-hub