### PR TITLE
Update Osmosis Versions History (v25-v27)

### DIFF
--- a/osmosis/versions.json
+++ b/osmosis/versions.json
@@ -609,7 +609,7 @@
         "type": "go",
         "version": "8.4.0",
         "repo": "https://github.com/cosmos/ibc-go",
-        "tag": "v8.4.0"
+        "tag": "v8.4.0",
         "ics_enabled": [
           "ics20-1"
         ]
@@ -654,7 +654,9 @@
       },
       "ibc": {
         "type": "go",
-        "version": "v7.4.0",
+        "version": "8.5.1",
+        "repo": "https://github.com/cosmos/ibc-go",
+        "tag": "v8.5.1",
         "ics_enabled": [
           "ics20-1"
         ]

--- a/osmosis/versions.json
+++ b/osmosis/versions.json
@@ -112,13 +112,10 @@
         "v15.1.2",
         "v15.0.0"
       ],
-      "cosmos_sdk_version": "0.46.10",
       "consensus": {
         "type": "tendermint",
         "version": "0.34.24"
       },
-      "cosmwasm_version": "0.30",
-      "cosmwasm_enabled": true,
       "binaries": {
         "linux/amd64": "https://github.com/osmosis-labs/osmosis/releases/download/v15.2.0/osmosisd-15.2.0-linux-amd64?checksum=sha256:3aab2f2668cb5a713d5770e46a777ef01c433753378702d9ae941aa2d1ee5618",
         "linux/arm64": "https://github.com/osmosis-labs/osmosis/releases/download/v15.2.0/osmosisd-15.2.0-linux-arm64?checksum=sha256:e158d30707a0ea51482237f99676223e81ce5a353966a5c83791d2662a930f35"
@@ -150,14 +147,11 @@
         "v16.1.0",
         "v16.1.1"
       ],
-      "cosmos_sdk_version": "osmosis-labs/cosmos-sdk@0.45.0-rc1.0.20230703010110-ed4eb883f2a6",
       "consensus": {
         "type": "tendermint",
         "version": "0.34.24",
         "repo": "https://github.com/informalsystems/tendermint"
       },
-      "cosmwasm_version": "osmosis-labs/wasmd@0.31.0-osmo-v16",
-      "cosmwasm_enabled": true,
       "binaries": {
         "linux/arm64": "https://github.com/osmosis-labs/osmosis/releases/download/v16.1.1/osmosisd-16.1.1-linux-arm64?checksum=sha256:b96ff1f4c9b4abecb1b38998b1a1f891cfed2cc8078ab64914b151183c0c199b",
         "darwin/arm64": "https://github.com/osmosis-labs/osmosis/releases/download/v16.1.1/osmosisd-16.1.1-darwin-arm64?checksum=sha256:c743da4d3632a2bc3ea0ce784bbd13383492a4a34d53295eb2c96987bacf8e8c",
@@ -194,14 +188,11 @@
       "compatible_versions": [
         "v17.0.0"
       ],
-      "cosmos_sdk_version": "osmosis-labs/cosmos-sdk@v0.45.0-rc1.0.20230703010110-ed4eb883f2a6",
       "consensus": {
         "type": "tendermint",
         "version": "0.34.24",
         "repo": "https://github.com/informalsystems/tendermint"
       },
-      "cosmwasm_version": "osmosis-labs/wasmd@0.31.0-osmo-v16",
-      "cosmwasm_enabled": true,
       "binaries": {
         "linux/arm64": "https://github.com/osmosis-labs/osmosis/releases/download/v17.0.0/osmosisd-17.0.0-linux-arm64?checksum=sha256:d5eeab6a15e2acd7e24e7caf4fe3336c35367ff376da6299d404defd09ce52f9",
         "darwin/arm64": "https://github.com/osmosis-labs/osmosis/releases/download/v17.0.0/osmosisd-17.0.0-darwin-arm64?checksum=sha256:5ca1b120a62ba473e7772682d89db949ae67aa10dc9bf4629b0022a95e7ff1df",
@@ -238,14 +229,11 @@
       "compatible_versions": [
         "v18.0.0"
       ],
-      "cosmos_sdk_version": "osmosis-labs/cosmos-sdk@v0.45.0-rc1.0.20230703010110-ed4eb883f2a6",
       "consensus": {
         "type": "tendermint",
         "version": "0.34.24",
         "repo": "https://github.com/informalsystems/tendermint"
       },
-      "cosmwasm_version": "osmosis-labs/wasmd@0.31.0-osmo-v16",
-      "cosmwasm_enabled": true,
       "binaries": {
         "linux/arm64": "https://github.com/osmosis-labs/osmosis/releases/download/v18.0.0/osmosisd-18.0.0-linux-arm64?checksum=sha256:4331f9a318f6dd2f012c36f6ef19af8378fd1e9bc85c751e3f56f7018176ed58",
         "linux/amd64": "https://github.com/osmosis-labs/osmosis/releases/download/v18.0.0/osmosisd-18.0.0-linux-amd64?checksum=sha256:9a98a57946e936e7380ae897a205b4e18a188332e91ca84a1f62c21cbb437845"
@@ -282,14 +270,11 @@
         "v19.1.0",
         "v19.0.0"
       ],
-      "cosmos_sdk_version": "osmosis-labs/cosmos-sdk@0.45.0-rc1.0.20230927020814-2854ac001f06",
       "consensus": {
         "type": "tendermint",
         "version": "0.34.24",
         "repo": "https://github.com/informalsystems/tendermint"
       },
-      "cosmwasm_version": "osmosis-labs/wasmd@0.31.0-osmo-v16",
-      "cosmwasm_enabled": true,
       "binaries": {
         "linux/amd64": "https://github.com/osmosis-labs/osmosis/releases/download/v19.2.0/osmosisd-19.2.0-linux-amd64?checksum=sha256:723ff1c5349eb3c039c3dc5f55895bbde2e1499fe7c0a96960cc6fadeec814c4",
         "linux/arm64": "https://github.com/osmosis-labs/osmosis/releases/download/v19.2.0/osmosisd-19.2.0-linux-arm64?checksum=sha256:d933b893d537422164a25bf161d7f269a59ea26d37f398cdb7dd575a9ec33ed2"
@@ -324,13 +309,10 @@
       "compatible_versions": [
         "v20.5.0"
       ],
-      "cosmos_sdk_version": "osmosis-labs/cosmos-sdk@0.45.0-rc1.0.20230922030206-734f99fba785",
       "consensus": {
         "type": "tendermint",
         "version": "0.38.0"
       },
-      "cosmwasm_version": "osmosis-labs/wasmd@0.31.0-osmo-v16",
-      "cosmwasm_enabled": true,
       "binaries": {
         "linux/amd64": "https://github.com/osmosis-labs/osmosis/releases/download/v20.5.0/osmosisd-20.5.0-linux-amd64?checksum=sha256:f9ff6176e32499f22b20288c71dbc802556eb5399baef23de164fe6158a55a69",
         "linux/arm64": "https://github.com/osmosis-labs/osmosis/releases/download/v20.5.0/osmosisd-20.5.0-linux-arm64?checksum=sha256:99359257ff81d21b55b685924a74473d532cbc5af196a672a784bf13dad06d26"
@@ -366,15 +348,12 @@
       "compatible_versions": [
         "v21.1.4"
       ],
-      "cosmos_sdk_version": "osmosis-labs/cosmos-sdk v0.47.5-v21-osmo-5",
       "consensus": {
         "type": "cometbft",
         "version": "v0.37.2",
         "repo": "https://github.com/osmosis-labs/cometbft",
         "tag": "v21-osmo-1"
       },
-      "cosmwasm_version": "osmosis-labs/wasmd v0.45.0-osmo",
-      "cosmwasm_enabled": true,
       "binaries": {
         "linux/amd64": "https://github.com/osmosis-labs/osmosis/releases/download/v21.1.4/osmosisd-21.1.4-linux-amd64?checksum=sha256:518fd61873622d505640ab08edb788e307e6beb4f52476fab77661dd96860416",
         "linux/arm64": "https://github.com/osmosis-labs/osmosis/releases/download/v21.1.4/osmosisd-21.1.4-linux-arm64?checksum=sha256:cdbc163f4f045718e1464a82ada4d9d2511dc8c6c3fea11044cb8e675b6f86f7"
@@ -415,15 +394,12 @@
         "v22.0.0",
         "v22.0.1"
       ],
-      "cosmos_sdk_version": "osmosis-labs/cosmos-sdk v0.47.5-v22-osmo-3",
       "consensus": {
         "type": "cometbft",
         "version": "v0.37.2",
         "repo": "https://github.com/osmosis-labs/cometbft",
         "tag": "v21-osmo-1"
       },
-      "cosmwasm_version": "osmosis-labs/wasmd v0.45.0-osmo",
-      "cosmwasm_enabled": true,
       "binaries": {
         "linux/amd64": "https://github.com/osmosis-labs/osmosis/releases/download/v22.0.1/osmosisd-22.0.1-linux-amd64",
         "linux/arm64": "https://github.com/osmosis-labs/osmosis/releases/download/v22.0.1/osmosisd-22.0.1-linux-arm64"
@@ -466,15 +442,12 @@
         "v23.0.3",
         "v23.0.0"
       ],
-      "cosmos_sdk_version": "osmosis-labs/cosmos-sdk v0.47.5-v23-osmo-4",
       "consensus": {
         "type": "cometbft",
         "version": "v0.37.4",
         "repo": "https://github.com/osmosis-labs/cometbft",
         "tag": "v23-osmo-3"
       },
-      "cosmwasm_version": "osmosis-labs/wasmd v0.45.0-osmo",
-      "cosmwasm_enabled": true,
       "binaries": {
         "linux/amd64": "https://github.com/osmosis-labs/osmosis/releases/download/v23.0.8/osmosisd-23.0.8-linux-amd64",
         "linux/arm64": "https://github.com/osmosis-labs/osmosis/releases/download/v23.0.8/osmosisd-23.0.8-linux-arm64"
@@ -515,15 +488,12 @@
         "v24.0.1",
         "v24.0.0"
       ],
-      "cosmos_sdk_version": "osmosis-labs/cosmos-sdk v0.47.5-v24-osmo-5",
       "consensus": {
         "type": "cometbft",
         "version": "v0.37.4",
         "repo": "https://github.com/osmosis-labs/cometbft",
         "tag": "v24-osmo-2"
       },
-      "cosmwasm_version": "osmosis-labs/wasmd v0.45.0-osmo",
-      "cosmwasm_enabled": true,
       "binaries": {
         "linux/amd64": "https://github.com/osmosis-labs/osmosis/releases/download/v24.0.1/osmosisd-24.0.1-linux-amd64",
         "linux/arm64": "https://github.com/osmosis-labs/osmosis/releases/download/v24.0.1/osmosisd-24.0.1-linux-arm64"
@@ -556,39 +526,131 @@
     },
     {
       "name": "v25",
-      "tag": "v25.0.0",
+      "tag": "v25.2.1",
       "proposal": 782,
       "height": 15753500,
-      "recommended_version": "v25.0.0",
+      "recommended_version": "25.2.1",
       "compatible_versions": [
-        "v25.0.0"
+        "25.0.0",
+        "25.0.1",
+        "25.0.2",
+        "25.0.3",
+        "25.1.0",
+        "25.1.1",
+        "25.1.2",
+        "25.1.3",
+        "25.2.0",
+        "25.2.1"
       ],
-      "cosmos_sdk_version": "osmosis-labs/cosmos-sdk v0.47.5-v25-osmo-1",
       "consensus": {
         "type": "cometbft",
-        "version": "v0.37.4",
+        "version": "0.37.4",
         "repo": "https://github.com/osmosis-labs/cometbft",
         "tag": "v25-osmo-2"
       },
-      "cosmwasm_version": "osmosis-labs/wasmd v0.45.0-osmo",
-      "cosmwasm_enabled": true,
-      "binaries": {
-        "linux/amd64": "https://github.com/osmosis-labs/osmosis/releases/download/v25.0.0/osmosisd-25.0.0-linux-amd64",
-        "linux/arm64": "https://github.com/osmosis-labs/osmosis/releases/download/v25.0.0/osmosisd-25.0.0-linux-arm64"
-      },
-      "previous_version_name": "v24",
-      "next_version_name": "",
       "cosmwasm": {
-        "version": "v0.45.0",
+        "version": "0.45.0",
         "repo": "https://github.com/osmosis-labs/wasmd",
         "tag": "v0.45.0-osmo",
         "enabled": true
       },
       "sdk": {
         "type": "cosmos",
-        "version": "v0.47.5",
+        "version": "0.47.5",
         "repo": "https://github.com/osmosis-labs/cosmos-sdk",
         "tag": "v0.47.5-v25-osmo-1"
+      },
+      "ibc": {
+        "type": "go",
+        "version": "7.4.0",
+        "ics_enabled": [
+          "ics20-1"
+        ]
+      },
+      "language": {
+        "type": "go",
+        "version": "1.21.4"
+      },
+      "binaries": {
+        "linux/amd64": "https://github.com/osmosis-labs/osmosis/releases/download/v25.2.1/osmosisd-25.2.1-linux-amd64",
+        "linux/arm64": "https://github.com/osmosis-labs/osmosis/releases/download/v25.2.1/osmosisd-25.2.1-linux-arm64"
+      },
+      "previous_version_name": "v24",
+      "next_version_name": "v26"
+    },
+    {
+      "name": "v26",
+      "tag": "v26.0.1",
+      "proposal": 837,
+      "height": 21046000,
+      "recommended_version": "26.0.1",
+      "compatible_versions": [
+        "26.0.1"
+      ],
+      "consensus": {
+        "type": "cometbft",
+        "version": "0.38.11",
+        "repo": "https://github.com/osmosis-labs/cometbft",
+        "tag": "v0.38.11-v26-osmo-1"
+      },
+      "cosmwasm": {
+        "version": "0.53.0",
+        "repo": "https://github.com/CosmWasm/wasmd",
+        "tag": "v0.53.0",
+        "enabled": true
+      },
+      "sdk": {
+        "type": "cosmos",
+        "version": "0.50.6",
+        "repo": "https://github.com/osmosis-labs/cosmos-sdk",
+        "tag": "v0.50.6-v26-osmo-2"
+      },
+      "ibc": {
+        "type": "go",
+        "version": "8.4.0",
+        "repo": "https://github.com/cosmos/ibc-go",
+        "tag": "v8.4.0"
+        "ics_enabled": [
+          "ics20-1"
+        ]
+      },
+      "language": {
+        "type": "go",
+        "version": "1.22.4"
+      },
+      "binaries": {
+        "linux/amd64": "https://github.com/osmosis-labs/osmosis/releases/download/v26.0.1/osmosisd-26.0.1-linux-amd64",
+        "linux/arm64": "https://github.com/osmosis-labs/osmosis/releases/download/v26.0.1/osmosisd-26.0.1-linux-arm64"
+      },
+      "previous_version_name": "v25",
+      "next_version_name": "v27"
+    },
+    {
+      "name": "v27",
+      "tag": "v27.0.0",
+      "proposal": 861,
+      "height": 24250100,
+      "recommended_version": "27.0.0",
+      "compatible_versions": [
+        "27.0.0"
+      ],
+      "consensus": {
+        "type": "cometbft",
+        "version": "0.38.15",
+        "repo": "https://github.com/osmosis-labs/cometbft",
+        "tag": "v0.38.15-v27-osmo-1"
+      },
+      "cosmwasm": {
+        "version": "0.53.0",
+        "repo": "https://github.com/CosmWasm/wasmd",
+        "tag": "v0.53.0",
+        "enabled": true
+      },
+      "sdk": {
+        "type": "cosmos",
+        "version": "0.50.10",
+        "repo": "https://github.com/osmosis-labs/cosmos-sdk",
+        "tag": "v0.50.10-v27-osmo-1"
       },
       "ibc": {
         "type": "go",
@@ -599,8 +661,14 @@
       },
       "language": {
         "type": "go",
-        "version": "1.21.4"
-      }
+        "version": "1.22.7"
+      },
+      "binaries": {
+        "linux/amd64": "https://github.com/osmosis-labs/osmosis/releases/download/v25.0.0/osmosisd-27.0.0-linux-amd64",
+        "linux/arm64": "https://github.com/osmosis-labs/osmosis/releases/download/v25.0.0/osmosisd-27.0.0-linux-arm64"
+      },
+      "previous_version_name": "v26",
+      "next_version_name": ""
     }
   ]
 }


### PR DESCRIPTION
Update Osmosis Versions History (v25-v27)
also cleaned up some deprecated properties (comsos_sdk_version, cosmwasm_version, cosmwasm_enabled)