### PR TITLE
Add new Pryzm derivatives with new maturity

### DIFF
--- a/pryzm/assetlist.json
+++ b/pryzm/assetlist.json
@@ -956,6 +956,34 @@
       "type_asset": "sdk.coin"
     },
     {
+      "description": "Pryzm's refracted principal token for ATOM with maturity of 31Dec2026",
+      "denom_units": [
+        {
+          "denom": "p:uatom:31Dec2026",
+          "exponent": 0
+        },
+        {
+          "denom": "pATOM31Dec2026",
+          "exponent": 6
+        }
+      ],
+      "base": "p:uatom:31Dec2026",
+      "name": "pAtom (31Dec2026)",
+      "display": "pATOM31Dec2026",
+      "symbol": "pATOM-31Dec2026",
+      "logo_URIs": {
+        "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/pryzm/images/pAtom.png",
+        "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/pryzm/images/pAtom.svg"
+      },
+      "images": [
+        {
+          "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/pryzm/images/pAtom.png",
+          "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/pryzm/images/pAtom.svg"
+        }
+      ],
+      "type_asset": "sdk.coin"
+    },
+    {
       "description": "Pryzm's refracted principal token for OSMO with maturity of 30Sep2024",
       "denom_units": [
         {
@@ -1027,6 +1055,34 @@
       "name": "pOsmo (31Dec2025)",
       "display": "pOSMO31Dec2025",
       "symbol": "pOSMO-31Dec2025",
+      "logo_URIs": {
+        "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/pryzm/images/pOsmo.png",
+        "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/pryzm/images/pOsmo.svg"
+      },
+      "images": [
+        {
+          "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/pryzm/images/pOsmo.png",
+          "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/pryzm/images/pOsmo.svg"
+        }
+      ],
+      "type_asset": "sdk.coin"
+    },
+    {
+      "description": "Pryzm's refracted principal token for OSMO with maturity of 31Dec2026",
+      "denom_units": [
+        {
+          "denom": "p:uosmo:31Dec2026",
+          "exponent": 0
+        },
+        {
+          "denom": "pOSMO31Dec2026",
+          "exponent": 6
+        }
+      ],
+      "base": "p:uosmo:31Dec2026",
+      "name": "pOsmo (31Dec2026)",
+      "display": "pOSMO31Dec2026",
+      "symbol": "pOSMO-31Dec2026",
       "logo_URIs": {
         "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/pryzm/images/pOsmo.png",
         "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/pryzm/images/pOsmo.svg"
@@ -1124,6 +1180,34 @@
       "type_asset": "sdk.coin"
     },
     {
+      "description": "Pryzm's refracted principal token for INJ with maturity of 31Dec2026",
+      "denom_units": [
+        {
+          "denom": "p:inj:31Dec2026",
+          "exponent": 0
+        },
+        {
+          "denom": "pINJ31Dec2026",
+          "exponent": 18
+        }
+      ],
+      "base": "p:inj:31Dec2026",
+      "name": "pInj (31Dec2026)",
+      "display": "pINJ31Dec2026",
+      "symbol": "pINJ-31Dec2026",
+      "logo_URIs": {
+        "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/pryzm/images/pInj.png",
+        "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/pryzm/images/pInj.svg"
+      },
+      "images": [
+        {
+          "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/pryzm/images/pInj.png",
+          "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/pryzm/images/pInj.svg"
+        }
+      ],
+      "type_asset": "sdk.coin"
+    },
+    {
       "description": "Pryzm's refracted principal token for LUNA with maturity of 30Sep2024",
       "denom_units": [
         {
@@ -1167,6 +1251,34 @@
       "name": "pLuna (31Dec2024)",
       "display": "pLUNA31Dec2024",
       "symbol": "pLUNA-31Dec2024",
+      "logo_URIs": {
+        "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/pryzm/images/pLuna.png",
+        "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/pryzm/images/pLuna.svg"
+      },
+      "images": [
+        {
+          "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/pryzm/images/pLuna.png",
+          "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/pryzm/images/pLuna.svg"
+        }
+      ],
+      "type_asset": "sdk.coin"
+    },
+    {
+      "description": "Pryzm's refracted principal token for LUNA with maturity of 31Dec2026",
+      "denom_units": [
+        {
+          "denom": "p:uluna:31Dec2026",
+          "exponent": 0
+        },
+        {
+          "denom": "pLUNA31Dec2026",
+          "exponent": 6
+        }
+      ],
+      "base": "p:uluna:31Dec2026",
+      "name": "pLuna (31Dec2026)",
+      "display": "pLUNA31Dec2026",
+      "symbol": "pLUNA-31Dec2026",
       "logo_URIs": {
         "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/pryzm/images/pLuna.png",
         "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/pryzm/images/pLuna.svg"
@@ -1292,6 +1404,34 @@
       "type_asset": "sdk.coin"
     },
     {
+      "description": "Pryzm's refracted principal token for AUUU with maturity of 31Dec2026",
+      "denom_units": [
+        {
+          "denom": "p:uauuu:31Dec2026",
+          "exponent": 0
+        },
+        {
+          "denom": "pAUUU31Dec2026",
+          "exponent": 6
+        }
+      ],
+      "base": "p:uauuu:31Dec2026",
+      "name": "pAuuu (31Dec2026)",
+      "display": "pAUUU31Dec2026",
+      "symbol": "pAUUU-31Dec2026",
+      "logo_URIs": {
+        "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/pryzm/images/pAuuu.png",
+        "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/pryzm/images/pAuuu.svg"
+      },
+      "images": [
+        {
+          "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/pryzm/images/pAuuu.png",
+          "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/pryzm/images/pAuuu.svg"
+        }
+      ],
+      "type_asset": "sdk.coin"
+    },
+    {
       "description": "Pryzm's refracted principal token for stTIA with maturity of 30Sep2024",
       "denom_units": [
         {
@@ -1363,6 +1503,34 @@
       "name": "pstTia (31Dec2025)",
       "display": "pstTIA31Dec2025",
       "symbol": "pstTIA-31Dec2025",
+      "logo_URIs": {
+        "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/pryzm/images/pstTia.png",
+        "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/pryzm/images/pstTia.svg"
+      },
+      "images": [
+        {
+          "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/pryzm/images/pstTia.png",
+          "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/pryzm/images/pstTia.svg"
+        }
+      ],
+      "type_asset": "sdk.coin"
+    },
+    {
+      "description": "Pryzm's refracted principal token for stTIA with maturity of 31Dec2026",
+      "denom_units": [
+        {
+          "denom": "p:stutia:31Dec2026",
+          "exponent": 0
+        },
+        {
+          "denom": "pstTIA31Dec2026",
+          "exponent": 6
+        }
+      ],
+      "base": "p:stutia:31Dec2026",
+      "name": "pstTia (31Dec2026)",
+      "display": "pstTIA31Dec2026",
+      "symbol": "pstTIA-31Dec2026",
       "logo_URIs": {
         "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/pryzm/images/pstTia.png",
         "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/pryzm/images/pstTia.svg"
@@ -1460,6 +1628,34 @@
       "type_asset": "sdk.coin"
     },
     {
+      "description": "Pryzm's refracted principal token for stDYDX with maturity of 31Dec2026",
+      "denom_units": [
+        {
+          "denom": "p:stadydx:31Dec2026",
+          "exponent": 0
+        },
+        {
+          "denom": "pstDYDX31Dec2026",
+          "exponent": 18
+        }
+      ],
+      "base": "p:stadydx:31Dec2026",
+      "name": "pstDydx (31Dec2026)",
+      "display": "pstDYDX31Dec2026",
+      "symbol": "pstDYDX-31Dec2026",
+      "logo_URIs": {
+        "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/pryzm/images/pstDydx.png",
+        "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/pryzm/images/pstDydx.svg"
+      },
+      "images": [
+        {
+          "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/pryzm/images/pstDydx.png",
+          "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/pryzm/images/pstDydx.svg"
+        }
+      ],
+      "type_asset": "sdk.coin"
+    },
+    {
       "description": "Pryzm's refracted principal token for dATOM with maturity of 31Dec2024",
       "denom_units": [
         {
@@ -1544,6 +1740,34 @@
       "type_asset": "sdk.coin"
     },
     {
+      "description": "Pryzm's refracted principal token for dATOM with maturity of 31Dec2026",
+      "denom_units": [
+        {
+          "denom": "p:udatom:31Dec2026",
+          "exponent": 0
+        },
+        {
+          "denom": "pdATOM31Dec2026",
+          "exponent": 6
+        }
+      ],
+      "base": "p:udatom:31Dec2026",
+      "name": "pdAtom (31Dec2026)",
+      "display": "pdATOM31Dec2026",
+      "symbol": "pdATOM-31Dec2026",
+      "logo_URIs": {
+        "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/pryzm/images/pdAtom.png",
+        "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/pryzm/images/pdAtom.svg"
+      },
+      "images": [
+        {
+          "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/pryzm/images/pdAtom.png",
+          "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/pryzm/images/pdAtom.svg"
+        }
+      ],
+      "type_asset": "sdk.coin"
+    },
+    {
       "description": "Pryzm's refracted principal token for TIA with maturity of 31Dec2024",
       "denom_units": [
         {
@@ -1587,6 +1811,34 @@
       "name": "pTia (31Dec2025)",
       "display": "pTIA31Dec2025",
       "symbol": "pTIA-31Dec2025",
+      "logo_URIs": {
+        "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/pryzm/images/pTia.png",
+        "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/pryzm/images/pTia.svg"
+      },
+      "images": [
+        {
+          "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/pryzm/images/pTia.png",
+          "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/pryzm/images/pTia.svg"
+        }
+      ],
+      "type_asset": "sdk.coin"
+    },
+    {
+      "description": "Pryzm's refracted principal token for TIA with maturity of 31Dec2026",
+      "denom_units": [
+        {
+          "denom": "p:utia:31Dec2026",
+          "exponent": 0
+        },
+        {
+          "denom": "pTIA31Dec2026",
+          "exponent": 6
+        }
+      ],
+      "base": "p:utia:31Dec2026",
+      "name": "pTia (31Dec2026)",
+      "display": "pTIA31Dec2026",
+      "symbol": "pTIA-31Dec2026",
       "logo_URIs": {
         "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/pryzm/images/pTia.png",
         "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/pryzm/images/pTia.svg"
@@ -1684,6 +1936,34 @@
       "type_asset": "sdk.coin"
     },
     {
+      "description": "Pryzm's refracted yield token for ATOM with maturity of 31Dec2026",
+      "denom_units": [
+        {
+          "denom": "y:uatom:31Dec2026",
+          "exponent": 0
+        },
+        {
+          "denom": "yATOM31Dec2026",
+          "exponent": 6
+        }
+      ],
+      "base": "y:uatom:31Dec2026",
+      "name": "yAtom (31Dec2026)",
+      "display": "yATOM31Dec2026",
+      "symbol": "yATOM-31Dec2026",
+      "logo_URIs": {
+        "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/pryzm/images/yAtom.png",
+        "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/pryzm/images/yAtom.svg"
+      },
+      "images": [
+        {
+          "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/pryzm/images/yAtom.png",
+          "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/pryzm/images/yAtom.svg"
+        }
+      ],
+      "type_asset": "sdk.coin"
+    },
+    {
       "description": "Pryzm's refracted yield token for OSMO with maturity of 30Sep2024",
       "denom_units": [
         {
@@ -1755,6 +2035,34 @@
       "name": "yOsmo (31Dec2025)",
       "display": "yOSMO31Dec2025",
       "symbol": "yOSMO-31Dec2025",
+      "logo_URIs": {
+        "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/pryzm/images/yOsmo.png",
+        "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/pryzm/images/yOsmo.svg"
+      },
+      "images": [
+        {
+          "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/pryzm/images/yOsmo.png",
+          "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/pryzm/images/yOsmo.svg"
+        }
+      ],
+      "type_asset": "sdk.coin"
+    },
+    {
+      "description": "Pryzm's refracted yield token for OSMO with maturity of 31Dec2026",
+      "denom_units": [
+        {
+          "denom": "y:uosmo:31Dec2026",
+          "exponent": 0
+        },
+        {
+          "denom": "yOSMO31Dec2026",
+          "exponent": 6
+        }
+      ],
+      "base": "y:uosmo:31Dec2026",
+      "name": "yOsmo (31Dec2026)",
+      "display": "yOSMO31Dec2026",
+      "symbol": "yOSMO-31Dec2026",
       "logo_URIs": {
         "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/pryzm/images/yOsmo.png",
         "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/pryzm/images/yOsmo.svg"
@@ -1852,6 +2160,34 @@
       "type_asset": "sdk.coin"
     },
     {
+      "description": "Pryzm's refracted yield token for INJ with maturity of 31Dec2026",
+      "denom_units": [
+        {
+          "denom": "y:inj:31Dec2026",
+          "exponent": 0
+        },
+        {
+          "denom": "yINJ31Dec2026",
+          "exponent": 18
+        }
+      ],
+      "base": "y:inj:31Dec2026",
+      "name": "yInj (31Dec2026)",
+      "display": "yINJ31Dec2026",
+      "symbol": "yINJ-31Dec2026",
+      "logo_URIs": {
+        "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/pryzm/images/yInj.png",
+        "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/pryzm/images/yInj.svg"
+      },
+      "images": [
+        {
+          "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/pryzm/images/yInj.png",
+          "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/pryzm/images/yInj.svg"
+        }
+      ],
+      "type_asset": "sdk.coin"
+    },
+    {
       "description": "Pryzm's refracted yield token for LUNA with maturity of 30Sep2024",
       "denom_units": [
         {
@@ -1923,6 +2259,34 @@
       "name": "yLuna (31Dec2025)",
       "display": "yLUNA31Dec2025",
       "symbol": "yLUNA-31Dec2025",
+      "logo_URIs": {
+        "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/pryzm/images/yLuna.png",
+        "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/pryzm/images/yLuna.svg"
+      },
+      "images": [
+        {
+          "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/pryzm/images/yLuna.png",
+          "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/pryzm/images/yLuna.svg"
+        }
+      ],
+      "type_asset": "sdk.coin"
+    },
+    {
+      "description": "Pryzm's refracted yield token for LUNA with maturity of 31Dec2026",
+      "denom_units": [
+        {
+          "denom": "y:uluna:31Dec2026",
+          "exponent": 0
+        },
+        {
+          "denom": "yLUNA31Dec2026",
+          "exponent": 6
+        }
+      ],
+      "base": "y:uluna:31Dec2026",
+      "name": "yLuna (31Dec2026)",
+      "display": "yLUNA31Dec2026",
+      "symbol": "yLUNA-31Dec2026",
       "logo_URIs": {
         "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/pryzm/images/yLuna.png",
         "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/pryzm/images/yLuna.svg"
@@ -2020,6 +2384,34 @@
       "type_asset": "sdk.coin"
     },
     {
+      "description": "Pryzm's refracted yield token for AUUU with maturity of 31Dec2026",
+      "denom_units": [
+        {
+          "denom": "y:uauuu:31Dec2026",
+          "exponent": 0
+        },
+        {
+          "denom": "yAUUU31Dec2026",
+          "exponent": 6
+        }
+      ],
+      "base": "y:uauuu:31Dec2026",
+      "name": "yAuuu (31Dec2026)",
+      "display": "yAUUU31Dec2026",
+      "symbol": "yAUUU-31Dec2026",
+      "logo_URIs": {
+        "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/pryzm/images/yAuuu.png",
+        "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/pryzm/images/yAuuu.svg"
+      },
+      "images": [
+        {
+          "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/pryzm/images/yAuuu.png",
+          "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/pryzm/images/yAuuu.svg"
+        }
+      ],
+      "type_asset": "sdk.coin"
+    },
+    {
       "description": "Pryzm's refracted yield token for stTIA with maturity of 30Sep2024",
       "denom_units": [
         {
@@ -2091,6 +2483,34 @@
       "name": "ystTia (31Dec2025)",
       "display": "ystTIA31Dec2025",
       "symbol": "ystTIA-31Dec2025",
+      "logo_URIs": {
+        "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/pryzm/images/ystTia.png",
+        "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/pryzm/images/ystTia.svg"
+      },
+      "images": [
+        {
+          "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/pryzm/images/ystTia.png",
+          "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/pryzm/images/ystTia.svg"
+        }
+      ],
+      "type_asset": "sdk.coin"
+    },
+    {
+      "description": "Pryzm's refracted yield token for stTIA with maturity of 31Dec2026",
+      "denom_units": [
+        {
+          "denom": "y:stutia:31Dec2026",
+          "exponent": 0
+        },
+        {
+          "denom": "ystTIA31Dec2026",
+          "exponent": 6
+        }
+      ],
+      "base": "y:stutia:31Dec2026",
+      "name": "ystTia (31Dec2026)",
+      "display": "ystTIA31Dec2026",
+      "symbol": "ystTIA-31Dec2026",
       "logo_URIs": {
         "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/pryzm/images/ystTia.png",
         "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/pryzm/images/ystTia.svg"
@@ -2188,6 +2608,34 @@
       "type_asset": "sdk.coin"
     },
     {
+      "description": "Pryzm's refracted yield token for stDYDX with maturity of 31Dec2026",
+      "denom_units": [
+        {
+          "denom": "y:stadydx:31Dec2026",
+          "exponent": 0
+        },
+        {
+          "denom": "ystDYDX31Dec2026",
+          "exponent": 6
+        }
+      ],
+      "base": "y:stadydx:31Dec2026",
+      "name": "ystDydx (31Dec2026)",
+      "display": "ystDYDX31Dec2026",
+      "symbol": "ystDYDX-31Dec2026",
+      "logo_URIs": {
+        "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/pryzm/images/ystDydx.png",
+        "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/pryzm/images/ystDydx.svg"
+      },
+      "images": [
+        {
+          "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/pryzm/images/ystDydx.png",
+          "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/pryzm/images/ystDydx.svg"
+        }
+      ],
+      "type_asset": "sdk.coin"
+    },
+    {
       "description": "Pryzm's refracted yield token for dATOM with maturity of 31Dec2024",
       "denom_units": [
         {
@@ -2272,6 +2720,34 @@
       "type_asset": "sdk.coin"
     },
     {
+      "description": "Pryzm's refracted yield token for dATOM with maturity of 31Dec2026",
+      "denom_units": [
+        {
+          "denom": "y:udatom:31Dec2026",
+          "exponent": 0
+        },
+        {
+          "denom": "ydATOM31Dec2026",
+          "exponent": 6
+        }
+      ],
+      "base": "y:udatom:31Dec2026",
+      "name": "ydAtom (31Dec2026)",
+      "display": "ydATOM31Dec2026",
+      "symbol": "ydATOM-31Dec2026",
+      "logo_URIs": {
+        "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/pryzm/images/ydAtom.png",
+        "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/pryzm/images/ydAtom.svg"
+      },
+      "images": [
+        {
+          "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/pryzm/images/ydAtom.png",
+          "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/pryzm/images/ydAtom.svg"
+        }
+      ],
+      "type_asset": "sdk.coin"
+    },
+    {
       "description": "Pryzm's refracted yield token for TIA with maturity of 31Dec2024",
       "denom_units": [
         {
@@ -2315,6 +2791,34 @@
       "name": "yTia (31Dec2025)",
       "display": "yTIA31Dec2025",
       "symbol": "yTIA-31Dec2025",
+      "logo_URIs": {
+        "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/pryzm/images/yTia.png",
+        "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/pryzm/images/yTia.svg"
+      },
+      "images": [
+        {
+          "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/pryzm/images/yTia.png",
+          "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/pryzm/images/yTia.svg"
+        }
+      ],
+      "type_asset": "sdk.coin"
+    },
+    {
+      "description": "Pryzm's refracted yield token for TIA with maturity of 31Dec2026",
+      "denom_units": [
+        {
+          "denom": "y:utia:31Dec2026",
+          "exponent": 0
+        },
+        {
+          "denom": "yTIA31Dec2026",
+          "exponent": 6
+        }
+      ],
+      "base": "y:utia:31Dec2026",
+      "name": "yTia (31Dec2026)",
+      "display": "yTIA31Dec2026",
+      "symbol": "yTIA-31Dec2026",
       "logo_URIs": {
         "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/pryzm/images/yTia.png",
         "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/pryzm/images/yTia.svg"

--- a/pryzm/assetlist.json
+++ b/pryzm/assetlist.json
@@ -2532,7 +2532,7 @@
         },
         {
           "denom": "ystDYDX30Sep2024",
-          "exponent": 6
+          "exponent": 18
         }
       ],
       "base": "y:stadydx:30Sep2024",
@@ -2560,7 +2560,7 @@
         },
         {
           "denom": "ystDYDX31Dec2024",
-          "exponent": 6
+          "exponent": 18
         }
       ],
       "base": "y:stadydx:31Dec2024",
@@ -2588,7 +2588,7 @@
         },
         {
           "denom": "ystDYDX31Dec2025",
-          "exponent": 6
+          "exponent": 18
         }
       ],
       "base": "y:stadydx:31Dec2025",
@@ -2616,7 +2616,7 @@
         },
         {
           "denom": "ystDYDX31Dec2026",
-          "exponent": 6
+          "exponent": 18
         }
       ],
       "base": "y:stadydx:31Dec2026",


### PR DESCRIPTION
This PR adds the new minted tokens with the maturity of 31Dec2026 to the list of Pryzm assets. It also fixes the decimal of `ystDYDX` tokens.