### PR TITLE
Remove Microtick CoinGecko ID

### DIFF
--- a/microtick/assetlist.json
+++ b/microtick/assetlist.json
@@ -22,7 +22,6 @@
         "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/microtick/images/tick.png",
         "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/microtick/images/tick.svg"
       },
-      "coingecko_id": "microtick",
       "images": [
         {
           "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/microtick/images/tick.png",


### PR DESCRIPTION
Remove Microtick CoinGecko ID
It no longer exists: https://api.coingecko.com/api/v3/coins/microtick