### PR TITLE
Add `ibc` neutron-terra (terra cw20-ics20)

### DIFF
--- a/_IBC/neutron-terra2.json
+++ b/_IBC/neutron-terra2.json
@@ -58,6 +58,22 @@
         "status": "live",
         "preferred": true
       }
+    },
+    {
+      "chain_1": {
+        "channel_id": "channel-5389",
+        "port_id": "transfer"
+      },
+      "chain_2": {
+        "channel_id": "channel-554",
+        "port_id": "wasm.terra1e0mrzy8077druuu42vs0hu7ugguade0cj65dgtauyaw4gsl4kv0qtdf2au"
+      },
+      "ordering": "unordered",
+      "version": "ics20-1",
+      "tags": {
+        "status": "live",
+        "preferred": true
+      }
     }
   ]
 }


### PR DESCRIPTION
This channel can be used to transfer `cw20` tokens like ROAR from terra2 to neutron.