### PR TITLE
Fix cbBTC Trace

### DIFF
--- a/_non-cosmos/base/assetlist.json
+++ b/_non-cosmos/base/assetlist.json
@@ -215,7 +215,7 @@
             "chain_name": "bitcoin",
             "base_denom": "sat"
           },
-          "provider": "Base Bridge"
+          "provider": "Coinbase"
         }
       ],
       "coingecko_id": "coinbase-wrapped-btc",


### PR DESCRIPTION
Fix cbBTC Trace
updating provider from Base Bridge to Coinbase
(because Base Bridge refers to an Ethereum to Base user-accessible bridge)