### PR TITLE
Update Pryzm-Terra ICA channels

### DIFF
--- a/_IBC/pryzm-terra2.json
+++ b/_IBC/pryzm-terra2.json
@@ -39,8 +39,8 @@
       "ordering": "ordered",
       "version": "ics27-1",
       "tags": {
-        "status": "live",
-        "preferred": true
+        "status": "killed",
+        "preferred": false
       }
     },
     {
@@ -66,6 +66,22 @@
       },
       "chain_2": {
         "channel_id": "channel-480",
+        "port_id": "icahost"
+      },
+      "ordering": "ordered",
+      "version": "ics27-1",
+      "tags": {
+        "status": "live",
+        "preferred": true
+      }
+    },
+    {
+      "chain_1": {
+        "channel_id": "channel-25",
+        "port_id": "icacontroller-delegation-uluna"
+      },
+      "chain_2": {
+        "channel_id": "channel-526",
         "port_id": "icahost"
       },
       "ordering": "ordered",


### PR DESCRIPTION
This PR intends to update the ICA channel for Pryzm delegations on Terra2. The former channel was closed due to timeout as a result of Terra's last night halt.