### PR TITLE
Update Pryzm to v0.21

### DIFF
--- a/pryzm/chain.json
+++ b/pryzm/chain.json
@@ -108,15 +108,15 @@
   },
   "codebase": {
     "git_repo": "https://github.com/pryzm-finance/pryzm-core",
-    "recommended_version": "v0.19.0",
+    "recommended_version": "v0.21.0",
     "compatible_versions": [
-      "v0.19.0"
+      "v0.21.0"
     ],
     "binaries": {
-      "darwin/amd64": "https://storage.googleapis.com/pryzm-zone/core/0.19.0/pryzmd-0.19.0-darwin-amd64",
-      "darwin/arm64": "https://storage.googleapis.com/pryzm-zone/core/0.19.0/pryzmd-0.19.0-darwin-arm64",
-      "linux/amd64": "https://storage.googleapis.com/pryzm-zone/core/0.19.0/pryzmd-0.19.0-linux-amd64",
-      "linux/arm64": "https://storage.googleapis.com/pryzm-zone/core/0.19.0/pryzmd-0.19.0-linux-arm64"
+      "darwin/amd64": "https://storage.googleapis.com/pryzm-zone/core/0.21.0/pryzmd-0.21.0-darwin-amd64",
+      "darwin/arm64": "https://storage.googleapis.com/pryzm-zone/core/0.21.0/pryzmd-0.21.0-darwin-arm64",
+      "linux/amd64": "https://storage.googleapis.com/pryzm-zone/core/0.21.0/pryzmd-0.21.0-linux-amd64",
+      "linux/arm64": "https://storage.googleapis.com/pryzm-zone/core/0.21.0/pryzmd-0.21.0-linux-arm64"
     },
     "consensus": {
       "type": "cometbft",
@@ -131,7 +131,7 @@
     },
     "sdk": {
       "type": "cosmos",
-      "version": "v0.47.13"
+      "version": "v0.47.14"
     },
     "ibc": {
       "type": "go",

--- a/pryzm/versions.json
+++ b/pryzm/versions.json
@@ -145,7 +145,7 @@
         "version": "0.37.5"
       },
       "previous_version_name": "v0.18",
-      "next_version_name": "",
+      "next_version_name": "v0.21",
       "cosmwasm": {
         "version": "v0.46.0",
         "enabled": true
@@ -153,6 +153,48 @@
       "sdk": {
         "type": "cosmos",
         "version": "v0.47.13"
+      },
+      "ibc": {
+        "type": "go",
+        "version": "7.4.1",
+        "ics_enabled": [
+          "ics20-1",
+          "ics27-1"
+        ]
+      },
+      "language": {
+        "type": "go",
+        "version": "1.22"
+      }
+    },
+    {
+      "name": "v0.21",
+      "tag": "v0.21.0",
+      "proposal": 21,
+      "height": 3326700,
+      "recommended_version": "v0.21.0",
+      "compatible_versions": [
+        "v0.21.0"
+      ],
+      "binaries": {
+        "darwin/amd64": "https://storage.googleapis.com/pryzm-zone/core/0.21.0/pryzmd-0.21.0-darwin-amd64",
+        "darwin/arm64": "https://storage.googleapis.com/pryzm-zone/core/0.21.0/pryzmd-0.21.0-darwin-arm64",
+        "linux/amd64": "https://storage.googleapis.com/pryzm-zone/core/0.21.0/pryzmd-0.21.0-linux-amd64",
+        "linux/arm64": "https://storage.googleapis.com/pryzm-zone/core/0.21.0/pryzmd-0.21.0-linux-arm64"
+      },
+      "consensus": {
+        "type": "cometbft",
+        "version": "0.37.5"
+      },
+      "previous_version_name": "v0.19",
+      "next_version_name": "",
+      "cosmwasm": {
+        "version": "v0.46.0",
+        "enabled": true
+      },
+      "sdk": {
+        "type": "cosmos",
+        "version": "v0.47.14"
       },
       "ibc": {
         "type": "go",


### PR DESCRIPTION
This PR updates the Pryzm chain version to the latest upgraded version.