### PR TITLE
Restore XION Explorer

### DIFF
--- a/xion/chain.json
+++ b/xion/chain.json
@@ -176,6 +176,12 @@
       "account_page": "https://explorer.whenmoonwhenlambo.money/xion/account/${accountAddress}"
     },
     {
+      "kind": "staking-explorer.com",
+      "url": "https://staking-explorer.com/explorer/xion",
+      "tx_page": "https://staking-explorer.com/transaction.php?chain=xion&tx=${txHash}",
+      "account_page": "https://staking-explorer.com/account.php?chain=xion&addr=${accountAddress}"
+    },
+    {
       "kind": "NodeStake",
       "url": "https://explorer.nodestake.org/xion",
       "tx_page": "https://explorer.nodestake.org/xion/tx/${txHash}",


### PR DESCRIPTION
Staking Explorer's XION Node was accidentally removed. This is restoring it