### PR TITLE
Add WHALE and Register migaloo-archway

### DIFF
--- a/_IBC/archway-migaloo.json
+++ b/_IBC/archway-migaloo.json
@@ -1,23 +1,23 @@
 {
   "$schema": "../ibc_data.schema.json",
   "chain_1": {
-    "chain_name": "migaloo",
-    "client_id": "07-tendermint-138",
-    "connection_id": "connection-108"
-  },
-  "chain_2": {
     "chain_name": "archway",
     "client_id": "07-tendermint-22",
     "connection_id": "connection-114"
   },
+  "chain_2": {
+    "chain_name": "migaloo",
+    "client_id": "07-tendermint-138",
+    "connection_id": "connection-108"
+  },
   "channels": [
     {
       "chain_1": {
-        "channel_id": "channel-141",
+        "channel_id": "channel-184",
         "port_id": "transfer"
       },
       "chain_2": {
-        "channel_id": "channel-184",
+        "channel_id": "channel-141",
         "port_id": "transfer"
       },
       "ordering": "unordered",

--- a/_IBC/archway-migaloo.json
+++ b/_IBC/archway-migaloo.json
@@ -2,7 +2,7 @@
   "$schema": "../ibc_data.schema.json",
   "chain_1": {
     "chain_name": "archway",
-    "client_id": "07-tendermint-22",
+    "client_id": "07-tendermint-119",
     "connection_id": "connection-114"
   },
   "chain_2": {

--- a/_IBC/archway-migaloo.json
+++ b/_IBC/archway-migaloo.json
@@ -1,0 +1,31 @@
+{
+  "$schema": "../ibc_data.schema.json",
+  "chain_1": {
+    "chain_name": "migaloo",
+    "client_id": "07-tendermint-138",
+    "connection_id": "connection-108"
+  },
+  "chain_2": {
+    "chain_name": "archway",
+    "client_id": "07-tendermint-22",
+    "connection_id": "connection-114"
+  },
+  "channels": [
+    {
+      "chain_1": {
+        "channel_id": "channel-141",
+        "port_id": "transfer"
+      },
+      "chain_2": {
+        "channel_id": "channel-184",
+        "port_id": "transfer"
+      },
+      "ordering": "unordered",
+      "version": "ics20-1",
+      "tags": {
+        "status": "live",
+        "preferred": true
+      }
+    }
+  ]
+}

--- a/archway/assetlist.json
+++ b/archway/assetlist.json
@@ -405,6 +405,58 @@
           }
         }
       ]
+    },
+    {
+      "description": "The native token of Migaloo Chain",
+      "denom_units": [
+        {
+          "denom": "ibc/3F882513A0CCD1C4110ACB7C6C761AC7B48974C9D2D439CD6F652F9B44362518",
+          "exponent": 0,
+          "aliases": [
+            "uwhale"
+          ]
+        },
+        {
+          "denom": "whale",
+          "exponent": 6
+        }
+      ],
+      "type_asset": "ics20",
+      "base": "ibc/3F882513A0CCD1C4110ACB7C6C761AC7B48974C9D2D439CD6F652F9B44362518",
+      "name": "Migaloo",
+      "display": "whale",
+      "symbol": "WHALE",
+      "traces": [
+        {
+          "type": "ibc",
+          "counterparty": {
+            "chain_name": "migaloo",
+            "base_denom": "uwhale",
+            "channel_id": "channel-141"
+          },
+          "chain": {
+            "channel_id": "channel-184",
+            "path": "transfer/channel-184/uwhale"
+          }
+        }
+      ],
+      "logo_URIs": {
+        "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/migaloo/images/white-whale.png",
+        "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/migaloo/images/white-whale.svg"
+      },
+      "images": [
+        {
+          "image_sync": {
+            "chain_name": "migaloo",
+            "base_denom": "uwhale"
+          },
+          "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/migaloo/images/white-whale.png",
+          "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/migaloo/images/white-whale.svg",
+          "theme": {
+            "primary_color_hex": "#1c1c1c"
+          }
+        }
+      ]
     }
   ]
 }

--- a/chihuahua/assetlist.json
+++ b/chihuahua/assetlist.json
@@ -415,6 +415,58 @@
       "logo_URIs": {
         "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/migaloo/images/guppy.png"
       }
+    },
+    {
+      "description": "The native token of Migaloo Chain",
+      "denom_units": [
+        {
+          "denom": "ibc/FA7112322CE7656DC84D441E49BAEAB9DC0AB3C7618A178A212CDE8B3F17C70B",
+          "exponent": 0,
+          "aliases": [
+            "uwhale"
+          ]
+        },
+        {
+          "denom": "whale",
+          "exponent": 6
+        }
+      ],
+      "type_asset": "ics20",
+      "base": "ibc/FA7112322CE7656DC84D441E49BAEAB9DC0AB3C7618A178A212CDE8B3F17C70B",
+      "name": "Migaloo",
+      "display": "whale",
+      "symbol": "WHALE",
+      "traces": [
+        {
+          "type": "ibc",
+          "counterparty": {
+            "chain_name": "migaloo",
+            "base_denom": "uwhale",
+            "channel_id": "channel-10"
+          },
+          "chain": {
+            "channel_id": "channel-39",
+            "path": "transfer/channel-39/uwhale"
+          }
+        }
+      ],
+      "logo_URIs": {
+        "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/migaloo/images/white-whale.png",
+        "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/migaloo/images/white-whale.svg"
+      },
+      "images": [
+        {
+          "image_sync": {
+            "chain_name": "migaloo",
+            "base_denom": "uwhale"
+          },
+          "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/migaloo/images/white-whale.png",
+          "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/migaloo/images/white-whale.svg",
+          "theme": {
+            "primary_color_hex": "#1c1c1c"
+          }
+        }
+      ]
     }
   ]
 }

--- a/injective/assetlist.json
+++ b/injective/assetlist.json
@@ -1146,6 +1146,58 @@
         }
       ],
       "type_asset": "sdk.coin"
+    },
+    {
+      "description": "The native token of Migaloo Chain",
+      "denom_units": [
+        {
+          "denom": "ibc/D6E6A20ABDD600742D22464340A7701558027759CE14D12590F8EA869CCCF445",
+          "exponent": 0,
+          "aliases": [
+            "uwhale"
+          ]
+        },
+        {
+          "denom": "whale",
+          "exponent": 6
+        }
+      ],
+      "type_asset": "ics20",
+      "base": "ibc/D6E6A20ABDD600742D22464340A7701558027759CE14D12590F8EA869CCCF445",
+      "name": "Migaloo",
+      "display": "whale",
+      "symbol": "WHALE",
+      "traces": [
+        {
+          "type": "ibc",
+          "counterparty": {
+            "chain_name": "migaloo",
+            "base_denom": "uwhale",
+            "channel_id": "channel-3"
+          },
+          "chain": {
+            "channel_id": "channel-102",
+            "path": "transfer/channel-102/uwhale"
+          }
+        }
+      ],
+      "logo_URIs": {
+        "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/migaloo/images/white-whale.png",
+        "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/migaloo/images/white-whale.svg"
+      },
+      "images": [
+        {
+          "image_sync": {
+            "chain_name": "migaloo",
+            "base_denom": "uwhale"
+          },
+          "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/migaloo/images/white-whale.png",
+          "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/migaloo/images/white-whale.svg",
+          "theme": {
+            "primary_color_hex": "#1c1c1c"
+          }
+        }
+      ]
     }
   ]
 }

--- a/juno/assetlist.json
+++ b/juno/assetlist.json
@@ -2581,6 +2581,58 @@
           }
         }
       ]
+    },
+    {
+      "description": "The native token of Migaloo Chain",
+      "denom_units": [
+        {
+          "denom": "ibc/3A6ADE78FB8169C034C29C4F2E1A61CE596EC8235366F22381D981A98F1F5A5C",
+          "exponent": 0,
+          "aliases": [
+            "uwhale"
+          ]
+        },
+        {
+          "denom": "whale",
+          "exponent": 6
+        }
+      ],
+      "type_asset": "ics20",
+      "base": "ibc/3A6ADE78FB8169C034C29C4F2E1A61CE596EC8235366F22381D981A98F1F5A5C",
+      "name": "Migaloo",
+      "display": "whale",
+      "symbol": "WHALE",
+      "traces": [
+        {
+          "type": "ibc",
+          "counterparty": {
+            "chain_name": "migaloo",
+            "base_denom": "uwhale",
+            "channel_id": "channel-1"
+          },
+          "chain": {
+            "channel_id": "channel-210",
+            "path": "transfer/channel-210/uwhale"
+          }
+        }
+      ],
+      "logo_URIs": {
+        "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/migaloo/images/white-whale.png",
+        "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/migaloo/images/white-whale.svg"
+      },
+      "images": [
+        {
+          "image_sync": {
+            "chain_name": "migaloo",
+            "base_denom": "uwhale"
+          },
+          "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/migaloo/images/white-whale.png",
+          "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/migaloo/images/white-whale.svg",
+          "theme": {
+            "primary_color_hex": "#1c1c1c"
+          }
+        }
+      ]
     }
   ]
 }

--- a/terra/assetlist.json
+++ b/terra/assetlist.json
@@ -6359,58 +6359,6 @@
       "logo_URIs": {
         "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/terra/images/FROG.png"
       }
-    },
-    {
-      "description": "The native token of Migaloo Chain",
-      "denom_units": [
-        {
-          "denom": "ibc/077EE5F87CE5CD419436D26533329BDC7BEE6850AD64BC316486B0DCCB13C0EB",
-          "exponent": 0,
-          "aliases": [
-            "uwhale"
-          ]
-        },
-        {
-          "denom": "whale",
-          "exponent": 6
-        }
-      ],
-      "type_asset": "ics20",
-      "base": "ibc/077EE5F87CE5CD419436D26533329BDC7BEE6850AD64BC316486B0DCCB13C0EB",
-      "name": "Migaloo",
-      "display": "whale",
-      "symbol": "WHALE",
-      "traces": [
-        {
-          "type": "ibc",
-          "counterparty": {
-            "chain_name": "migaloo",
-            "base_denom": "uwhale",
-            "channel_id": "channel-114"
-          },
-          "chain": {
-            "channel_id": "channel-87",
-            "path": "transfer/channel-87/uwhale"
-          }
-        }
-      ],
-      "logo_URIs": {
-        "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/migaloo/images/white-whale.png",
-        "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/migaloo/images/white-whale.svg"
-      },
-      "images": [
-        {
-          "image_sync": {
-            "chain_name": "migaloo",
-            "base_denom": "uwhale"
-          },
-          "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/migaloo/images/white-whale.png",
-          "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/migaloo/images/white-whale.svg",
-          "theme": {
-            "primary_color_hex": "#1c1c1c"
-          }
-        }
-      ]
     }
   ]
 }

--- a/terra/assetlist.json
+++ b/terra/assetlist.json
@@ -6359,6 +6359,58 @@
       "logo_URIs": {
         "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/terra/images/FROG.png"
       }
+    },
+    {
+      "description": "The native token of Migaloo Chain",
+      "denom_units": [
+        {
+          "denom": "ibc/077EE5F87CE5CD419436D26533329BDC7BEE6850AD64BC316486B0DCCB13C0EB",
+          "exponent": 0,
+          "aliases": [
+            "uwhale"
+          ]
+        },
+        {
+          "denom": "whale",
+          "exponent": 6
+        }
+      ],
+      "type_asset": "ics20",
+      "base": "ibc/077EE5F87CE5CD419436D26533329BDC7BEE6850AD64BC316486B0DCCB13C0EB",
+      "name": "Migaloo",
+      "display": "whale",
+      "symbol": "WHALE",
+      "traces": [
+        {
+          "type": "ibc",
+          "counterparty": {
+            "chain_name": "migaloo",
+            "base_denom": "uwhale",
+            "channel_id": "channel-114"
+          },
+          "chain": {
+            "channel_id": "channel-87",
+            "path": "transfer/channel-87/uwhale"
+          }
+        }
+      ],
+      "logo_URIs": {
+        "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/migaloo/images/white-whale.png",
+        "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/migaloo/images/white-whale.svg"
+      },
+      "images": [
+        {
+          "image_sync": {
+            "chain_name": "migaloo",
+            "base_denom": "uwhale"
+          },
+          "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/migaloo/images/white-whale.png",
+          "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/migaloo/images/white-whale.svg",
+          "theme": {
+            "primary_color_hex": "#1c1c1c"
+          }
+        }
+      ]
     }
   ]
 }

--- a/terra2/assetlist.json
+++ b/terra2/assetlist.json
@@ -1692,6 +1692,58 @@
         "website": "https://www.cryptodungeon.org",
         "twitter": "https://twitter.com/cryptodungeonma"
       }
+    },
+    {
+      "description": "The native token of Migaloo Chain",
+      "denom_units": [
+        {
+          "denom": "ibc/36A02FFC4E74DF4F64305130C3DFA1B06BEAC775648927AA44467C76A77AB8DB",
+          "exponent": 0,
+          "aliases": [
+            "uwhale"
+          ]
+        },
+        {
+          "denom": "whale",
+          "exponent": 6
+        }
+      ],
+      "type_asset": "ics20",
+      "base": "ibc/36A02FFC4E74DF4F64305130C3DFA1B06BEAC775648927AA44467C76A77AB8DB",
+      "name": "Migaloo",
+      "display": "whale",
+      "symbol": "WHALE",
+      "traces": [
+        {
+          "type": "ibc",
+          "counterparty": {
+            "chain_name": "migaloo",
+            "base_denom": "uwhale",
+            "channel_id": "channel-0"
+          },
+          "chain": {
+            "channel_id": "channel-86",
+            "path": "transfer/channel-86/uwhale"
+          }
+        }
+      ],
+      "logo_URIs": {
+        "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/migaloo/images/white-whale.png",
+        "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/migaloo/images/white-whale.svg"
+      },
+      "images": [
+        {
+          "image_sync": {
+            "chain_name": "migaloo",
+            "base_denom": "uwhale"
+          },
+          "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/migaloo/images/white-whale.png",
+          "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/migaloo/images/white-whale.svg",
+          "theme": {
+            "primary_color_hex": "#1c1c1c"
+          }
+        }
+      ]
     }
   ]
 }


### PR DESCRIPTION
This PR adds WHALE, Native token of the Migaloo blockchain, to multiple chain assetlists:

Terra2
Terra
Archway
Juno
Chihuahua
Injective

Additionally it also registers migaloo-archway connection in _IBC