### PR TITLE
WhisperNode - deprecated asset cleanup

### DIFF
--- a/archway/chain.json
+++ b/archway/chain.json
@@ -278,11 +278,6 @@
         "provider": "AM Solutions"
       },
       {
-        "id": "c28827cb96c14c905b127b92065a3fb4cd77d7f6",
-        "address": "seeds.whispernode.com:11556",
-        "provider": "WhisperNode 🤐"
-      },
-      {
         "id": "ebc272824924ea1a27ea3183dd0b9ba713494f83",
         "address": "archway-mainnet-seed.autostake.com:26946",
         "provider": "AutoStake 🛡️ Slash Protected"
@@ -395,10 +390,6 @@
         "provider": "AM Solutions"
       },
       {
-        "address": "https://rpc-archway.whispernode.com:443",
-        "provider": "WhisperNode 🤐"
-      },
-      {
         "address": "https://archway-rpc.w3coins.io",
         "provider": "w3coins"
       },
@@ -503,10 +494,6 @@
       {
         "address": "https://rest-archway.theamsolutions.info",
         "provider": "AM Solutions"
-      },
-      {
-        "address": "https://lcd-archway.whispernode.com:443",
-        "provider": "WhisperNode 🤐"
       },
       {
         "address": "https://rest.lavenderfive.com:443/archway",

--- a/assetmantle/chain.json
+++ b/assetmantle/chain.json
@@ -65,11 +65,6 @@
         "provider": "Allnodes ⚡️ Nodes & Staking"
       },
       {
-        "id": "c28827cb96c14c905b127b92065a3fb4cd77d7f6",
-        "address": "seeds.whispernode.com:14656",
-        "provider": "WhisperNode 🤐"
-      },
-      {
         "id": "df949a46ae6529ae1e09b034b49716468d5cc7e9",
         "address": "seeds.stakerhouse.com:10156",
         "provider": "StakerHouse"
@@ -149,10 +144,6 @@
         "provider": "Notional"
       },
       {
-        "address": "https://rpc-assetmantle.whispernode.com:443",
-        "provider": "WhisperNode 🤐"
-      },
-      {
         "address": "https://rpc.mantle.paranorm.pro:443",
         "provider": "paranorm"
       },
@@ -185,10 +176,6 @@
       {
         "address": "https://assetmantle-api.polkachu.com",
         "provider": "Polkachu"
-      },
-      {
-        "address": "https://lcd-assetmantle.whispernode.com:443",
-        "provider": "WhisperNode 🤐"
       },
       {
         "address": "https://api.mantle.paranorm.pro:443",

--- a/comdex/chain.json
+++ b/comdex/chain.json
@@ -209,11 +209,6 @@
         "provider": "Allnodes ⚡️ Nodes & Staking"
       },
       {
-        "id": "c28827cb96c14c905b127b92065a3fb4cd77d7f6",
-        "address": "seeds.whispernode.com:13156",
-        "provider": "WhisperNode 🤐"
-      },
-      {
         "id": "88ba33fbdf0279efaf27cff629f3cf72814d4069",
         "address": "seed-comdex-01.stakeflow.io:10007",
         "provider": "Stakeflow"
@@ -282,10 +277,6 @@
         "provider": "Cosmos Spaces"
       },
       {
-        "address": "https://rpc-comdex.whispernode.com:443",
-        "provider": "WhisperNode 🤐"
-      },
-      {
         "address": "https://comdex-mainnet-rpc.autostake.com:443",
         "provider": "AutoStake 🛡️ Slash Protected"
       },
@@ -346,10 +337,6 @@
       {
         "address": "https://comdex-mainnet-lcd.autostake.com:443",
         "provider": "AutoStake 🛡️ Slash Protected"
-      },
-      {
-        "address": "https://lcd-comdex.whispernode.com:443",
-        "provider": "WhisperNode 🤐"
       },
       {
         "address": "https://comdex-api.w3coins.io",

--- a/composable/chain.json
+++ b/composable/chain.json
@@ -320,11 +320,6 @@
         "provider": "Lavender.Five Nodes 🐝"
       },
       {
-        "id": "c28827cb96c14c905b127b92065a3fb4cd77d7f6",
-        "address": "seeds.whispernode.com:22256",
-        "provider": "WhisperNode 🤐"
-      },
-      {
         "id": "a3910d1bf22b4dacf66979d6ea75fd134aee00db",
         "address": "seed.composable.validatus.com:2000",
         "provider": "Validatus"
@@ -391,10 +386,6 @@
         "provider": "genznodes"
       },
       {
-        "address": "https://rpc-picasso.whispernode.com:443",
-        "provider": "WhisperNode 🤐"
-      },
-      {
         "address": "https://picasso-rpc.stake-town.com",
         "provider": "StakeTown"
       },
@@ -443,10 +434,6 @@
       {
         "address": "https://composable-api.genznodes.dev",
         "provider": "genznodes"
-      },
-      {
-        "address": "https://api-picasso.whispernode.com:443",
-        "provider": "WhisperNode 🤐"
       },
       {
         "address": "https://picasso-api.stake-town.com",
@@ -537,10 +524,6 @@
       {
         "address": "composable.grpc.m.stavr.tech:9907",
         "provider": "🔥STAVR🔥"
-      },
-      {
-        "address": "grpc-picasso.whispernode.com:443",
-        "provider": "WhisperNode 🤐"
       }
     ]
   },

--- a/empowerchain/chain.json
+++ b/empowerchain/chain.json
@@ -80,11 +80,6 @@
         "address": "seed.empowerchain.io:26656"
       },
       {
-        "id": "c28827cb96c14c905b127b92065a3fb4cd77d7f6",
-        "address": "seeds.whispernode.com:17456",
-        "provider": "WhisperNode 🤐"
-      },
-      {
         "id": "9aa8a73ea9364aa3cf7806d4dd25b6aed88d8152",
         "address": "empowerchain.seed.mzonder.com:12156",
         "provider": "MZONDER"
@@ -157,10 +152,6 @@
         "provider": "🔥STAVR🔥"
       },
       {
-        "address": "https://rpc-empower.whispernode.com:443",
-        "provider": "WhisperNode 🤐"
-      },
-      {
         "address": "https://rpc-empowerchain.mzonder.com:443",
         "provider": "MZONDER"
       },
@@ -221,10 +212,6 @@
       {
         "address": "https://empower-api.w3coins.io",
         "provider": "w3coins"
-      },
-      {
-        "address": "https://lcd-empower.whispernode.com:443",
-        "provider": "WhisperNode 🤐"
       },
       {
         "address": "https://api-empower.vinjan.xyz:443",

--- a/gitopia/chain.json
+++ b/gitopia/chain.json
@@ -253,11 +253,6 @@
         "provider": "autostake"
       },
       {
-        "id": "c28827cb96c14c905b127b92065a3fb4cd77d7f6",
-        "address": "seeds.whispernode.com:11356",
-        "provider": "WhisperNode 🤐"
-      },
-      {
         "id": "187425bc3739daaef8cb1d7cf47d655117396dbe",
         "address": "seed-gitopia.ibs.team:16660",
         "provider": "Inter Blockchain Services"
@@ -441,10 +436,6 @@
         "provider": "genznodes"
       },
       {
-        "address": "https://rpc-gitopia.whispernode.com:443",
-        "provider": "WhisperNode 🤐"
-      },
-      {
         "address": "https://gitopia.rpc.liveraven.net",
         "provider": "LiveRaveN"
       },
@@ -565,10 +556,6 @@
       {
         "address": "https://gitopia-api.genznodes.dev",
         "provider": "genznodes"
-      },
-      {
-        "address": "https://lcd-gitopia.whispernode.com:443",
-        "provider": "WhisperNode 🤐"
       },
       {
         "address": "https://gitopia.api.liveraven.net",

--- a/juno/chain.json
+++ b/juno/chain.json
@@ -483,11 +483,6 @@
         "provider": "AutoStake 🛡️ Slash Protected"
       },
       {
-        "id": "c28827cb96c14c905b127b92065a3fb4cd77d7f6",
-        "address": "seeds.whispernode.com:12656",
-        "provider": "WhisperNode 🤐"
-      },
-      {
         "id": "509f6dbae3133a9df177edea051b31e1210b117e",
         "address": "seed-juno-01.stakeflow.io:2307",
         "provider": "Stakeflow"
@@ -552,10 +547,6 @@
   },
   "apis": {
     "rpc": [
-      {
-        "address": "https://rpc-juno.whispernode.com:443",
-        "provider": "WhisperNode 🤐"
-      },
       {
         "address": "https://rpc-juno.itastakers.com",
         "provider": "itastakers"
@@ -745,10 +736,6 @@
       {
         "address": "https://juno-api.stake-town.com",
         "provider": "StakeTown"
-      },
-      {
-        "address": "https://lcd-juno.whispernode.com:443",
-        "provider": "WhisperNode 🤐"
       },
       {
         "address": "https://juno-api.stakeandrelax.net",

--- a/kujira/chain.json
+++ b/kujira/chain.json
@@ -364,11 +364,6 @@
         "provider": "Allnodes ⚡️ Nodes & Staking"
       },
       {
-        "id": "c28827cb96c14c905b127b92065a3fb4cd77d7f6",
-        "address": "seeds.whispernode.com:11856",
-        "provider": "WhisperNode 🤐"
-      },
-      {
         "id": "654ba97f74254965a80c0fac0f277f6f6e5506b6",
         "address": "seed-node.mms.team:29656",
         "provider": "MMS"
@@ -394,10 +389,6 @@
   },
   "apis": {
     "rpc": [
-      {
-        "address": "https://rpc-kujira.whispernode.com:443",
-        "provider": "WhisperNode 🤐"
-      },
       {
         "address": "https://rpc.kaiyo.kujira.setten.io",
         "provider": "setten.io"
@@ -472,10 +463,6 @@
       }
     ],
     "rest": [
-      {
-        "address": "https://lcd-kujira.whispernode.com:443",
-        "provider": "WhisperNode 🤐"
-      },
       {
         "address": "https://lcd.kaiyo.kujira.setten.io",
         "provider": "setten.io"
@@ -581,10 +568,6 @@
       {
         "address": "kujira-grpc.publicnode.com:443",
         "provider": "Allnodes ⚡️ Nodes & Staking"
-      },
-      {
-        "address": "grpc-kujira.whispernode.com:443",
-        "provider": "WhisperNode 🤐"
       }
     ]
   },

--- a/passage/chain.json
+++ b/passage/chain.json
@@ -168,11 +168,6 @@
         "provider": "Allnodes ⚡️ Nodes & Staking"
       },
       {
-        "id": "c28827cb96c14c905b127b92065a3fb4cd77d7f6",
-        "address": "seeds.whispernode.com:15656",
-        "provider": "WhisperNode 🤐"
-      },
-      {
         "id": "df949a46ae6529ae1e09b034b49716468d5cc7e9",
         "address": "seeds.stakerhouse.com:10556",
         "provider": "StakerHouse"
@@ -262,10 +257,6 @@
         "provider": "D-stake"
       },
       {
-        "address": "https://rpc-passage.whispernode.com:443",
-        "provider": "WhisperNode 🤐"
-      },
-      {
         "address": "https://passage-mainnet-rpc.autostake.com:443",
         "provider": "AutoStake 🛡️ Slash Protected"
       },
@@ -338,10 +329,6 @@
       {
         "address": "https://passage-mainnet-lcd.autostake.com:443",
         "provider": "AutoStake 🛡️ Slash Protected"
-      },
-      {
-        "address": "https://lcd-passage.whispernode.com:443",
-        "provider": "WhisperNode 🤐"
       },
       {
         "address": "https://passage-rest.stakerhouse.com",

--- a/quasar/chain.json
+++ b/quasar/chain.json
@@ -211,11 +211,6 @@
         "provider": "AutoStake 🛡️ Slash Protected"
       },
       {
-        "id": "c28827cb96c14c905b127b92065a3fb4cd77d7f6",
-        "address": "seeds.whispernode.com:18256",
-        "provider": "WhisperNode 🤐"
-      },
-      {
         "id": "86fd17151eec60145e6c1a635e8365aff70a77d7",
         "address": "seed-quasar.ibs.team:16667",
         "provider": "Inter Blockchain Services"
@@ -247,10 +242,6 @@
       {
         "address": "https://quasar-rpc.polkachu.com",
         "provider": "polkachu"
-      },
-      {
-        "address": "https://rpc-quasar.whispernode.com:443",
-        "provider": "WhisperNode 🤐"
       },
       {
         "address": "https://quasar-rpc.enigma-validator.com",
@@ -301,10 +292,6 @@
       {
         "address": "https://quasar-api.polkachu.com",
         "provider": "polkachu"
-      },
-      {
-        "address": "https://lcd-quasar.whispernode.com:443",
-        "provider": "WhisperNode 🤐"
       },
       {
         "address": "https://api-quasar.cosmos-spaces.cloud",

--- a/sentinel/chain.json
+++ b/sentinel/chain.json
@@ -108,11 +108,6 @@
         "provider": "BadgerBite"
       },
       {
-        "id": "c28827cb96c14c905b127b92065a3fb4cd77d7f6",
-        "address": "seeds.whispernode.com:17256",
-        "provider": "WhisperNode 🤐"
-      },
-      {
         "id": "b85358e035343a3b15e77e1102857dcdaf70053b",
         "address": "seeds.bluestake.net:26556",
         "provider": "BlueStake 🚀"
@@ -291,10 +286,6 @@
         "provider": "Notional"
       },
       {
-        "address": "https://rpc-sentinel.whispernode.com:443",
-        "provider": "WhisperNode 🤐"
-      },
-      {
         "address": "https://rpc.sentinel.chaintools.tech/",
         "provider": "ChainTools"
       },
@@ -367,10 +358,6 @@
       {
         "address": "https://api-sentinel-ia.cosmosia.notional.ventures/",
         "provider": "Notional"
-      },
-      {
-        "address": "https://lcd-sentinel.whispernode.com:443",
-        "provider": "WhisperNode 🤐"
       },
       {
         "address": "https://api.sentinel.quokkastake.io",

--- a/stargaze/chain.json
+++ b/stargaze/chain.json
@@ -196,11 +196,6 @@
         "provider": "Allnodes ⚡️ Nodes & Staking"
       },
       {
-        "id": "c28827cb96c14c905b127b92065a3fb4cd77d7f6",
-        "address": "seeds.whispernode.com:13756",
-        "provider": "WhisperNode 🤐"
-      },
-      {
         "id": "96e0040d44a2f0b59d2a07e128369363d8535b67",
         "address": "seed-stargaze.ibs.team:16669",
         "provider": "Inter Blockchain Services"
@@ -275,10 +270,6 @@
       {
         "address": "https://rpc.stargaze.silentvalidator.com/",
         "provider": "silent"
-      },
-      {
-        "address": "https://rpc-stargaze.whispernode.com:443",
-        "provider": "WhisperNode 🤐"
       },
       {
         "address": "https://stargaze-mainnet-rpc.autostake.com:443",
@@ -361,10 +352,6 @@
       {
         "address": "https://stargaze-mainnet-lcd.autostake.com:443",
         "provider": "AutoStake 🛡️ Slash Protected"
-      },
-      {
-        "address": "https://lcd-stargaze.whispernode.com:443",
-        "provider": "WhisperNode 🤐"
       },
       {
         "address": "https://stargaze-api.ramuchi.tech",

--- a/stratos/chain.json
+++ b/stratos/chain.json
@@ -58,11 +58,6 @@
         "provider": "thestratos.org"
       },
       {
-        "id": "c28827cb96c14c905b127b92065a3fb4cd77d7f6",
-        "address": "seeds.whispernode.com:21856",
-        "provider": "WhisperNode 🤐"
-      },
-      {
         "id": "8542cd7e6bf9d260fef543bc49e59be5a3fa9074",
         "address": "seed.publicnode.com:26656",
         "provider": "Allnodes ⚡️ Nodes & Staking"
@@ -87,10 +82,6 @@
         "provider": "[NODERS]TEAM"
       },
       {
-        "address": "https://rpc-stratos.whispernode.com:443",
-        "provider": "WhisperNode 🤐"
-      },
-      {
         "address": "https://stratos-rpc.noders.services:443",
         "provider": "[NODERS]TEAM"
       }
@@ -99,10 +90,6 @@
       {
         "address": "https://rest.thestratos.org",
         "provider": "thestratos.org"
-      },
-      {
-        "address": "https://lcd-stratos.whispernode.com:443",
-        "provider": "WhisperNode 🤐"
       },
       {
         "address": "https://stratos-api.noders.services:443",
@@ -166,12 +153,6 @@
       "url": "https://explorer.tcnetwork.io/stratos",
       "tx_page": "https://explorer.tcnetwork.io/stratos/transaction/${txHash}",
       "account_page": "https://explorer.tcnetwork.io/stratos/account/${accountAddress}"
-    },
-    {
-      "kind": "WhisperNode 🤐",
-      "url": "https://mainnet.whispernode.com/stratos",
-      "tx_page": "https://mainnet.whispernode.com/stratos/tx/${txHash}",
-      "account_page": "https://mainnet.whispernode.com/stratos/account/${accountAddress}"
     }
   ],
   "images": [


### PR DESCRIPTION
Removing public endpoints and infrastructure that is no longer operational due to decommissioning these chains.