### PR TITLE
feat: upgrade celestia to v2.1.2

### DIFF
--- a/celestia/chain.json
+++ b/celestia/chain.json
@@ -34,28 +34,25 @@
   },
   "codebase": {
     "git_repo": "https://github.com/celestiaorg/celestia-app",
-    "recommended_version": "v1.13celestiaorg/cosmos-sdk v1.24.1-sdk-v0.46.16.0",
+    "recommended_version": "v2.1.2",
     "compatible_versions": [
-      "v1.3.0",
-      "v1.6.0",
-      "v1.7.0",
-      "v1.9.0",
-      "v1.10.1",
-      "v1.11.0",
-      "v1.13.0"
+      "v2.0.0",
+      "v2.1.0",
+      "v2.1.1",
+      "v2.1.2"
     ],
-    "cosmos_sdk_version": "celestiaorg/cosmos-sdk v1.23.0-sdk-v0.46.16",
+    "cosmos_sdk_version": "celestiaorg/cosmos-sdk v1.24.1-sdk-v0.46.16",
     "ibc_go_version": "v6.2.1",
     "consensus": {
       "type": "tendermint",
-      "version": "celestiaorg/celestia-core v1.38.0-tm-v0.34.29"
+      "version": "celestiaorg/celestia-core v1.40.0-tm-v0.34.29"
     },
     "genesis": {
       "genesis_url": "https://raw.githubusercontent.com/celestiaorg/networks/master/celestia/genesis.json"
     },
     "versions": [
       {
-        "name": "v1.3.0",
+        "name": "v1",
         "recommended_version": "v1.13.0",
         "compatible_versions": [
           "v1.3.0",
@@ -83,6 +80,16 @@
           "type": "go",
           "version": "v6.2.1"
         }
+      },
+      {
+        "name": "v2",
+        "recommended_version": "v2.1.2",
+        "compatible_versions": [
+          "v2.0.0",
+          "v2.1.0",
+          "v2.1.1",
+          "v2.1.2"
+        ]
       }
     ],
     "sdk": {

--- a/celestia/chain.json
+++ b/celestia/chain.json
@@ -95,8 +95,8 @@
     "sdk": {
       "type": "cosmos",
       "repo": "https://github.com/celestiaorg/cosmos-sdk",
-      "version": "v1.23.0",
-      "tag": "v1.23.0-sdk-v0.46.16"
+      "version": "v1.24.1",
+      "tag": "v1.24.1-sdk-v0.46.16"
     },
     "ibc": {
       "type": "go",


### PR DESCRIPTION
[celestia-app v2.1.2](https://github.com/celestiaorg/celestia-app/releases/tag/v2.1.2) is recommended for Mainnet Beta. Please tag me and @jcstein on future PRs that modify Celestia files.