### PR TITLE
Remove Duplicate Shido from Osmosis Assetlist

### DIFF
--- a/osmosis/assetlist.json
+++ b/osmosis/assetlist.json
@@ -25438,61 +25438,6 @@
       ]
     },
     {
-      "description": "The native EVM and Wasm, governance and staking token of the Shido Chain",
-      "denom_units": [
-        {
-          "denom": "ibc/BBE825F7D1673E1EBF05AB02000E23E6077967B79547A3733B60AE4ED62C4D32",
-          "exponent": 0,
-          "aliases": [
-            "shido"
-          ]
-        },
-        {
-          "denom": "SHIDO",
-          "exponent": 18
-        }
-      ],
-      "type_asset": "ics20",
-      "base": "ibc/BBE825F7D1673E1EBF05AB02000E23E6077967B79547A3733B60AE4ED62C4D32",
-      "name": "Shido",
-      "display": "SHIDO",
-      "symbol": "SHIDO",
-      "traces": [
-        {
-          "type": "ibc",
-          "counterparty": {
-            "chain_name": "shido",
-            "base_denom": "shido",
-            "channel_id": "channel-0"
-          },
-          "chain": {
-            "channel_id": "channel-38921",
-            "path": "transfer/channel-38921/shido"
-          }
-        }
-      ],
-      "logo_URIs": {
-        "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/shido/images/shido.png",
-        "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/shido/images/shido.svg"
-      },
-      "images": [
-        {
-          "image_sync": {
-            "chain_name": "shido",
-            "base_denom": "shido"
-          },
-          "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/shido/images/shido.png",
-          "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/shido/images/shido.svg",
-          "theme": {
-            "primary_color_hex": "#046ffc"
-          }
-        }
-      ],
-      "keywords": [
-        "osmosis_unlisted"
-      ]
-    },
-    {
       "denom_units": [
         {
           "denom": "ibc/0B3C3D06228578334B66B57FBFBA4033216CEB8119B27ACDEE18D92DA5B28D43",


### PR DESCRIPTION
Remove Duplicate Shido from Osmosis Assetlist
only ibc/62B50BB1DAEAD2A92D6C6ACAC118F4ED8CBE54265DCF5688E8D0A0A978AA46E7 is used