### PR TITLE
Set status of Nois to killed

### DIFF
--- a/nois/chain.json
+++ b/nois/chain.json
@@ -1,7 +1,7 @@
 {
   "$schema": "../chain.schema.json",
   "chain_name": "nois",
-  "status": "live",
+  "status": "killed",
   "network_type": "mainnet",
   "website": "https://nois.network",
   "pretty_name": "Nois",


### PR DESCRIPTION
A governance proposal passed today to end the blockchain on December 10th:
https://nois.explorers.guru/proposal/11

The last block will be [22777777](https://nois.explorers.guru/block/22777777)

-----------------

For the archive:

![Screenshot 2024-12-07 at 22-36-19 Proposal #11 Details - Nois (NOIS) Blockchain Explorer](https://github.com/user-attachments/assets/a7741a69-13ea-45c6-a88f-cf6cd338230f)
