### PR TITLE
bluechip-1 to bluechip-2

### DIFF
--- a/bluechip/chain.json
+++ b/bluechip/chain.json
@@ -55,7 +55,7 @@
         "cosmwasm_enabled": true,
         "sdk": {
           "type": "cosmos",
-          "version": "0.46.7"
+          "version": "0.47.11"
         },
         "cosmwasm": {
           "enabled": true
@@ -64,7 +64,7 @@
     ],
     "sdk": {
       "type": "cosmos",
-      "version": "0.46.7"
+      "version": "0.47.11"
     },
     "cosmwasm": {
       "enabled": true

--- a/bluechip/chain.json
+++ b/bluechip/chain.json
@@ -6,7 +6,7 @@
   "network_type": "mainnet",
   "pretty_name": "BlueChip",
   "chain_type": "cosmos",
-  "chain_id": "bluechip-1",
+  "chain_id": "bluechip-2",
   "bech32_prefix": "bcp",
   "daemon_name": "bluechipd",
   "node_home": "$HOME/.bluechip",
@@ -39,7 +39,7 @@
     "compatible_versions": [
       "v1"
     ],
-    "cosmos_sdk_version": "0.46.7",
+    "cosmos_sdk_version": "0.47.11",
     "cosmwasm_enabled": true,
     "genesis": {
       "genesis_url": "https://github.com/Bluechip23/bluechip/blob/main/genesis.json"
@@ -51,7 +51,7 @@
         "compatible_versions": [
           "v1"
         ],
-        "cosmos_sdk_version": "0.46.7",
+        "cosmos_sdk_version": "0.47.11",
         "cosmwasm_enabled": true,
         "sdk": {
           "type": "cosmos",
@@ -74,7 +74,7 @@
     "seeds": [],
     "persistent_peers": [
       {
-        "id": "3x4pynlp86prhcmtns742kgsgu7pjtzjpk8d93",
+        "id": "8cc3f0821599561159a6157617820f1770c447d7",
         "address": "http://67.28.8.88:26659/",
         "provider": "CryptoDungeon"
       }


### PR DESCRIPTION
We originally had changed out chain-Id but after doing so, we ran into multiple issues with syncing to other nodes and IBC issues. We upgraded our chain at created a new one. Everything else about the chain is the same.