### PR TITLE
Update chain.schema.json

### DIFF
--- a/chain.schema.json
+++ b/chain.schema.json
@@ -667,6 +667,7 @@
     "version": {
       "type": "string",
       "minLength": 1,
+      "pattern": "^v?(\\d+)(?:\\.(\\d+))?(?:\\.(\\d+))?(?=-[\\w.-]+|$)",
       "description": "Simple version string (e.g., 'v1.0.0')."
     },
     "tag": {


### PR DESCRIPTION
here is a proposed regex for version:

```
v?(\d+)(?:\.(\d+))?(?:\.(\d+))?(?=-[\w.-]+|$)
```

Explanation:
v?: Matches an optional "v" prefix.
(\d+): Matches the first part of the version (the major version number).
(?:\.(\d+))?: Matches the optional minor version (second number), preceded by a dot.
(?:\.(\d+))?: Matches the optional patch version (third number), preceded by a dot.
(?=-[\w.-]+|$): Ensures that it either ends or is followed by a dash and other alphanumeric characters (to account for tags or pre-releases like -alpha or -beta).

Examples that this regex will match:
Full Semver: 1.2.3, v1.0.0
Partial Semver: 1.2, v2.5
Basic Version: 1, v0
Simple: v1, 2.5, 1.2.3