### PR TITLE
Remove Legacy Properties from Versions.json Files

### DIFF
--- a/agoric/versions.json
+++ b/agoric/versions.json
@@ -29,14 +29,12 @@
       "compatible_versions": [
         "agoric-upgrade-16"
       ],
-      "cosmos_sdk_version": "agoric-labs/cosmos-sdk v0.46.16-alpha.agoric.2.4",
       "consensus": {
         "type": "cometbft",
         "version": "v0.34.30",
         "repo": "https://github.com/agoric-labs/cometbft",
         "tag": "v0.34.30-alpha.agoric.1"
       },
-      "cosmwasm_enabled": false,
       "cosmwasm": {
         "enabled": false
       },
@@ -68,14 +66,12 @@
       "compatible_versions": [
         "agoric-upgrade-17"
       ],
-      "cosmos_sdk_version": "agoric-labs/cosmos-sdk v0.46.16-alpha.agoric.2.4",
       "consensus": {
         "type": "cometbft",
         "version": "v0.34.30",
         "repo": "https://github.com/agoric-labs/cometbft",
         "tag": "v0.34.30-alpha.agoric.1"
       },
-      "cosmwasm_enabled": false,
       "cosmwasm": {
         "enabled": false
       },

--- a/lava/versions.json
+++ b/lava/versions.json
@@ -12,12 +12,10 @@
       "binaries": {
         "linux/amd64": "https://github.com/lavanet/lava/releases/download/v0.33.1/lavad-v0.33.1-linux-amd64?checksum=sha256:ae2e49e53bd8c979ca27c83d3d10a708fc23247dae020840fe46b9b68cb8e925"
       },
-      "cosmos_sdk_version": "lavanet/cosmos-sdk v0.47.7-0.20231211141641-2a9ea55b724d",
       "consensus": {
         "type": "cometbft",
         "version": "0.37.4"
       },
-      "cosmwasm_enabled": false,
       "next_version_name": "",
       "sdk": {
         "type": "cosmos",
@@ -52,12 +50,10 @@
       "binaries": {
         "linux/amd64": "https://github.com/lavanet/lava/releases/download/v0.34.0/lavad-v0.34.0-linux-amd64"
       },
-      "cosmos_sdk_version": "lavanet/cosmos-sdk v0.47.7-0.20231211141641-2a9ea55b724d",
       "consensus": {
         "type": "cometbft",
         "version": "0.37.4"
       },
-      "cosmwasm_enabled": false,
       "next_version_name": "v0.35.0",
       "sdk": {
         "type": "cosmos",
@@ -92,12 +88,10 @@
       "binaries": {
         "linux/amd64": "https://github.com/lavanet/lava/releases/download/v0.35.0/lavad-v0.35.0-linux-amd64"
       },
-      "cosmos_sdk_version": "lavanet/cosmos-sdk v0.47.7-0.20231211141641-2a9ea55b724d",
       "consensus": {
         "type": "cometbft",
         "version": "0.37.4"
       },
-      "cosmwasm_enabled": false,
       "next_version_name": "v1.0.1",
       "sdk": {
         "type": "cosmos",
@@ -132,12 +126,10 @@
       "binaries": {
         "linux/amd64": "https://github.com/lavanet/lava/releases/download/v1.0.1/lavad-v1.0.1-linux-amd64"
       },
-      "cosmos_sdk_version": "lavanet/cosmos-sdk v0.47.7-0.20231211141641-2a9ea55b724d",
       "consensus": {
         "type": "cometbft",
         "version": "0.37.4"
       },
-      "cosmwasm_enabled": false,
       "next_version_name": "v2.2.0",
       "sdk": {
         "type": "cosmos",
@@ -172,12 +164,10 @@
       "binaries": {
         "linux/amd64": "https://github.com/lavanet/lava/releases/download/v2.2.0/lavad-v2.2.0-linux-amd64"
       },
-      "cosmos_sdk_version": "lavanet/cosmos-sdk v0.47.10-lava-cosmos",
       "consensus": {
         "type": "cometbft",
         "version": "0.37.4"
       },
-      "cosmwasm_enabled": false,
       "next_version_name": "v3.1.0",
       "sdk": {
         "type": "cosmos",
@@ -212,12 +202,10 @@
       "binaries": {
         "linux/amd64": "https://github.com/lavanet/lava/releases/download/v3.1.0/lavad-v3.1.0-linux-amd64"
       },
-      "cosmos_sdk_version": "lavanet/cosmos-sdk v0.47.13-lava-cosmos",
       "consensus": {
         "type": "cometbft",
         "version": "v0.37.5"
       },
-      "cosmwasm_enabled": false,
       "next_version_name": "",
       "sdk": {
         "type": "cosmos",

--- a/pryzm/versions.json
+++ b/pryzm/versions.json
@@ -15,13 +15,10 @@
         "linux/amd64": "https://storage.googleapis.com/pryzm-zone/core/0.16.0/pryzmd-0.16.0-linux-amd64",
         "linux/arm64": "https://storage.googleapis.com/pryzm-zone/core/0.16.0/pryzmd-0.16.0-linux-arm64"
       },
-      "cosmos_sdk_version": "0.47.10",
       "consensus": {
         "type": "tendermint",
         "version": "0.37.4"
       },
-      "cosmwasm_enabled": true,
-      "cosmwasm_version": "v0.45.0",
       "next_version_name": "v0.17",
       "cosmwasm": {
         "version": "v0.45.0",
@@ -59,13 +56,10 @@
         "linux/amd64": "https://storage.googleapis.com/pryzm-zone/core/0.17.0/pryzmd-0.17.0-linux-amd64",
         "linux/arm64": "https://storage.googleapis.com/pryzm-zone/core/0.17.0/pryzmd-0.17.0-linux-arm64"
       },
-      "cosmos_sdk_version": "v0.47.11",
       "consensus": {
         "type": "cometbft",
         "version": "0.37.5"
       },
-      "cosmwasm_enabled": true,
-      "cosmwasm_version": "v0.45.0",
       "previous_version_name": "v0.16",
       "next_version_name": "v0.18",
       "cosmwasm": {
@@ -104,13 +98,10 @@
         "linux/amd64": "https://storage.googleapis.com/pryzm-zone/core/0.18.0/pryzmd-0.18.0-linux-amd64",
         "linux/arm64": "https://storage.googleapis.com/pryzm-zone/core/0.18.0/pryzmd-0.18.0-linux-arm64"
       },
-      "cosmos_sdk_version": "v0.47.11",
       "consensus": {
         "type": "cometbft",
         "version": "0.37.5"
       },
-      "cosmwasm_enabled": true,
-      "cosmwasm_version": "v0.45.0",
       "previous_version_name": "v0.17",
       "next_version_name": "v0.19",
       "cosmwasm": {
@@ -149,13 +140,10 @@
         "linux/amd64": "https://storage.googleapis.com/pryzm-zone/core/0.19.0/pryzmd-0.19.0-linux-amd64",
         "linux/arm64": "https://storage.googleapis.com/pryzm-zone/core/0.19.0/pryzmd-0.19.0-linux-arm64"
       },
-      "cosmos_sdk_version": "v0.47.13",
       "consensus": {
         "type": "cometbft",
         "version": "0.37.5"
       },
-      "cosmwasm_enabled": true,
-      "cosmwasm_version": "v0.46.0",
       "previous_version_name": "v0.18",
       "next_version_name": "",
       "cosmwasm": {

--- a/versions.schema.json
+++ b/versions.schema.json
@@ -58,50 +58,20 @@
               "type": "string"
             }
           },
-          "cosmos_sdk_version": {
-            "type": "string"
-          },
           "sdk": {
             "$ref": "#/$defs/sdk"
           },
           "consensus": {
             "$ref": "#/$defs/consensus"
           },
-          "cosmwasm_version": {
-            "type": "string"
-          },
-          "cosmwasm_enabled": {
-            "type": "boolean"
-          },
-          "cosmwasm_path": {
-            "type": "string",
-            "description": "Relative path to the cosmwasm directory. ex. $HOME/.juno/data/wasm",
-            "pattern": "^\\$HOME.*$"
-          },
           "cosmwasm": {
             "$ref": "#/$defs/cosmwasm"
-          },
-          "ibc_go_version": {
-            "type": "string"
           },
           "ibc": {
             "$ref": "#/$defs/ibc"
           },
           "language": {
             "$ref": "#/$defs/language"
-          },
-          "ics_enabled": {
-            "type": "array",
-            "description": "List of IBC apps (usually corresponding to a ICS standard) which have been enabled on the network.",
-            "items": {
-              "type": "string",
-              "description": "IBC app or ICS standard.",
-              "enum": [
-                "ics20-1",
-                "ics27-1",
-                "mauth"
-              ]
-            }
           },
           "binaries": {
             "$ref": "#/$defs/binaries"


### PR DESCRIPTION
Remove Legacy Properties from Versions.json Files
Agoric
Lava
Pryzm,
and the versions.schema.json