### PR TITLE
fix: CHEQD: Reflect v3 protocol release + versioning

### DIFF
--- a/cheqd/chain.json
+++ b/cheqd/chain.json
@@ -31,16 +31,15 @@
   },
   "codebase": {
     "git_repo": "https://github.com/cheqd/cheqd-node",
-    "recommended_version": "v2.0.1",
+    "recommended_version": "v3.0.1",
     "compatible_versions": [
-      "v2.0.0",
-      "v2.0.1"
+      "v3.0.1"
     ],
     "binaries": {
-      "linux/amd64": "https://github.com/cheqd/cheqd-node/releases/download/v2.0.1/cheqd-noded-2.0.1-linux-amd64.tar.gz",
-      "linux/arm64": "https://github.com/cheqd/cheqd-node/releases/download/v2.0.1/cheqd-noded-2.0.1-linux-arm64.tar.gz",
-      "darwin/amd64": "https://github.com/cheqd/cheqd-node/releases/download/v2.0.1/cheqd-noded-2.0.1-darwin-amd64.tar.gz",
-      "darwin/arm64": "https://github.com/cheqd/cheqd-node/releases/download/v2.0.1/cheqd-noded-2.0.1-darwin-arm64.tar.gz"
+      "linux/amd64": "https://github.com/cheqd/cheqd-node/releases/download/v3.0.1/cheqd-noded-3.0.1-linux-amd64.tar.gz",
+      "linux/arm64": "https://github.com/cheqd/cheqd-node/releases/download/v3.0.1/cheqd-noded-3.0.1-linux-arm64.tar.gz",
+      "darwin/amd64": "https://github.com/cheqd/cheqd-node/releases/download/v3.0.1/cheqd-noded-3.0.1-darwin-amd64.tar.gz",
+      "darwin/arm64": "https://github.com/cheqd/cheqd-node/releases/download/v3.0.1/cheqd-noded-3.0.1-darwin-arm64.tar.gz"
     },
     "consensus": {
       "type": "cometbft",

--- a/cheqd/versions.json
+++ b/cheqd/versions.json
@@ -153,10 +153,11 @@
     },
     {
       "name": "v2",
-      "recommended_version": "v2.0.1",
+      "recommended_version": "v2.0.2",
       "compatible_versions": [
         "v2.0.0",
-        "v2.0.1"
+        "v2.0.1",
+        "v2.0.2"
       ],
       "consensus": {
         "type": "cometbft",
@@ -165,10 +166,10 @@
       "proposal": 48,
       "height": 13024570,
       "binaries": {
-        "linux/amd64": "https://github.com/cheqd/cheqd-node/releases/download/v2.0.1/cheqd-noded-2.0.1-linux-amd64.tar.gz",
-        "linux/arm64": "https://github.com/cheqd/cheqd-node/releases/download/v2.0.1/cheqd-noded-2.0.1-linux-arm64.tar.gz",
-        "darwin/amd64": "https://github.com/cheqd/cheqd-node/releases/download/v2.0.1/cheqd-noded-2.0.1-darwin-amd64.tar.gz",
-        "darwin/arm64": "https://github.com/cheqd/cheqd-node/releases/download/v2.0.1/cheqd-noded-2.0.1-darwin-arm64.tar.gz"
+        "linux/amd64": "https://github.com/cheqd/cheqd-node/releases/download/v2.0.2/cheqd-noded-2.0.2-linux-amd64.tar.gz",
+        "linux/arm64": "https://github.com/cheqd/cheqd-node/releases/download/v2.0.2/cheqd-noded-2.0.2-linux-arm64.tar.gz",
+        "darwin/amd64": "https://github.com/cheqd/cheqd-node/releases/download/v2.0.2/cheqd-noded-2.0.2-darwin-amd64.tar.gz",
+        "darwin/arm64": "https://github.com/cheqd/cheqd-node/releases/download/v2.0.2/cheqd-noded-2.0.2-darwin-arm64.tar.gz"
       },
       "previous_version_name": "v1",
       "next_version_name": "v3",

--- a/cheqd/versions.json
+++ b/cheqd/versions.json
@@ -171,6 +171,37 @@
         "darwin/arm64": "https://github.com/cheqd/cheqd-node/releases/download/v2.0.1/cheqd-noded-2.0.1-darwin-arm64.tar.gz"
       },
       "previous_version_name": "v1",
+      "next_version_name": "v3",
+      "sdk": {
+        "type": "cosmos",
+        "repo": "https://github.com/cheqd/cosmos-sdk",
+        "version": "v0.47.10",
+        "tag": "v0.47.10-height-mismatch"
+      },
+      "ibc": {
+        "type": "go",
+        "version": "v7.4.0"
+      }
+    },
+    {
+      "name": "v3",
+      "recommended_version": "v3.0.1",
+      "compatible_versions": [
+        "v3.0.1"
+      ],
+      "consensus": {
+        "type": "cometbft",
+        "version": "0.37.5"
+      },
+      "proposal": 57,
+      "height": 16502390,
+      "binaries": {
+        "linux/amd64": "https://github.com/cheqd/cheqd-node/releases/download/v3.0.1/cheqd-noded-3.0.1-linux-amd64.tar.gz",
+        "linux/arm64": "https://github.com/cheqd/cheqd-node/releases/download/v3.0.1/cheqd-noded-3.0.1-linux-arm64.tar.gz",
+        "darwin/amd64": "https://github.com/cheqd/cheqd-node/releases/download/v3.0.1/cheqd-noded-3.0.1-darwin-amd64.tar.gz",
+        "darwin/arm64": "https://github.com/cheqd/cheqd-node/releases/download/v3.0.1/cheqd-noded-3.0.1-darwin-arm64.tar.gz"
+      },
+      "previous_version_name": "v2",
       "next_version_name": "",
       "sdk": {
         "type": "cosmos",

--- a/testnets/cheqdtestnet/chain.json
+++ b/testnets/cheqdtestnet/chain.json
@@ -23,16 +23,15 @@
   },
   "codebase": {
     "git_repo": "https://github.com/cheqd/cheqd-node",
-    "recommended_version": "v2.0.1",
+    "recommended_version": "v3.0.1",
     "compatible_versions": [
-      "v2.0.0",
-      "v2.0.1"
+      "v3.0.1"
     ],
     "binaries": {
-      "linux/amd64": "https://github.com/cheqd/cheqd-node/releases/download/v2.0.1/cheqd-noded-2.0.1-linux-amd64.tar.gz",
-      "linux/arm64": "https://github.com/cheqd/cheqd-node/releases/download/v2.0.1/cheqd-noded-2.0.1-linux-arm64.tar.gz",
-      "darwin/amd64": "https://github.com/cheqd/cheqd-node/releases/download/v2.0.1/cheqd-noded-2.0.1-darwin-amd64.tar.gz",
-      "darwin/arm64": "https://github.com/cheqd/cheqd-node/releases/download/v2.0.1/cheqd-noded-2.0.1-darwin-arm64.tar.gz"
+      "linux/amd64": "https://github.com/cheqd/cheqd-node/releases/download/v3.0.1/cheqd-noded-3.0.1-linux-amd64.tar.gz",
+      "linux/arm64": "https://github.com/cheqd/cheqd-node/releases/download/v3.0.1/cheqd-noded-3.0.1-linux-arm64.tar.gz",
+      "darwin/amd64": "https://github.com/cheqd/cheqd-node/releases/download/v3.0.1/cheqd-noded-3.0.1-darwin-amd64.tar.gz",
+      "darwin/arm64": "https://github.com/cheqd/cheqd-node/releases/download/v3.0.1/cheqd-noded-3.0.1-darwin-arm64.tar.gz"
     },
     "consensus": {
       "type": "cometbft",

--- a/testnets/cheqdtestnet/versions.json
+++ b/testnets/cheqdtestnet/versions.json
@@ -70,10 +70,11 @@
     },
     {
       "name": "v2",
-      "recommended_version": "v2.0.1",
+      "recommended_version": "v2.0.2",
       "compatible_versions": [
         "v2.0.0",
-        "v2.0.1"
+        "v2.0.1",
+        "v2.0.2"
       ],
       "consensus": {
         "type": "cometbft",
@@ -82,12 +83,43 @@
       "proposal": 12,
       "height": 6194750,
       "binaries": {
-        "linux/amd64": "https://github.com/cheqd/cheqd-node/releases/download/v2.0.1/cheqd-noded-2.0.1-linux-amd64.tar.gz",
-        "linux/arm64": "https://github.com/cheqd/cheqd-node/releases/download/v2.0.1/cheqd-noded-2.0.1-linux-arm64.tar.gz",
-        "darwin/amd64": "https://github.com/cheqd/cheqd-node/releases/download/v2.0.1/cheqd-noded-2.0.1-darwin-amd64.tar.gz",
-        "darwin/arm64": "https://github.com/cheqd/cheqd-node/releases/download/v2.0.1/cheqd-noded-2.0.1-darwin-arm64.tar.gz"
+        "linux/amd64": "https://github.com/cheqd/cheqd-node/releases/download/v2.0.2/cheqd-noded-2.0.2-linux-amd64.tar.gz",
+        "linux/arm64": "https://github.com/cheqd/cheqd-node/releases/download/v2.0.2/cheqd-noded-2.0.2-linux-arm64.tar.gz",
+        "darwin/amd64": "https://github.com/cheqd/cheqd-node/releases/download/v2.0.2/cheqd-noded-2.0.2-darwin-amd64.tar.gz",
+        "darwin/arm64": "https://github.com/cheqd/cheqd-node/releases/download/v2.0.2/cheqd-noded-2.0.2-darwin-arm64.tar.gz"
       },
       "previous_version_name": "v1",
+      "next_version_name": "v3",
+      "sdk": {
+        "type": "cosmos",
+        "repo": "https://github.com/cheqd/cosmos-sdk",
+        "version": "v0.47.10",
+        "tag": "v0.47.10-height-mismatch"
+      },
+      "ibc": {
+        "type": "go",
+        "version": "v7.4.0"
+      }
+    },
+    {
+      "name": "v3",
+      "recommended_version": "v3.0.1",
+      "compatible_versions": [
+        "v3.0.1"
+      ],
+      "consensus": {
+        "type": "cometbft",
+        "version": "0.37.5"
+      },
+      "proposal": 15,
+      "height": 9309600,
+      "binaries": {
+        "linux/amd64": "https://github.com/cheqd/cheqd-node/releases/download/v3.0.1/cheqd-noded-3.0.1-linux-amd64.tar.gz",
+        "linux/arm64": "https://github.com/cheqd/cheqd-node/releases/download/v3.0.1/cheqd-noded-3.0.1-linux-arm64.tar.gz",
+        "darwin/amd64": "https://github.com/cheqd/cheqd-node/releases/download/v3.0.1/cheqd-noded-3.0.1-darwin-amd64.tar.gz",
+        "darwin/arm64": "https://github.com/cheqd/cheqd-node/releases/download/v3.0.1/cheqd-noded-3.0.1-darwin-arm64.tar.gz"
+      },
+      "previous_version_name": "v2",
       "next_version_name": "",
       "sdk": {
         "type": "cosmos",


### PR DESCRIPTION
- Updates cheqd v3 protocol release values.
- Backfills versioning.