### PR TITLE
Upgrade Cosmos Hub Testnets to Gaia v20

### DIFF
--- a/testnets/cosmoshubtestnet/chain.json
+++ b/testnets/cosmoshubtestnet/chain.json
@@ -33,18 +33,14 @@
   },
   "codebase": {
     "git_repo": "https://github.com/cosmos/gaia",
-    "recommended_version": "v14.1.0",
+    "recommended_version": "v20.0.0-rc0",
     "compatible_versions": [
-      "v14.1.0-rc0",
-      "v14.1.0"
+      "v20.0.0-rc0"
     ],
     "binaries": {
-      "linux/amd64": "https://github.com/cosmos/gaia/releases/download/v14.1.0/gaiad-v14.1.0-linux-amd64",
-      "linux/arm64": "https://github.com/cosmos/gaia/releases/download/v14.1.0/gaiad-v14.1.0-linux-arm64",
-      "darwin/amd64": "https://github.com/cosmos/gaia/releases/download/v14.1.0/gaiad-v14.1.0-darwin-amd64",
-      "darwin/arm64": "https://github.com/cosmos/gaia/releases/download/v14.1.0/gaiad-v14.1.0-darwin-arm64",
-      "windows/amd64": "https://github.com/cosmos/gaia/releases/download/v14.1.0/gaiad-v14.1.0-windows-amd64.exe",
-      "windows/arm64": "https://github.com/cosmos/gaia/releases/download/v14.1.0/gaiad-v14.1.0-windows-arm64.exe"
+      "linux/amd64": "https://github.com/cosmos/gaia/releases/download/v20.0.0-rc0/gaiad-v20.0.0-rc0-linux-amd64",
+      "darwin/amd64": "https://github.com/cosmos/gaia/releases/download/v20.0.0-rc0/gaiad-v20.0.0-rc0-darwin-amd64",
+      "darwin/arm64": "https://github.com/cosmos/gaia/releases/download/v20.0.0-rc0/gaiad-v20.0.0-rc0-darwin-arm64"
     },
     "genesis": {
       "genesis_url": "https://github.com/cosmos/testnets/raw/master/public/genesis.json.gz"
@@ -140,6 +136,18 @@
           "windows/amd64": "https://github.com/cosmos/gaia/releases/download/v14.1.0/gaiad-v14.1.0-windows-amd64.exe",
           "windows/arm64": "https://github.com/cosmos/gaia/releases/download/v14.1.0/gaiad-v14.1.0-windows-arm64.exe"
         }
+      },
+      {
+        "name": "v20",
+        "recommended_version": "v20.0.0-rc0",
+        "compatible_versions": [
+          "v20.0.0-rc0"
+        ],
+        "binaries": {
+          "linux/amd64": "https://github.com/cosmos/gaia/releases/download/v20.0.0-rc0/gaiad-v20.0.0-rc0-linux-amd64",
+          "darwin/amd64": "https://github.com/cosmos/gaia/releases/download/v20.0.0-rc0/gaiad-v20.0.0-rc0-darwin-amd64",
+          "darwin/arm64": "https://github.com/cosmos/gaia/releases/download/v20.0.0-rc0/gaiad-v20.0.0-rc0-darwin-arm64"
+        }
       }
     ]
   },
@@ -233,13 +241,13 @@
   "explorers": [
     {
       "kind": "Mintscan",
-      "url": "https://mintscan.io/cosmoshub-testnet",
-      "tx_page": "https://mintscan.io/cosmoshub-testnet/txs/${txHash}"
+      "url": "https://mintscan.io/cosmos-testnet",
+      "tx_page": "https://mintscan.io/cosmos-testnet/tx/${txHash}"
     },
     {
-      "kind": "Big Dipper",
-      "url": "https://explorer.theta-testnet.polypore.xyz/",
-      "tx_page": "https://explorer.theta-testnet.polypore.xyz/transactions/${txHash}"
+      "kind": "ping.pub",
+      "url": "https://explorer.polypore.xyz/",
+      "tx_page": "https://explorer.polypore.xyz/theta-testnet-001/tx/${txHash}"
     }
   ]
 }

--- a/testnets/cosmosicsprovidertestnet/chain.json
+++ b/testnets/cosmosicsprovidertestnet/chain.json
@@ -33,23 +33,20 @@
   },
   "codebase": {
     "git_repo": "https://github.com/cosmos/gaia",
-    "recommended_version": "v18.0.0-rc3",
+    "recommended_version": "v20.0.0-rc0",
     "compatible_versions": [
-      "v18.0.0-rc3"
+      "v20.0.0-rc0"
     ],
-    "cosmos_sdk_version": "v0.47.16-ics-lsm",
-    "ibc_go_version": "v7.6.0",
+    "cosmos_sdk_version": "v0.50.9-lsm",
+    "ibc_go_version": "v8.5.1",
     "consensus": {
       "type": "cometbft",
-      "version": "v0.37.6"
+      "version": "v0.38.11"
     },
     "binaries": {
-      "linux/amd64": "https://github.com/cosmos/gaia/releases/download/v18.0.0-rc3/gaiad-v18.0.0-rc3-linux-amd64",
-      "linux/arm64": "https://github.com/cosmos/gaia/releases/download/v18.0.0-rc3/gaiad-v18.0.0-rc3-linux-arm64",
-      "darwin/amd64": "https://github.com/cosmos/gaia/releases/download/v18.0.0-rc3/gaiad-v18.0.0-rc3-darwin-amd64",
-      "darwin/arm64": "https://github.com/cosmos/gaia/releases/download/v18.0.0-rc3/gaiad-v18.0.0-rc3-darwin-arm64",
-      "windows/amd64": "https://github.com/cosmos/gaia/releases/download/v18.0.0-rc3/gaiad-v18.0.0-rc3-darwin-amd64",
-      "windows/arm64": "https://github.com/cosmos/gaia/releases/download/v18.0.0-rc3/gaiad-v18.0.0-rc3-windows-arm64.exe"
+      "linux/amd64": "https://github.com/cosmos/gaia/releases/download/v20.0.0-rc0/gaiad-v20.0.0-rc0-linux-amd64",
+      "darwin/amd64": "https://github.com/cosmos/gaia/releases/download/v20.0.0-rc0/gaiad-v20.0.0-rc0-darwin-amd64",
+      "darwin/arm64": "https://github.com/cosmos/gaia/releases/download/v20.0.0-rc0/gaiad-v20.0.0-rc0-darwin-arm64"
     },
     "genesis": {
       "genesis_url": "https://raw.githubusercontent.com/cosmos/testnets/master/interchain-security/provider/provider-genesis.json"
@@ -181,6 +178,35 @@
         "ibc": {
           "type": "go",
           "version": "v7.6.0"
+        }
+      },
+      {
+        "name": "v20",
+        "tag": "v20.0.0-rc0",
+        "recommended_version": "v20.0.0-rc0",
+        "compatible_versions": [
+          "v20.0.0-rc0"
+        ],
+        "cosmos_sdk_version": "v0.50.9-lsm",
+        "ibc_go_version": "v8.5.1",
+        "consensus": {
+          "type": "cometbft",
+          "version": "v0.38.11"
+        },
+        "binaries": {
+          "linux/amd64": "https://github.com/cosmos/gaia/releases/download/v20.0.0-rc0/gaiad-v20.0.0-rc0-linux-amd64",
+          "darwin/amd64": "https://github.com/cosmos/gaia/releases/download/v20.0.0-rc0/gaiad-v20.0.0-rc0-darwin-amd64",
+          "darwin/arm64": "https://github.com/cosmos/gaia/releases/download/v20.0.0-rc0/gaiad-v20.0.0-rc0-darwin-arm64"
+        },
+        "next_version_name": "v21",
+        "sdk": {
+          "type": "cosmos",
+          "version": "v0.50.9-lsm",
+          "tag": "v0.50.9-lsm"
+        },
+        "ibc": {
+          "type": "go",
+          "version": "v8.5.1"
         }
       }
     ],

--- a/testnets/cosmosicsprovidertestnet/chain.json
+++ b/testnets/cosmosicsprovidertestnet/chain.json
@@ -295,12 +295,12 @@
     {
       "kind": "Mintscan",
       "url": "https://mintscan.io/ics-testnet-provider",
-      "tx_page": "https://mintscan.io/ics-testnet-provider/txs/${txHash}"
+      "tx_page": "https://mintscan.io/ics-testnet-provider/tx/${txHash}"
     },
     {
       "kind": "Ping.pub",
-      "url": "https://explorer.rs-testnet.polypore.xyz/provider",
-      "tx_page": "https://explorer.rs-testnet.polypore.xyz/provider/tx/${txHash}"
+      "url": "https://explorer.polypore.xyz/provider",
+      "tx_page": "https://explorer.polypore.xyz/provider/tx/${txHash}"
     }
   ]
 }


### PR DESCRIPTION
The `provider` and `theta-testnet-001` chains are running Gaia v20 now.
Thanks!