### PR TITLE
Fix LTC Image URL

### DIFF
--- a/_non-cosmos/litecoin/assetlist.json
+++ b/_non-cosmos/litecoin/assetlist.json
@@ -23,8 +23,8 @@
       "coingecko_id": "litecoin",
       "images": [
         {
-          "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/_non-cosmos/dogecoin/images/ltc.svg",
-          "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/_non-cosmos/dogecoin/images/ltc.png",
+          "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/_non-cosmos/litecoin/images/ltc.svg",
+          "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/_non-cosmos/litecoin/images/ltc.png",
           "theme": {
             "primary_color_hex": "#345D9D",
             "circle": true


### PR DESCRIPTION
Fix LTC Image URL
was mistakenly pointing at Dogecoin's directory