### PR TITLE
Remove Trivium's Archway endpoints

### DIFF
--- a/archway/chain.json
+++ b/archway/chain.json
@@ -451,10 +451,6 @@
         "provider": "StakeUp"
       },
       {
-        "address": "https://archway.api.trivium.network:26657",
-        "provider": "TriviumX | Architech"
-      },
-      {
         "address": "https://archway-rpc.stakeandrelax.net",
         "provider": "Stake&Relax 🦥"
       },
@@ -553,10 +549,6 @@
         "provider": "StakeUp"
       },
       {
-        "address": "https://archway.api.trivium.network:1317",
-        "provider": "TriviumX | Architech"
-      },
-      {
         "address": "https://archway-mainnet-archive.allthatnode.com:1317",
         "provider": "All That Node"
       },
@@ -649,10 +641,6 @@
       {
         "address": "grpc-archway-mainnet.testnet-pride.com:9096",
         "provider": "TestnetPride"
-      },
-      {
-        "address": "archway.api.trivium.network:9090",
-        "provider": "TriviumX | Architech"
       },
       {
         "address": "archway-grpc.tienthuattoan.ventures:9290",


### PR DESCRIPTION
Trivium has discontinued our Archway services.