### PR TITLE
Fix incorrect RPC/REST endpoints for Shido

### DIFF
--- a/shido/chain.json
+++ b/shido/chain.json
@@ -179,7 +179,7 @@
         "provider": "🚀 WHEN MOON 🌕 WHEN LAMBO 🔥"
       },
       {
-        "address": "https://rest.shido.256x25.tech:443",
+        "address": "https://rpc.shido.256x25.tech:443",
         "provider": "256x25"
       },
       {
@@ -205,7 +205,7 @@
         "provider": "🚀 WHEN MOON 🌕 WHEN LAMBO 🔥"
       },
       {
-        "address": "https://rpc.shido.256x25.tech:443",
+        "address": "https://rest.shido.256x25.tech:443",
         "provider": "256x25"
       },
       {


### PR DESCRIPTION
`256x25.tech` had their RPC and REST entries in the wrong areas.