### PR TITLE
Fix INJ derivative decimals on Pryzm

### DIFF
--- a/pryzm/assetlist.json
+++ b/pryzm/assetlist.json
@@ -690,7 +690,7 @@
         },
         {
           "denom": "cINJ",
-          "exponent": 6
+          "exponent": 18
         }
       ],
       "base": "c:inj",
@@ -1048,7 +1048,7 @@
         },
         {
           "denom": "pINJ30Sep2024",
-          "exponent": 6
+          "exponent": 18
         }
       ],
       "base": "p:inj:30Sep2024",
@@ -1076,7 +1076,7 @@
         },
         {
           "denom": "pINJ31Dec2024",
-          "exponent": 6
+          "exponent": 18
         }
       ],
       "base": "p:inj:31Dec2024",
@@ -1104,7 +1104,7 @@
         },
         {
           "denom": "pINJ31Dec2025",
-          "exponent": 6
+          "exponent": 18
         }
       ],
       "base": "p:inj:31Dec2025",
@@ -1776,7 +1776,7 @@
         },
         {
           "denom": "yINJ30Sep2024",
-          "exponent": 6
+          "exponent": 18
         }
       ],
       "base": "y:inj:30Sep2024",
@@ -1804,7 +1804,7 @@
         },
         {
           "denom": "yINJ31Dec2024",
-          "exponent": 6
+          "exponent": 18
         }
       ],
       "base": "y:inj:31Dec2024",
@@ -1832,7 +1832,7 @@
         },
         {
           "denom": "yINJ31Dec2025",
-          "exponent": 6
+          "exponent": 18
         }
       ],
       "base": "y:inj:31Dec2025",
@@ -2448,7 +2448,7 @@
         },
         {
           "denom": "lp:1:INJ",
-          "exponent": 6
+          "exponent": 18
         }
       ],
       "base": "lp:1:inj",
@@ -2476,7 +2476,7 @@
         },
         {
           "denom": "lp:4:INJypt-INJ",
-          "exponent": 6
+          "exponent": 18
         }
       ],
       "base": "lp:4:injypt-inj",


### PR DESCRIPTION
The INJ drivatives on Pryzm have an 18 decimal while it was mistakenly set to 6.