### PR TITLE
Add new Pryzm derivatives with 31Mar2025 maturity

### DIFF
--- a/pryzm/assetlist.json
+++ b/pryzm/assetlist.json
@@ -1376,34 +1376,6 @@
       "type_asset": "sdk.coin"
     },
     {
-      "description": "Pryzm's refracted principal token for LUNA with maturity of 31Dec2026",
-      "denom_units": [
-        {
-          "denom": "p:uluna:31Dec2026",
-          "exponent": 0
-        },
-        {
-          "denom": "pLUNA31Dec2026",
-          "exponent": 6
-        }
-      ],
-      "base": "p:uluna:31Dec2026",
-      "name": "pLuna (31Dec2026)",
-      "display": "pLUNA31Dec2026",
-      "symbol": "pLUNA-31Dec2026",
-      "logo_URIs": {
-        "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/pryzm/images/pLuna.png",
-        "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/pryzm/images/pLuna.svg"
-      },
-      "images": [
-        {
-          "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/pryzm/images/pLuna.png",
-          "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/pryzm/images/pLuna.svg"
-        }
-      ],
-      "type_asset": "sdk.coin"
-    },
-    {
       "description": "Pryzm's refracted principal token for LUNA with maturity of 31Dec2025",
       "denom_units": [
         {
@@ -1419,6 +1391,34 @@
       "name": "pLuna (31Dec2025)",
       "display": "pLUNA31Dec2025",
       "symbol": "pLUNA-31Dec2025",
+      "logo_URIs": {
+        "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/pryzm/images/pLuna.png",
+        "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/pryzm/images/pLuna.svg"
+      },
+      "images": [
+        {
+          "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/pryzm/images/pLuna.png",
+          "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/pryzm/images/pLuna.svg"
+        }
+      ],
+      "type_asset": "sdk.coin"
+    },
+    {
+      "description": "Pryzm's refracted principal token for LUNA with maturity of 31Dec2026",
+      "denom_units": [
+        {
+          "denom": "p:uluna:31Dec2026",
+          "exponent": 0
+        },
+        {
+          "denom": "pLUNA31Dec2026",
+          "exponent": 6
+        }
+      ],
+      "base": "p:uluna:31Dec2026",
+      "name": "pLuna (31Dec2026)",
+      "display": "pLUNA31Dec2026",
+      "symbol": "pLUNA-31Dec2026",
       "logo_URIs": {
         "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/pryzm/images/pLuna.png",
         "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/pryzm/images/pLuna.svg"

--- a/pryzm/assetlist.json
+++ b/pryzm/assetlist.json
@@ -928,6 +928,34 @@
       "type_asset": "sdk.coin"
     },
     {
+      "description": "Pryzm's refracted principal token for ATOM with maturity of 31Mar2025",
+      "denom_units": [
+        {
+          "denom": "p:uatom:31Mar2025",
+          "exponent": 0
+        },
+        {
+          "denom": "pATOM31Mar2025",
+          "exponent": 6
+        }
+      ],
+      "base": "p:uatom:31Mar2025",
+      "name": "pAtom (31Mar2025)",
+      "display": "pATOM31Mar2025",
+      "symbol": "pATOM-31Mar2025",
+      "logo_URIs": {
+        "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/pryzm/images/pAtom.png",
+        "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/pryzm/images/pAtom.svg"
+      },
+      "images": [
+        {
+          "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/pryzm/images/pAtom.png",
+          "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/pryzm/images/pAtom.svg"
+        }
+      ],
+      "type_asset": "sdk.coin"
+    },
+    {
       "description": "Pryzm's refracted principal token for ATOM with maturity of 31Dec2025",
       "denom_units": [
         {
@@ -1027,6 +1055,34 @@
       "name": "pOsmo (31Dec2024)",
       "display": "pOSMO31Dec2024",
       "symbol": "pOSMO-31Dec2024",
+      "logo_URIs": {
+        "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/pryzm/images/pOsmo.png",
+        "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/pryzm/images/pOsmo.svg"
+      },
+      "images": [
+        {
+          "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/pryzm/images/pOsmo.png",
+          "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/pryzm/images/pOsmo.svg"
+        }
+      ],
+      "type_asset": "sdk.coin"
+    },
+    {
+      "description": "Pryzm's refracted principal token for OSMO with maturity of 31Mar2025",
+      "denom_units": [
+        {
+          "denom": "p:uosmo:31Mar2025",
+          "exponent": 0
+        },
+        {
+          "denom": "pOSMO31Mar2025",
+          "exponent": 6
+        }
+      ],
+      "base": "p:uosmo:31Mar2025",
+      "name": "pOsmo (31Mar2025)",
+      "display": "pOSMO31Mar2025",
+      "symbol": "pOSMO-31Mar2025",
       "logo_URIs": {
         "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/pryzm/images/pOsmo.png",
         "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/pryzm/images/pOsmo.svg"
@@ -1152,6 +1208,34 @@
       "type_asset": "sdk.coin"
     },
     {
+      "description": "Pryzm's refracted principal token for INJ with maturity of 31Mar2025",
+      "denom_units": [
+        {
+          "denom": "p:inj:31Mar2025",
+          "exponent": 0
+        },
+        {
+          "denom": "pINJ31Mar2025",
+          "exponent": 18
+        }
+      ],
+      "base": "p:inj:31Mar2025",
+      "name": "pInj (31Mar2025)",
+      "display": "pINJ31Mar2025",
+      "symbol": "pINJ-31Mar2025",
+      "logo_URIs": {
+        "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/pryzm/images/pInj.png",
+        "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/pryzm/images/pInj.svg"
+      },
+      "images": [
+        {
+          "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/pryzm/images/pInj.png",
+          "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/pryzm/images/pInj.svg"
+        }
+      ],
+      "type_asset": "sdk.coin"
+    },
+    {
       "description": "Pryzm's refracted principal token for INJ with maturity of 31Dec2025",
       "denom_units": [
         {
@@ -1251,6 +1335,34 @@
       "name": "pLuna (31Dec2024)",
       "display": "pLUNA31Dec2024",
       "symbol": "pLUNA-31Dec2024",
+      "logo_URIs": {
+        "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/pryzm/images/pLuna.png",
+        "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/pryzm/images/pLuna.svg"
+      },
+      "images": [
+        {
+          "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/pryzm/images/pLuna.png",
+          "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/pryzm/images/pLuna.svg"
+        }
+      ],
+      "type_asset": "sdk.coin"
+    },
+    {
+      "description": "Pryzm's refracted principal token for LUNA with maturity of 31Mar2025",
+      "denom_units": [
+        {
+          "denom": "p:uluna:31Mar2025",
+          "exponent": 0
+        },
+        {
+          "denom": "pLUNA31Mar2025",
+          "exponent": 6
+        }
+      ],
+      "base": "p:uluna:31Mar2025",
+      "name": "pLuna (31Mar2025)",
+      "display": "pLUNA31Mar2025",
+      "symbol": "pLUNA-31Mar2025",
       "logo_URIs": {
         "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/pryzm/images/pLuna.png",
         "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/pryzm/images/pLuna.svg"
@@ -1488,6 +1600,34 @@
       "type_asset": "sdk.coin"
     },
     {
+      "description": "Pryzm's refracted principal token for stTIA with maturity of 31Mar2025",
+      "denom_units": [
+        {
+          "denom": "p:stutia:31Mar2025",
+          "exponent": 0
+        },
+        {
+          "denom": "pstTIA31Mar2025",
+          "exponent": 6
+        }
+      ],
+      "base": "p:stutia:31Mar2025",
+      "name": "pstTia (31Mar2025)",
+      "display": "pstTIA31Mar2025",
+      "symbol": "pstTIA-31Mar2025",
+      "logo_URIs": {
+        "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/pryzm/images/pstTia.png",
+        "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/pryzm/images/pstTia.svg"
+      },
+      "images": [
+        {
+          "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/pryzm/images/pstTia.png",
+          "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/pryzm/images/pstTia.svg"
+        }
+      ],
+      "type_asset": "sdk.coin"
+    },
+    {
       "description": "Pryzm's refracted principal token for stTIA with maturity of 31Dec2025",
       "denom_units": [
         {
@@ -1600,6 +1740,34 @@
       "type_asset": "sdk.coin"
     },
     {
+      "description": "Pryzm's refracted principal token for stDYDX with maturity of 31Mar2025",
+      "denom_units": [
+        {
+          "denom": "p:stadydx:31Mar2025",
+          "exponent": 0
+        },
+        {
+          "denom": "pstDYDX31Mar2025",
+          "exponent": 18
+        }
+      ],
+      "base": "p:stadydx:31Mar2025",
+      "name": "pstDydx (31Mar2025)",
+      "display": "pstDYDX31Mar2025",
+      "symbol": "pstDYDX-31Mar2025",
+      "logo_URIs": {
+        "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/pryzm/images/pstDydx.png",
+        "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/pryzm/images/pstDydx.svg"
+      },
+      "images": [
+        {
+          "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/pryzm/images/pstDydx.png",
+          "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/pryzm/images/pstDydx.svg"
+        }
+      ],
+      "type_asset": "sdk.coin"
+    },
+    {
       "description": "Pryzm's refracted principal token for stDYDX with maturity of 31Dec2025",
       "denom_units": [
         {
@@ -1671,6 +1839,34 @@
       "name": "pdAtom (31Dec2024)",
       "display": "pdATOM31Dec2024",
       "symbol": "pdATOM-31Dec2024",
+      "logo_URIs": {
+        "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/pryzm/images/pdAtom.png",
+        "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/pryzm/images/pdAtom.svg"
+      },
+      "images": [
+        {
+          "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/pryzm/images/pdAtom.png",
+          "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/pryzm/images/pdAtom.svg"
+        }
+      ],
+      "type_asset": "sdk.coin"
+    },
+    {
+      "description": "Pryzm's refracted principal token for dATOM with maturity of 31Mar2025",
+      "denom_units": [
+        {
+          "denom": "p:udatom:31Mar2025",
+          "exponent": 0
+        },
+        {
+          "denom": "pdATOM31Mar2025",
+          "exponent": 6
+        }
+      ],
+      "base": "p:udatom:31Mar2025",
+      "name": "pdAtom (31Mar2025)",
+      "display": "pdATOM31Mar2025",
+      "symbol": "pdATOM-31Mar2025",
       "logo_URIs": {
         "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/pryzm/images/pdAtom.png",
         "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/pryzm/images/pdAtom.svg"
@@ -1796,6 +1992,34 @@
       "type_asset": "sdk.coin"
     },
     {
+      "description": "Pryzm's refracted principal token for TIA with maturity of 31Mar2025",
+      "denom_units": [
+        {
+          "denom": "p:utia:31Mar2025",
+          "exponent": 0
+        },
+        {
+          "denom": "pTIA31Mar2025",
+          "exponent": 6
+        }
+      ],
+      "base": "p:utia:31Mar2025",
+      "name": "pTia (31Mar2025)",
+      "display": "pTIA31Mar2025",
+      "symbol": "pTIA-31Mar2025",
+      "logo_URIs": {
+        "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/pryzm/images/pTia.png",
+        "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/pryzm/images/pTia.svg"
+      },
+      "images": [
+        {
+          "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/pryzm/images/pTia.png",
+          "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/pryzm/images/pTia.svg"
+        }
+      ],
+      "type_asset": "sdk.coin"
+    },
+    {
       "description": "Pryzm's refracted principal token for TIA with maturity of 31Dec2025",
       "denom_units": [
         {
@@ -1895,6 +2119,34 @@
       "name": "yAtom (31Dec2024)",
       "display": "yATOM31Dec2024",
       "symbol": "yATOM-31Dec2024",
+      "logo_URIs": {
+        "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/pryzm/images/yAtom.png",
+        "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/pryzm/images/yAtom.svg"
+      },
+      "images": [
+        {
+          "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/pryzm/images/yAtom.png",
+          "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/pryzm/images/yAtom.svg"
+        }
+      ],
+      "type_asset": "sdk.coin"
+    },
+    {
+      "description": "Pryzm's refracted yield token for ATOM with maturity of 31Mar2025",
+      "denom_units": [
+        {
+          "denom": "y:uatom:31Mar2025",
+          "exponent": 0
+        },
+        {
+          "denom": "yATOM31Mar2025",
+          "exponent": 6
+        }
+      ],
+      "base": "y:uatom:31Mar2025",
+      "name": "yAtom (31Mar2025)",
+      "display": "yATOM31Mar2025",
+      "symbol": "yATOM-31Mar2025",
       "logo_URIs": {
         "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/pryzm/images/yAtom.png",
         "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/pryzm/images/yAtom.svg"
@@ -2020,6 +2272,34 @@
       "type_asset": "sdk.coin"
     },
     {
+      "description": "Pryzm's refracted yield token for OSMO with maturity of 31Mar2025",
+      "denom_units": [
+        {
+          "denom": "y:uosmo:31Mar2025",
+          "exponent": 0
+        },
+        {
+          "denom": "yOSMO31Mar2025",
+          "exponent": 6
+        }
+      ],
+      "base": "y:uosmo:31Mar2025",
+      "name": "yOsmo (31Mar2025)",
+      "display": "yOSMO31Mar2025",
+      "symbol": "yOSMO-31Mar2025",
+      "logo_URIs": {
+        "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/pryzm/images/yOsmo.png",
+        "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/pryzm/images/yOsmo.svg"
+      },
+      "images": [
+        {
+          "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/pryzm/images/yOsmo.png",
+          "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/pryzm/images/yOsmo.svg"
+        }
+      ],
+      "type_asset": "sdk.coin"
+    },
+    {
       "description": "Pryzm's refracted yield token for OSMO with maturity of 31Dec2025",
       "denom_units": [
         {
@@ -2132,6 +2412,34 @@
       "type_asset": "sdk.coin"
     },
     {
+      "description": "Pryzm's refracted yield token for INJ with maturity of 31Mar2025",
+      "denom_units": [
+        {
+          "denom": "y:inj:31Mar2025",
+          "exponent": 0
+        },
+        {
+          "denom": "yINJ31Mar2025",
+          "exponent": 18
+        }
+      ],
+      "base": "y:inj:31Mar2025",
+      "name": "yInj (31Mar2025)",
+      "display": "yINJ31Mar2025",
+      "symbol": "yINJ-31Mar2025",
+      "logo_URIs": {
+        "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/pryzm/images/yInj.png",
+        "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/pryzm/images/yInj.svg"
+      },
+      "images": [
+        {
+          "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/pryzm/images/yInj.png",
+          "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/pryzm/images/yInj.svg"
+        }
+      ],
+      "type_asset": "sdk.coin"
+    },
+    {
       "description": "Pryzm's refracted yield token for INJ with maturity of 31Dec2025",
       "denom_units": [
         {
@@ -2231,6 +2539,34 @@
       "name": "yLuna (31Dec2024)",
       "display": "yLUNA31Dec2024",
       "symbol": "yLUNA-31Dec2024",
+      "logo_URIs": {
+        "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/pryzm/images/yLuna.png",
+        "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/pryzm/images/yLuna.svg"
+      },
+      "images": [
+        {
+          "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/pryzm/images/yLuna.png",
+          "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/pryzm/images/yLuna.svg"
+        }
+      ],
+      "type_asset": "sdk.coin"
+    },
+    {
+      "description": "Pryzm's refracted yield token for LUNA with maturity of 31Mar2025",
+      "denom_units": [
+        {
+          "denom": "y:uluna:31Mar2025",
+          "exponent": 0
+        },
+        {
+          "denom": "yLUNA31Mar2025",
+          "exponent": 6
+        }
+      ],
+      "base": "y:uluna:31Mar2025",
+      "name": "yLuna (31Mar2025)",
+      "display": "yLUNA31Mar2025",
+      "symbol": "yLUNA-31Mar2025",
       "logo_URIs": {
         "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/pryzm/images/yLuna.png",
         "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/pryzm/images/yLuna.svg"
@@ -2468,6 +2804,34 @@
       "type_asset": "sdk.coin"
     },
     {
+      "description": "Pryzm's refracted yield token for stTIA with maturity of 31Mar2025",
+      "denom_units": [
+        {
+          "denom": "y:stutia:31Mar2025",
+          "exponent": 0
+        },
+        {
+          "denom": "ystTIA31Mar2025",
+          "exponent": 6
+        }
+      ],
+      "base": "y:stutia:31Mar2025",
+      "name": "ystTia (31Mar2025)",
+      "display": "ystTIA31Mar2025",
+      "symbol": "ystTIA-31Mar2025",
+      "logo_URIs": {
+        "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/pryzm/images/ystTia.png",
+        "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/pryzm/images/ystTia.svg"
+      },
+      "images": [
+        {
+          "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/pryzm/images/ystTia.png",
+          "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/pryzm/images/ystTia.svg"
+        }
+      ],
+      "type_asset": "sdk.coin"
+    },
+    {
       "description": "Pryzm's refracted yield token for stTIA with maturity of 31Dec2025",
       "denom_units": [
         {
@@ -2580,6 +2944,34 @@
       "type_asset": "sdk.coin"
     },
     {
+      "description": "Pryzm's refracted yield token for stDYDX with maturity of 31Mar2025",
+      "denom_units": [
+        {
+          "denom": "y:stadydx:31Mar2025",
+          "exponent": 0
+        },
+        {
+          "denom": "ystDYDX31Mar2025",
+          "exponent": 6
+        }
+      ],
+      "base": "y:stadydx:31Mar2025",
+      "name": "ystDydx (31Mar2025)",
+      "display": "ystDYDX31Mar2025",
+      "symbol": "ystDYDX-31Mar2025",
+      "logo_URIs": {
+        "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/pryzm/images/ystDydx.png",
+        "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/pryzm/images/ystDydx.svg"
+      },
+      "images": [
+        {
+          "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/pryzm/images/ystDydx.png",
+          "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/pryzm/images/ystDydx.svg"
+        }
+      ],
+      "type_asset": "sdk.coin"
+    },
+    {
       "description": "Pryzm's refracted yield token for stDYDX with maturity of 31Dec2025",
       "denom_units": [
         {
@@ -2651,6 +3043,34 @@
       "name": "ydAtom (31Dec2024)",
       "display": "ydATOM31Dec2024",
       "symbol": "ydATOM-31Dec2024",
+      "logo_URIs": {
+        "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/pryzm/images/ydAtom.png",
+        "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/pryzm/images/ydAtom.svg"
+      },
+      "images": [
+        {
+          "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/pryzm/images/ydAtom.png",
+          "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/pryzm/images/ydAtom.svg"
+        }
+      ],
+      "type_asset": "sdk.coin"
+    },
+    {
+      "description": "Pryzm's refracted yield token for dATOM with maturity of 31Mar2025",
+      "denom_units": [
+        {
+          "denom": "y:udatom:31Mar2025",
+          "exponent": 0
+        },
+        {
+          "denom": "ydATOM31Mar2025",
+          "exponent": 6
+        }
+      ],
+      "base": "y:udatom:31Mar2025",
+      "name": "ydAtom (31Mar2025)",
+      "display": "ydATOM31Mar2025",
+      "symbol": "ydATOM-31Mar2025",
       "logo_URIs": {
         "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/pryzm/images/ydAtom.png",
         "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/pryzm/images/ydAtom.svg"
@@ -2763,6 +3183,34 @@
       "name": "yTia (31Dec2024)",
       "display": "yTIA31Dec2024",
       "symbol": "yTIA-31Dec2024",
+      "logo_URIs": {
+        "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/pryzm/images/yTia.png",
+        "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/pryzm/images/yTia.svg"
+      },
+      "images": [
+        {
+          "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/pryzm/images/yTia.png",
+          "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/pryzm/images/yTia.svg"
+        }
+      ],
+      "type_asset": "sdk.coin"
+    },
+    {
+      "description": "Pryzm's refracted yield token for TIA with maturity of 31Mar2025",
+      "denom_units": [
+        {
+          "denom": "y:utia:31Mar2025",
+          "exponent": 0
+        },
+        {
+          "denom": "yTIA31Mar2025",
+          "exponent": 6
+        }
+      ],
+      "base": "y:utia:31Mar2025",
+      "name": "yTia (31Mar2025)",
+      "display": "yTIA31Mar2025",
+      "symbol": "yTIA-31Mar2025",
       "logo_URIs": {
         "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/pryzm/images/yTia.png",
         "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/pryzm/images/yTia.svg"


### PR DESCRIPTION
This PR adds the new minted tokens with the maturity of 31Mar2025 to the list of Pryzm assets.