### PR TITLE
Remove CoinGecko ID from Testnet $XION

### DIFF
--- a/testnets/xiontestnet/assetlist.json
+++ b/testnets/xiontestnet/assetlist.json
@@ -24,7 +24,6 @@
       "display": "XION",
       "name": "xion",
       "symbol": "XION",
-      "coingecko_id": "xion-2",
       "logo_URIs": {
         "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/xion/images/burnt-round.png"
       },


### PR DESCRIPTION
Remove CoinGecko ID from Testnet $XION
Should only be there for mainnet assets