### PR TITLE
chore: update KYVE mainnet, testnet and devnet

### DIFF
--- a/kyve/chain.json
+++ b/kyve/chain.json
@@ -44,10 +44,10 @@
       "tag": "v0.38.7-kyve-rpc-fix-rc0"
     },
     "binaries": {
-      "linux/amd64": "https://github.com/KYVENetwork/chain/releases/download/v1.5.0/kyved_mainnet_linux_amd64.tar.gz",
-      "linux/arm64": "https://github.com/KYVENetwork/chain/releases/download/v1.5.0/kyved_mainnet_linux_arm64.tar.gz",
-      "darwin/amd64": "https://github.com/KYVENetwork/chain/releases/download/v1.5.0/kyved_mainnet_darwin_amd64.tar.gz",
-      "darwin/arm64": "https://github.com/KYVENetwork/chain/releases/download/v1.5.0/kyved_mainnet_darwin_arm64.tar.gz"
+      "linux/amd64": "https://github.com/KYVENetwork/chain/releases/download/v1.5.0/kyved_mainnet_linux_amd64",
+      "linux/arm64": "https://github.com/KYVENetwork/chain/releases/download/v1.5.0/kyved_mainnet_linux_arm64",
+      "darwin/amd64": "https://github.com/KYVENetwork/chain/releases/download/v1.5.0/kyved_mainnet_darwin_amd64",
+      "darwin/arm64": "https://github.com/KYVENetwork/chain/releases/download/v1.5.0/kyved_mainnet_darwin_arm64"
     },
     "genesis": {
       "genesis_url": "https://raw.githubusercontent.com/KYVENetwork/networks/main/kyve-1/genesis.json"
@@ -97,29 +97,14 @@
     ],
     "persistent_peers": [
       {
-        "id": "fae8cd5f04406e64484a7a8b6719eacbb861c094",
-        "address": "44.241.103.199:26656",
-        "provider": "kyve"
-      },
-      {
-        "id": "146d27829fd240e0e4672700514e9835cb6fdd98",
-        "address": "34.212.201.1:26656",
+        "id": "308e55a36755c68b2c49fb602e2efa3d80fc2b78",
+        "address": "46.105.71.59:26656",
         "provider": "kyve"
       },
       {
         "id": "23f2668adb6d7387c8bc7fdc8a9d10430a092df7",
         "address": "kyve.peer.stavr.tech:12356",
         "provider": "\ud83d\udd25STAVR\ud83d\udd25"
-      },
-      {
-        "id": "25da6253fc8740893277630461eb34c2e4daf545",
-        "address": "3.76.244.30:26656",
-        "provider": "kyve"
-      },
-      {
-        "id": "b950b6b08f7a6d5c3e068fcd263802b336ffe047",
-        "address": "18.198.182.214:26656",
-        "provider": "kyve"
       },
       {
         "id": "ae3f75549c0fe53bae94909fb7477eb308dfe989",
@@ -146,7 +131,7 @@
   "apis": {
     "rpc": [
       {
-        "address": "https://rpc-eu-1.kyve.network",
+        "address": "https://rpc.kyve.network",
         "provider": "kyve"
       },
       {
@@ -200,7 +185,7 @@
     ],
     "rest": [
       {
-        "address": "https://api-eu-1.kyve.network",
+        "address": "https://api.kyve.network",
         "provider": "kyve"
       },
       {
@@ -339,6 +324,18 @@
       "url": "https://explorer.whenmoonwhenlambo.money/kyve",
       "tx_page": "https://explorer.whenmoonwhenlambo.money/kyve/txs/${txHash}",
       "account_page": "https://explorer.whenmoonwhenlambo.money/kyve/account/${accountAddress}"
+    },
+    {
+      "kind": "KYVE Explorer",
+      "url": "https://explorer.kyve.network/kyve",
+      "tx_page": "https://explorer.kyve.network/kyve/tx/${txHash}",
+      "account_page": "https://explorer.kyve.network/kyve/account/${accountAddress}"
+    },
+    {
+      "kind": "Viewblock",
+      "url": "https://viewblock.io/kyve",
+      "tx_page": "https://viewblock.io/kyve/tx/${txHash}",
+      "account_page": "https://viewblock.io/kyve/address/${accountAddress}"
     }
   ],
   "images": [

--- a/testnets/kyvedevnet/chain.json
+++ b/testnets/kyvedevnet/chain.json
@@ -7,7 +7,7 @@
   "status": "live",
   "network_type": "devnet",
   "bech32_prefix": "kyve",
-  "daemon_name": "chaind",
+  "daemon_name": "kyved",
   "node_home": "$HOME/.kyve",
   "key_algos": [
     "secp256k1"
@@ -23,28 +23,26 @@
   },
   "codebase": {
     "git_repo": "https://github.com/KYVENetwork/chain",
-    "recommended_version": "v0.6.3",
+    "recommended_version": "v1.5.0",
     "compatible_versions": [
-      "v0.6.3"
+      "v1.5.0"
     ],
     "binaries": {
-      "linux/amd64": "https://github.com/KYVENetwork/chain/releases/download/v0.6.3/chain_linux_amd64.tar.gz"
+      "darwin/amd64": "https://files.kyve.network/korellia-2/v1.5.0-rc0/kyved_kaon_darwin_amd64?checksum=sha256:5f0c2e02eced4af81d15fbb46ba1f5bca45b662096b8bee3e90a20ef3cb1f54c",
+      "darwin/arm64": "https://files.kyve.network/korellia-2/v1.5.0-rc0/kyved_kaon_darwin_arm64?checksum=sha256:9c3667945a3f559d6a48f03fb61ea4045f410f1207bb9c1705a1043253877bf3",
+      "linux/amd64": "https://files.kyve.network/korellia-2/v1.5.0-rc0/kyved_kaon_linux_amd64?checksum=sha256:f165f4ca6c3831ac0d789fa5b5d6a98c0a9084b767bd048d12cca3691a861e23",
+      "linux/arm64": "https://files.kyve.network/korellia-2/v1.5.0-rc0/kyved_kaon_linux_arm64?checksum=sha256:fbd042016cd6973b301184af39df3020c69b0b35ce08d4286e974bb008ebbff0"
     },
     "genesis": {
-      "genesis_url": "https://github.com/KYVENetwork/chain/releases/download/v0.0.1/genesis.json"
+      "genesis_url": "https://files.kyve.network/korellia-2/genesis.json"
     }
   },
   "peers": {
-    "seeds": [
-      {
-        "id": "02dd2c26948ea758a25d3dbc91744f8897681652",
-        "address": "3.73.27.185:26656"
-      }
-    ],
+    "seeds": [],
     "persistent_peers": [
       {
-        "id": "70556c82352b9919fb6f339b9da0ebc587e9148c",
-        "address": "3.68.232.117:26656"
+        "id": "42ad60464c5104aa61a08e032e2d1bd9aeaa2524",
+        "address": "148.113.187.189:46656"
       }
     ]
   },
@@ -64,9 +62,10 @@
   },
   "explorers": [
     {
-      "kind": "explorers.guru",
-      "url": "https://kyve.explorers.guru/",
-      "tx_page": "https://kyve.explorers.guru/transaction/${txHash}"
+      "kind": "KYVE Explorer",
+      "url": "https://explorer.kyve.network/korellia",
+      "tx_page": "https://explorer.kyve.network/korellia/tx/${txHash}",
+      "account_page": "https://explorer.kyve.network/korellia/account/${accountAddress}"
     }
   ]
 }

--- a/testnets/kyvetestnet/chain.json
+++ b/testnets/kyvetestnet/chain.json
@@ -33,15 +33,15 @@
   },
   "codebase": {
     "git_repo": "https://github.com/KYVENetwork/chain",
-    "recommended_version": "v1.0.0-rc0",
+    "recommended_version": "v1.5.0",
     "compatible_versions": [
-      "v1.0.0-rc0"
+      "v1.5.0"
     ],
     "binaries": {
-      "linux/amd64": "https://files.kyve.network/chain/v1.0.0-rc0/kyved_linux_amd64.tar.gz",
-      "linux/arm64": "https://files.kyve.network/chain/v1.0.0-rc0/kyved_linux_arm64.tar.gz",
-      "darwin/amd64": "https://files.kyve.network/chain/v1.0.0-rc0/kyved_darwin_amd64.tar.gz",
-      "darwin/arm64": "https://files.kyve.network/chain/v1.0.0-rc0/kyved_darwin_arm64.tar.gz"
+      "linux/amd64": "https://github.com/KYVENetwork/chain/releases/download/v1.5.0/kyved_kaon_linux_amd64",
+      "linux/arm64": "https://github.com/KYVENetwork/chain/releases/download/v1.5.0/kyved_kaon_linux_arm64",
+      "darwin/amd64": "https://github.com/KYVENetwork/chain/releases/download/v1.5.0/kyved_kaon_darwin_amd64",
+      "darwin/arm64": "https://github.com/KYVENetwork/chain/releases/download/v1.5.0/kyved_kaon_darwin_arm64"
     },
     "genesis": {
       "genesis_url": "https://raw.githubusercontent.com/KYVENetwork/networks/main/kaon-1/genesis.json"
@@ -50,20 +50,8 @@
   "peers": {
     "persistent_peers": [
       {
-        "id": "430845649afaad0a817bdf36da63b6f93bbd8bd1",
-        "address": "3.67.29.225:26656"
-      },
-      {
-        "id": "b68e5131552e40b9ee70427879eb34e146ef20df",
-        "address": "18.194.131.3:26656"
-      },
-      {
-        "id": "801fa026c6d9227874eeaeba288eae3b800aad7f",
-        "address": "52.29.15.250:26656"
-      },
-      {
-        "id": "bc8b5fbb40a1b82dfba591035cb137278a21c57d",
-        "address": "52.59.65.9:26656"
+        "id": "506d1aff9398b1ba1697c68289414e1d0e1a28b4",
+        "address": "148.113.187.189:36656"
       }
     ],
     "seeds": [
@@ -77,7 +65,7 @@
   "apis": {
     "rpc": [
       {
-        "address": "https://rpc-eu-1.kaon.kyve.network",
+        "address": "https://rpc.kaon.kyve.network",
         "provider": "kyve"
       },
       {
@@ -91,7 +79,7 @@
     ],
     "rest": [
       {
-        "address": "https://api-eu-1.kaon.kyve.network",
+        "address": "https://api.kaon.kyve.network",
         "provider": "kyve"
       },
       {
@@ -110,6 +98,12 @@
       "url": "https://mintscan.io/kyve-testnet",
       "tx_page": "https://mintscan.io/kyve-testnet/txs/${txHash}",
       "account_page": "https://mintscan.io/kyve-testnet/account/${accountAddress}"
+    },
+    {
+      "kind": "KYVE Explorer",
+      "url": "https://explorer.kyve.network/kaon",
+      "tx_page": "https://explorer.kyve.network/kaon/tx/${txHash}",
+      "account_page": "https://explorer.kyve.network/kaon/account/${accountAddress}"
     }
   ]
 }


### PR DESCRIPTION
Update the entries for KYVE (https://github.com/KYVENetwork) mainnet, testnet and devnet. 

Changes:
- Update all networks to current binary
- Official KYVE endpoints have slightly changed
- Removed terminated servers and replaced with the current ones (persistent peers)
- Added Viewblock explorer
- Removed incorrect explorer entry for devnet