### PR TITLE
Neutaro chain.json update

### DIFF
--- a/neutaro/chain.json
+++ b/neutaro/chain.json
@@ -80,7 +80,7 @@
         "provider": "Neutaro"
       },
       {
-        "address": "https://rpc3.neutaro.tech:26657",
+        "address": "https://rpc3.neutaro.io:26657",
         "provider": "Neutaro"
       }
     ],


### PR DESCRIPTION
We are moving from neutaro.tech to neutaro.io. The other RPCs will be moved soon.