### PR TITLE
Bump Cronos "recommended_version" to v1.3.0

### DIFF
--- a/cronos/chain.json
+++ b/cronos/chain.json
@@ -26,37 +26,39 @@
   },
   "codebase": {
     "git_repo": "https://github.com/crypto-org-chain/cronos",
-    "recommended_version": "v1.2.2",
+    "recommended_version": "v1.3.0",
     "compatible_versions": [
       "v1.2.0",
       "v1.2.1",
-      "v1.2.2"
+      "v1.2.2",
+      "v1.3.0"
     ],
     "binaries": {
-      "linux/amd64": "https://github.com/crypto-org-chain/cronos/releases/download/v1.2.2/cronos_1.2.2_Linux_x86_64.tar.gz",
-      "linux/arm64": "https://github.com/crypto-org-chain/cronos/releases/download/v1.2.2/cronos_1.2.2_Linux_arm64.tar.gz",
-      "darwin/amd64": "https://github.com/crypto-org-chain/cronos/releases/download/v1.2.2/cronos_1.2.2_Darwin_x86_64.tar.gz",
-      "darwin/arm64": "https://github.com/crypto-org-chain/cronos/releases/download/v1.2.2/cronos_1.2.2_Darwin_arm64.tar.gz",
-      "windows/amd64": "https://github.com/crypto-org-chain/cronos/releases/download/v1.2.2/cronos_1.2.2_Windows_x86_64.zip"
+      "linux/amd64": "https://github.com/crypto-org-chain/cronos/releases/download/v1.3.0/cronos_1.3.0_Linux_x86_64.tar.gz",
+      "linux/arm64": "https://github.com/crypto-org-chain/cronos/releases/download/v1.3.0/cronos_1.3.0_Linux_arm64.tar.gz",
+      "darwin/amd64": "https://github.com/crypto-org-chain/cronos/releases/download/v1.3.0/cronos_1.3.0_Darwin_x86_64.tar.gz",
+      "darwin/arm64": "https://github.com/crypto-org-chain/cronos/releases/download/v1.3.0/cronos_1.3.0_Darwin_arm64.tar.gz",
+      "windows/amd64": "https://github.com/crypto-org-chain/cronos/releases/download/v1.3.0/cronos_1.3.0_Windows_x86_64.tar.gz"
     },
     "genesis": {
       "genesis_url": "https://raw.githubusercontent.com/crypto-org-chain/cronos-mainnet/master/cronosmainnet_25-1/genesis.json"
     },
     "versions": [
       {
-        "name": "v1.2.2",
-        "recommended_version": "v1.2.2",
+        "name": "v1.3.0",
+        "recommended_version": "v1.3.0",
         "compatible_versions": [
           "v1.2.0",
           "v1.2.1",
-          "v1.2.2"
+          "v1.2.2",
+          "v1.3.0",
         ],
         "binaries": {
-          "linux/amd64": "https://github.com/crypto-org-chain/cronos/releases/download/v1.2.2/cronos_1.2.2_Linux_x86_64.tar.gz",
-          "linux/arm64": "https://github.com/crypto-org-chain/cronos/releases/download/v1.2.2/cronos_1.2.2_Linux_arm64.tar.gz",
-          "darwin/amd64": "https://github.com/crypto-org-chain/cronos/releases/download/v1.2.2/cronos_1.2.2_Darwin_x86_64.tar.gz",
-          "darwin/arm64": "https://github.com/crypto-org-chain/cronos/releases/download/v1.2.2/cronos_1.2.2_Darwin_arm64.tar.gz",
-          "windows/amd64": "https://github.com/crypto-org-chain/cronos/releases/download/v1.2.2/cronos_1.2.2_Windows_x86_64.zip"
+          "linux/amd64": "https://github.com/crypto-org-chain/cronos/releases/download/v1.3.0/cronos_1.3.0_Linux_x86_64.tar.gz",
+          "linux/arm64": "https://github.com/crypto-org-chain/cronos/releases/download/v1.3.0/cronos_1.3.0_Linux_arm64.tar.gz",
+          "darwin/amd64": "https://github.com/crypto-org-chain/cronos/releases/download/v1.3.0/cronos_1.3.0_Darwin_x86_64.tar.gz",
+          "darwin/arm64": "https://github.com/crypto-org-chain/cronos/releases/download/v1.3.0/cronos_1.3.0_Darwin_arm64.tar.gz",
+          "windows/amd64": "https://github.com/crypto-org-chain/cronos/releases/download/v1.3.0/cronos_1.3.0_Windows_x86_64.tar.gz"
         }
       }
     ]

--- a/cronos/chain.json
+++ b/cronos/chain.json
@@ -51,7 +51,7 @@
           "v1.2.0",
           "v1.2.1",
           "v1.2.2",
-          "v1.3.0",
+          "v1.3.0"
         ],
         "binaries": {
           "linux/amd64": "https://github.com/crypto-org-chain/cronos/releases/download/v1.3.0/cronos_1.3.0_Linux_x86_64.tar.gz",


### PR DESCRIPTION
Hello Cosmos team, this PR is to bump the `recommended_version` of cronosd to [v1.3.0](https://github.com/crypto-org-chain/cronos/releases/tag/v1.3.0).