### PR TITLE
Bump Cosmos ICS Testnet to Gaia v21.0.1

### DIFF
--- a/testnets/cosmosicsprovidertestnet/chain.json
+++ b/testnets/cosmosicsprovidertestnet/chain.json
@@ -33,18 +33,18 @@
   },
   "codebase": {
     "git_repo": "https://github.com/cosmos/gaia",
-    "recommended_version": "v21.0.0",
+    "recommended_version": "v21.0.1",
     "compatible_versions": [
-      "v21.0.0"
+      "v21.0.1"
     ],
     "consensus": {
       "type": "cometbft",
       "version": "v0.38.11"
     },
     "binaries": {
-      "linux/amd64": "https://github.com/cosmos/gaia/releases/download/v21.0.0/gaiad-v21.0.0-linux-amd64",
-      "darwin/amd64": "https://github.com/cosmos/gaia/releases/download/v21.0.0/gaiad-v21.0.0-darwin-amd64",
-      "darwin/arm64": "https://github.com/cosmos/gaia/releases/download/v21.0.0/gaiad-v21.0.0-darwin-arm64"
+      "linux/amd64": "https://github.com/cosmos/gaia/releases/download/v21.0.1/gaiad-v21.0.1-linux-amd64",
+      "darwin/amd64": "https://github.com/cosmos/gaia/releases/download/v21.0.1/gaiad-v21.0.1-darwin-amd64",
+      "darwin/arm64": "https://github.com/cosmos/gaia/releases/download/v21.0.1/gaiad-v21.0.1-darwin-arm64"
     },
     "genesis": {
       "genesis_url": "https://raw.githubusercontent.com/cosmos/testnets/master/interchain-security/provider/provider-genesis.json"
@@ -63,12 +63,12 @@
     "seeds": [
       {
         "id": "08ec17e86dac67b9da70deb20177655495a55407",
-        "address": "provider-seed-01.rs-testnet.polypore.xyz:26656",
+        "address": "provider-seed-01.ics-testnet.polypore.xyz:26656",
         "provider": "Hypha"
       },
       {
         "id": "4ea6e56300a2f37b90e58de5ee27d1c9065cf871",
-        "address": "provider-seed-02.rs-testnet.polypore.xyz:26656",
+        "address": "provider-seed-02.ics-testnet.polypore.xyz:26656",
         "provider": "Hypha"
       }
     ],
@@ -77,55 +77,55 @@
   "apis": {
     "rpc": [
       {
-        "address": "https://rpc.provider-sentry-01.rs-testnet.polypore.xyz",
+        "address": "https://rpc.provider-sentry-01.ics-testnet.polypore.xyz",
         "provider": "Hypha"
       },
       {
-        "address": "https://rpc.provider-sentry-02.rs-testnet.polypore.xyz",
+        "address": "https://rpc.provider-sentry-02.ics-testnet.polypore.xyz",
         "provider": "Hypha"
       },
       {
-        "address": "https://rpc.provider-state-sync-01.rs-testnet.polypore.xyz",
+        "address": "https://rpc.provider-state-sync-01.ics-testnet.polypore.xyz",
         "provider": "Hypha"
       },
       {
-        "address": "https://rpc.provider-state-sync-02.rs-testnet.polypore.xyz",
+        "address": "https://rpc.provider-state-sync-02.ics-testnet.polypore.xyz",
         "provider": "Hypha"
       }
     ],
     "rest": [
       {
-        "address": "https://rest.provider-sentry-01.rs-testnet.polypore.xyz",
+        "address": "https://rest.provider-sentry-01.ics-testnet.polypore.xyz",
         "provider": "Hypha"
       },
       {
-        "address": "https://rest.provider-sentry-02.rs-testnet.polypore.xyz",
+        "address": "https://rest.provider-sentry-02.ics-testnet.polypore.xyz",
         "provider": "Hypha"
       },
       {
-        "address": "https://rest.provider-state-sync-01.rs-testnet.polypore.xyz",
+        "address": "https://rest.provider-state-sync-01.ics-testnet.polypore.xyz",
         "provider": "Hypha"
       },
       {
-        "address": "https://rest.provider-state-sync-02.rs-testnet.polypore.xyz",
+        "address": "https://rest.provider-state-sync-02.ics-testnet.polypore.xyz",
         "provider": "Hypha"
       }
     ],
     "grpc": [
       {
-        "address": "https://grpc.provider-sentry-01.rs-testnet.polypore.xyz",
+        "address": "https://grpc.provider-sentry-01.ics-testnet.polypore.xyz",
         "provider": "Hypha"
       },
       {
-        "address": "https://grpc.provider-sentry-02.rs-testnet.polypore.xyz",
+        "address": "https://grpc.provider-sentry-02.ics-testnet.polypore.xyz",
         "provider": "Hypha"
       },
       {
-        "address": "https://grpc.provider-state-sync-01.rs-testnet.polypore.xyz",
+        "address": "https://grpc.provider-state-sync-01.ics-testnet.polypore.xyz",
         "provider": "Hypha"
       },
       {
-        "address": "https://grpc.provider-state-sync-02.rs-testnet.polypore.xyz",
+        "address": "https://grpc.provider-state-sync-02.ics-testnet.polypore.xyz",
         "provider": "Hypha"
       }
     ]
@@ -138,8 +138,8 @@
     },
     {
       "kind": "Ping.pub",
-      "url": "https://explorer.rs-testnet.polypore.xyz/provider",
-      "tx_page": "https://explorer.rs-testnet.polypore.xyz/provider/tx/${txHash}"
+      "url": "https://explorer.polypore.xyz/provider",
+      "tx_page": "https://explorer.polypore.xyz/provider/tx/${txHash}"
     }
   ]
 }

--- a/testnets/cosmosicsprovidertestnet/versions.json
+++ b/testnets/cosmosicsprovidertestnet/versions.json
@@ -157,19 +157,19 @@
     },
     {
       "name": "v21",
-      "tag": "v21.0.0",
-      "recommended_version": "v21.0.0",
+      "tag": "v21.0.1",
+      "recommended_version": "v21.0.1",
       "compatible_versions": [
-        "v21.0.0"
+        "v21.0.1"
       ],
       "consensus": {
         "type": "cometbft",
         "version": "v0.38.11"
       },
       "binaries": {
-        "linux/amd64": "https://github.com/cosmos/gaia/releases/download/v20.0.0/gaiad-v21.0.0-linux-amd64",
-        "darwin/amd64": "https://github.com/cosmos/gaia/releases/download/v20.0.0/gaiad-v21.0.0-darwin-amd64",
-        "darwin/arm64": "https://github.com/cosmos/gaia/releases/download/v20.0.0/gaiad-v21.0.0-darwin-arm64"
+        "linux/amd64": "https://github.com/cosmos/gaia/releases/download/v21.0.1/gaiad-v21.0.1-linux-amd64",
+        "darwin/amd64": "https://github.com/cosmos/gaia/releases/download/v21.0.1/gaiad-v21.0.1-darwin-amd64",
+        "darwin/arm64": "https://github.com/cosmos/gaia/releases/download/v21.0.1/gaiad-v21.0.1-darwin-arm64"
       },
       "next_version_name": "v22",
       "sdk": {


### PR DESCRIPTION
* Bump v21.0.0 to v21.0.1
* Update endpoint and explorer URLs