### PR TITLE
Remove Deprecated CoinGecko IDs

### DIFF
--- a/acrechain/assetlist.json
+++ b/acrechain/assetlist.json
@@ -58,7 +58,6 @@
         "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/acrechain/images/arusd.png",
         "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/acrechain/images/arusd.svg"
       },
-      "coingecko_id": "arable-usd",
       "images": [
         {
           "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/acrechain/images/arusd.png",

--- a/comdex/assetlist.json
+++ b/comdex/assetlist.json
@@ -54,7 +54,6 @@
         "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/comdex/images/harbor.png",
         "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/comdex/images/harbor.svg"
       },
-      "coingecko_id": "harbor-2",
       "images": [
         {
           "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/comdex/images/harbor.png",

--- a/crescent/assetlist.json
+++ b/crescent/assetlist.json
@@ -22,7 +22,6 @@
         "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/crescent/images/cre.png",
         "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/crescent/images/cre.svg"
       },
-      "coingecko_id": "crescent-network",
       "images": [
         {
           "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/crescent/images/cre.png",

--- a/gravitybridge/assetlist.json
+++ b/gravitybridge/assetlist.json
@@ -155,7 +155,6 @@
       "name": "USD Coin",
       "display": "gusdc",
       "symbol": "USDC",
-      "coingecko_id": "gravity-bridge-usdc",
       "logo_URIs": {
         "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/_non-cosmos/ethereum/images/usdc.png",
         "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/_non-cosmos/ethereum/images/usdc.svg"

--- a/imversed/assetlist.json
+++ b/imversed/assetlist.json
@@ -22,7 +22,6 @@
         "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/imversed/images/imversed.png",
         "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/imversed/images/imversed.svg"
       },
-      "coingecko_id": "imv",
       "images": [
         {
           "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/imversed/images/imversed.png",

--- a/juno/assetlist.json
+++ b/juno/assetlist.json
@@ -931,7 +931,6 @@
         "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/juno/images/wynd.png",
         "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/juno/images/wynd.svg"
       },
-      "coingecko_id": "wynd",
       "images": [
         {
           "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/juno/images/wynd.png",

--- a/kichain/assetlist.json
+++ b/kichain/assetlist.json
@@ -55,7 +55,6 @@
       "logo_URIs": {
         "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/kichain/images/lvn.png"
       },
-      "coingecko_id": "lvn",
       "images": [
         {
           "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/kichain/images/lvn.png",

--- a/osmosis/assetlist.json
+++ b/osmosis/assetlist.json
@@ -16913,7 +16913,6 @@
           }
         }
       ],
-      "coingecko_id": "sail-dao",
       "socials": {
         "website": "https://daodao.zone/dao/osmo106tvcj58rvdn9k36m9m3xcmcwk2c3fgft3ldcst9lgy05gcmjanqexru3h/home",
         "twitter": "https://twitter.com/Sail_DAO_"

--- a/provenance/assetlist.json
+++ b/provenance/assetlist.json
@@ -22,7 +22,6 @@
         "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/provenance/images/prov.png",
         "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/provenance/images/prov.svg"
       },
-      "coingecko_id": "provenance-blockchain",
       "images": [
         {
           "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/provenance/images/prov.png",

--- a/quasar/assetlist.json
+++ b/quasar/assetlist.json
@@ -21,7 +21,6 @@
       "name": "Quasar (legacy)",
       "display": "qsr",
       "symbol": "QSR.legacy",
-      "coingecko_id": "quasar-2",
       "logo_URIs": {
         "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/quasar/images/quasar.png"
       },

--- a/qwoyn/assetlist.json
+++ b/qwoyn/assetlist.json
@@ -30,7 +30,6 @@
           }
         }
       ],
-      "coingecko_id": "qwoyn",
       "keywords": [
         "gaming"
       ],

--- a/stride/assetlist.json
+++ b/stride/assetlist.json
@@ -232,7 +232,6 @@
         "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/stride/images/stluna.png",
         "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/stride/images/stluna.svg"
       },
-      "coingecko_id": "stride-staked-luna",
       "images": [
         {
           "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/stride/images/stluna.png",
@@ -313,7 +312,6 @@
         "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/stride/images/stevmos.png",
         "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/stride/images/stevmos.svg"
       },
-      "coingecko_id": "stride-staked-evmos",
       "images": [
         {
           "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/stride/images/stevmos.png",

--- a/tgrade/assetlist.json
+++ b/tgrade/assetlist.json
@@ -22,7 +22,6 @@
         "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/tgrade/images/tgrade-symbol-gradient.png",
         "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/tgrade/images/tgrade-symbol-gradient.svg"
       },
-      "coingecko_id": "tgrade",
       "images": [
         {
           "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/tgrade/images/tgrade-symbol-gradient.png",


### PR DESCRIPTION
Remove Deprecated CoinGecko IDs
The following CoinGecko IDs no longer exist

"gravity-bridge-usdc",
      "provenance-blockchain",
      "tgrade",
      "lvn",
      "crescent-network",
      "imv",
      "arable-usd",
      "wynd",
      "stride-staked-luna",
      "stride-staked-evmos",
      "harbor-2",
      "quasar-2",
      "qwoyn",
      "sail-dao"