### PR TITLE
dYdX Chain-registry update to reflect release to v6.0.4

### DIFF
--- a/dydx/chain.json
+++ b/dydx/chain.json
@@ -41,15 +41,15 @@
   },
   "codebase": {
     "git_repo": "https://github.com/dydxprotocol/v4-chain/",
-    "recommended_version": "protocol/v5.2.0",
+    "recommended_version": "protocol/v6.0.4",
     "compatible_versions": [
-      "protocol/v5.2.0"
+      "protocol/v6.0.4"
     ],
     "binaries": {
-      "linux/amd64": "https://github.com/dydxprotocol/v4-chain/releases/download/protocol%2Fv5.2.0/dydxprotocold-v5.2.0-linux-amd64.tar.gz",
-      "linux/arm64": "https://github.com/dydxprotocol/v4-chain/releases/download/protocol%2Fv5.2.0/dydxprotocold-v5.2.0-linux-arm64.tar.gz"
+      "linux/amd64": "https://github.com/dydxprotocol/v4-chain/releases/download/protocol%2Fv6.0.4/dydxprotocold-v6.0.4-linux-amd64.tar.gz",
+      "linux/arm64": "https://github.com/dydxprotocol/v4-chain/releases/download/protocol%2Fv6.0.4/dydxprotocold-v6.0.4-linux-arm64.tar.gz"
     },
-    "cosmos_sdk_version": "dydxprotocol/cosmos-sdk v0.50.6-0.20240606183841-18966898625f",
+    "cosmos_sdk_version": "dydxprotocol/cosmos-sdk v0.50.6-0.20240808180557-4b1c1dc17703",
     "consensus": {
       "type": "cometbft",
       "version": "v0.38.6",


### PR DESCRIPTION
Cosmos chain-registry update to reflect dydx release to v6.0.4.
@reversesigh 