### PR TITLE
change "bech32" prefix for bitbadges

### DIFF
--- a/bitbadges/chain.json
+++ b/bitbadges/chain.json
@@ -8,6 +8,7 @@
   "pretty_name": "BitBadges",
   "chain_id": "bitbadges-1",
   "daemon_name": "bitbadgeschaind",
+  "bech32_prefix": "bb",
   "node_home": "$HOME/.bitbadgeschaind",
   "slip44": 118,
   "fees": {

--- a/bitbadges/chain.json
+++ b/bitbadges/chain.json
@@ -31,26 +31,26 @@
   },
   "codebase": {
     "git_repo": "https://github.com/bitbadges/bitbadgeschain/",
-    "recommended_version": "v1.0-mainnet",
+    "recommended_version": "v1.0-bb-mainnet",
     "compatible_versions": [
-      "v1.0-mainnet"
+      "v1.0-bb-mainnet"
     ],
     "versions": [
       {
-        "name": "v1.0-mainnet",
+        "name": "v1.0-bb-mainnet",
         "binaries": {
-          "linux/amd64": "https://github.com/BitBadges/bitbadgeschain/releases/download/v1.0-mainnet/bitbadgeschain-linux-amd64",
-          "linux/arm64": "https://github.com/BitBadges/bitbadgeschain/releases/download/v1.0-mainnet/bitbadgeschain-linux-arm64"
+          "linux/amd64": "https://github.com/BitBadges/bitbadgeschain/releases/download/v1.0-bb-mainnet/bitbadgeschain-linux-amd64",
+          "linux/arm64": "https://github.com/BitBadges/bitbadgeschain/releases/download/v1.0-bb-mainnet/bitbadgeschain-linux-arm64"
         },
-        "cosmos_sdk_version": "v0.50.8",
+        "cosmos_sdk_version": "v0.50.10",
         "consensus": {
           "type": "cometbft",
-          "version": "v0.38.9",
+          "version": "v0.38.12",
           "repo": "https://github.com/cometbft/cometbft"
         },
         "sdk": {
           "type": "cosmos",
-          "version": "v0.50.8"
+          "version": "v0.50.10"
         },
         "ibc": {
           "type": "go",
@@ -59,13 +59,13 @@
       }
     ],
     "binaries": {
-      "linux/amd64": "https://github.com/BitBadges/bitbadgeschain/releases/download/v1.0-mainnet/bitbadgeschain-linux-amd64",
-      "linux/arm64": "https://github.com/BitBadges/bitbadgeschain/releases/download/v1.0-mainnet/bitbadgeschain-linux-arm64"
+      "linux/amd64": "https://github.com/BitBadges/bitbadgeschain/releases/download/v1.0-bb-mainnet/bitbadgeschain-linux-amd64",
+      "linux/arm64": "https://github.com/BitBadges/bitbadgeschain/releases/download/v1.0-bb-mainnet/bitbadgeschain-linux-arm64"
     },
-    "cosmos_sdk_version": "v0.50.8",
+    "cosmos_sdk_version": "v0.50.10",
     "sdk": {
       "type": "cosmos",
-      "version": "v0.50.8"
+      "version": "v0.50.10"
     },
     "ibc": {
       "type": "go",
@@ -73,7 +73,7 @@
     },
     "consensus": {
       "type": "cometbft",
-      "version": "v0.38.9",
+      "version": "v0.38.12",
       "repo": "https://github.com/cometbft/cometbft"
     },
     "genesis": {
@@ -88,7 +88,7 @@
     "seeds": [],
     "persistent_peers": [
       {
-        "id": "8d1ca31723a66b9058651220fd8da4618bc6f67c",
+        "id": "2703c1304a70186372aa726a762d60da94c29ffe",
         "address": "134.122.12.165:26656"
       }
     ]

--- a/bitbadges/chain.json
+++ b/bitbadges/chain.json
@@ -7,7 +7,6 @@
   "website": "https://bitbadges.io/",
   "pretty_name": "BitBadges",
   "chain_id": "bitbadges-1",
-  "bech32_prefix": "cosmos",
   "daemon_name": "bitbadgeschaind",
   "node_home": "$HOME/.bitbadgeschaind",
   "slip44": 118,


### PR DESCRIPTION
It has come to my attention via X that using the bech32 prefix "cosmos" has broken some services that depend on this registry. BitBadges is showing up where the Cosmos Hub is expected or causing other problems due to the collision.

To avoid confusion and breaking anything, I would like to remove this line from the registry. I noted that "bech32_prefix" is not required in the schema file, so for the time being, I would like to remove it. 

I think this is a better solution because:
-Collisions are avoided.
-If not having the "bech32_prefix" causes issues, this would only occur for BitBadges and we will handle accordingly (rather than affecting other projects).
-Anyone can still just view the BitBadges documentation to get our Cosmos prefix.

I still plan to migrate to a personal prefix, but that may require a complete chain restart or some other difficult feat of engineering.