### PR TITLE
Add ibc assets for manifesttestnet and osmosistestnet

### DIFF
--- a/testnets/manifesttestnet/assetlist.json
+++ b/testnets/manifesttestnet/assetlist.json
@@ -92,14 +92,11 @@
       "images": [
         {
           "image_sync": {
-            "chain_name": "osmosis",
-            "base_denom": "osmo"
+            "chain_name": "osmosistestnet",
+            "base_denom": "uosmo"
           },
           "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/osmosis/images/osmo.svg",
-          "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/osmosis/images/osmo.png",
-          "theme": {
-            "primary_color_hex": "#760dbb"
-          }
+          "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/osmosis/images/osmo.png"
         }
       ],
       "logo_URIs": {

--- a/testnets/manifesttestnet/assetlist.json
+++ b/testnets/manifesttestnet/assetlist.json
@@ -57,6 +57,55 @@
         }
       ],
       "type_asset": "sdk.coin"
+    },
+    {
+      "description": "Osmosis token on Manifest Ledger Testnet",
+      "denom_units": [
+        {
+          "denom": "ibc/ED07A3391A112B175915CD8FAF43A2DA8E4790EDE12566649D0C2F97716B8518",
+          "exponent": 0
+        },
+        {
+          "denom": "osmo",
+          "exponent": 6
+        }
+      ],
+      "type_asset": "ics20",
+      "base": "ibc/ED07A3391A112B175915CD8FAF43A2DA8E4790EDE12566649D0C2F97716B8518",
+      "name": "Osmosis",
+      "display": "osmo",
+      "symbol": "OSMO",
+      "traces": [
+        {
+          "type": "ibc",
+          "counterparty": {
+            "chain_name": "osmosistestnet",
+            "base_denom": "osmo",
+            "channel_id": "channel-10016"
+          },
+          "chain": {
+            "channel_id": "channel-0",
+            "path": "transfer/channel-0/osmo"
+          }
+        }
+      ],
+      "images": [
+        {
+          "image_sync": {
+            "chain_name": "osmosis",
+            "base_denom": "osmo"
+          },
+          "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/osmosis/images/osmo.svg",
+          "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/osmosis/images/osmo.png",
+          "theme": {
+            "primary_color_hex": "#760dbb"
+          }
+        }
+      ],
+      "logo_URIs": {
+        "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/osmosis/images/osmo.png",
+        "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/osmosis/images/osmo.svg"
+      }
     }
   ]
 }

--- a/testnets/manifesttestnet/assetlist.json
+++ b/testnets/manifesttestnet/assetlist.json
@@ -80,12 +80,12 @@
           "type": "ibc",
           "counterparty": {
             "chain_name": "osmosistestnet",
-            "base_denom": "osmo",
+            "base_denom": "uosmo",
             "channel_id": "channel-10016"
           },
           "chain": {
             "channel_id": "channel-0",
-            "path": "transfer/channel-0/osmo"
+            "path": "transfer/channel-0/uosmo"
           }
         }
       ],

--- a/testnets/osmosistestnet/assetlist.json
+++ b/testnets/osmosistestnet/assetlist.json
@@ -32,10 +32,7 @@
         }
       ],
       "coingecko_id": "osmosis",
-      "keywords": [
-        "dex",
-        "staking"
-      ]
+      "keywords": ["dex", "staking"]
     },
     {
       "denom_units": [
@@ -64,9 +61,7 @@
         }
       ],
       "coingecko_id": "ion",
-      "keywords": [
-        "memecoin"
-      ]
+      "keywords": ["memecoin"]
     },
     {
       "description": "The native staking and governance token of the Theta testnet version of the Cosmos Hub.",
@@ -74,9 +69,7 @@
         {
           "denom": "ibc/9FF2B7A5F55038A7EE61F4FD6749D9A648B48E89830F2682B67B5DC158E2753C",
           "exponent": 0,
-          "aliases": [
-            "uatom"
-          ]
+          "aliases": ["uatom"]
         },
         {
           "denom": "atom",
@@ -183,9 +176,7 @@
         {
           "denom": "ibc/1F42AC9631DBE03009219ECCFE151786F53A038DE9F7A07C709158514F1D5942",
           "exponent": 0,
-          "aliases": [
-            "eth-wei"
-          ]
+          "aliases": ["eth-wei"]
         },
         {
           "denom": "weth",
@@ -246,9 +237,7 @@
         {
           "denom": "ibc/31D220286E6C224C0F72D890D0EB75A228D388089EF5C4D77212344F9EAF0183",
           "exponent": 0,
-          "aliases": [
-            "ujunox"
-          ]
+          "aliases": ["ujunox"]
         },
         {
           "denom": "junox",
@@ -295,9 +284,7 @@
         {
           "denom": "ibc/66A7ADA623D33D0B66C6890FE3E1AF3D638D56CE2B56F8BDA210B2AA62016216",
           "exponent": 0,
-          "aliases": [
-            "umars"
-          ]
+          "aliases": ["umars"]
         },
         {
           "denom": "mars",
@@ -344,10 +331,7 @@
         {
           "denom": "ibc/DE6792CF9E521F6AD6E9A4BDF6225C9571A3B74ACC0A529F92BC5122A39D2E58",
           "exponent": 0,
-          "aliases": [
-            "microusdc",
-            "uusdc"
-          ]
+          "aliases": ["microusdc", "uusdc"]
         },
         {
           "denom": "usdc",
@@ -422,9 +406,7 @@
         {
           "denom": "ibc/AD59D59CFB0E628E73C798415F823AB5B6257C2FE4BF67DBB5D6A677B2686E82",
           "exponent": 0,
-          "aliases": [
-            "uakt"
-          ]
+          "aliases": ["uakt"]
         },
         {
           "denom": "akt",
@@ -471,9 +453,7 @@
         {
           "denom": "ibc/AB8AF05799E299FB5C5C80781DA35887F53E029745D20E5641233DB4E6B28515",
           "exponent": 0,
-          "aliases": [
-            "tkyve"
-          ]
+          "aliases": ["tkyve"]
         },
         {
           "denom": "kyve",
@@ -531,9 +511,7 @@
         {
           "denom": "ibc/F37CF69589DE12342758382F8770C0852CD8D2E4519F55166EBDAF472AD667C9",
           "exponent": 0,
-          "aliases": [
-            "uqck"
-          ]
+          "aliases": ["uqck"]
         },
         {
           "denom": "qck",
@@ -579,9 +557,7 @@
         {
           "denom": "ibc/E3D323CB6F427C49E56F913C853A416F6B71BAA9B0164625AD0203266F92B3ED",
           "exponent": 0,
-          "aliases": [
-            "uc4e"
-          ]
+          "aliases": ["uc4e"]
         },
         {
           "denom": "c4e",
@@ -626,9 +602,7 @@
         {
           "denom": "ibc/754C8533F8A418B03AD5F2C6AA19D4703CF78BBAB9E2E4DDD6212AAC2E502CA6",
           "exponent": 0,
-          "aliases": [
-            "uxprt"
-          ]
+          "aliases": ["uxprt"]
         },
         {
           "denom": "xprt",
@@ -675,17 +649,12 @@
         {
           "denom": "ibc/3642669AD14386D3E38F43F30CFCA859B3E8A05BF6BD6A23DEBD2115AD1325E9",
           "exponent": 0,
-          "aliases": [
-            "microxion",
-            "uxion"
-          ]
+          "aliases": ["microxion", "uxion"]
         },
         {
           "denom": "XION",
           "exponent": 6,
-          "aliases": [
-            "xion"
-          ]
+          "aliases": ["xion"]
         }
       ],
       "type_asset": "ics20",
@@ -726,9 +695,7 @@
         {
           "denom": "ibc/48384130079A5987378F5776775F8C29A02505273E777BBB99361F2BB5B577C9",
           "exponent": 0,
-          "aliases": [
-            "utsaga"
-          ]
+          "aliases": ["utsaga"]
         },
         {
           "denom": "tsaga",
@@ -776,9 +743,7 @@
         {
           "denom": "ibc/88C815D69587CF0F05E96E5E2731EA56194D73C9A02A500095294D3A5DE68F16",
           "exponent": 0,
-          "aliases": [
-            "uixo"
-          ]
+          "aliases": ["uixo"]
         },
         {
           "denom": "ixo",
@@ -849,9 +814,7 @@
         "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/testnets/osmosistestnet/images/willyz.png",
         "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/testnets/osmosistestnet/images/willyz.svg"
       },
-      "keywords": [
-        "memecoin"
-      ],
+      "keywords": ["memecoin"],
       "images": [
         {
           "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/testnets/osmosistestnet/images/willyz.png",
@@ -912,23 +875,17 @@
         {
           "denom": "ibc/28EEF762052DB8C3D27A7BF625E9F86A1B3B689CC8D80C818CEDF2EB6CBA02A6",
           "exponent": 0,
-          "aliases": [
-            "atkx"
-          ]
+          "aliases": ["atkx"]
         },
         {
           "denom": "utkx",
           "exponent": 12,
-          "aliases": [
-            "microtkx"
-          ]
+          "aliases": ["microtkx"]
         },
         {
           "denom": "mtkx",
           "exponent": 15,
-          "aliases": [
-            "millitkx"
-          ]
+          "aliases": ["millitkx"]
         },
         {
           "denom": "tkx",
@@ -960,6 +917,53 @@
       "images": [
         {
           "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/testnets/titantestnet/images/tkx.png"
+        }
+      ]
+    },
+    {
+      "description": "Manifest Testnet Token",
+      "denom_units": [
+        {
+          "denom": "ibc/8402769A51AEE1CDF35223998D284E937EBF03F4A2CE43EC10BB028BB5AD29C8",
+          "exponent": 0,
+          "aliases": ["umfx"]
+        },
+        {
+          "denom": "mfx",
+          "exponent": 6
+        }
+      ],
+      "type_asset": "ics20",
+      "base": "ibc/8402769A51AEE1CDF35223998D284E937EBF03F4A2CE43EC10BB028BB5AD29C8",
+      "name": "Manifest Testnet",
+      "display": "mfx",
+      "symbol": "MFX",
+      "traces": [
+        {
+          "type": "ibc",
+          "counterparty": {
+            "chain_name": "manifesttestnet",
+            "base_denom": "umfx",
+            "channel_id": "channel-0"
+          },
+          "chain": {
+            "channel_id": "channel-10016",
+            "path": "transfer/channel-10016/umfx"
+          }
+        }
+      ],
+      "logo_URIs": {
+        "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/testnets/manifesttestnet/images/mfx.png",
+        "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/testnets/manifesttestnet/images/mfx.svg"
+      },
+      "images": [
+        {
+          "image_sync": {
+            "chain_name": "manifesttestnet",
+            "base_denom": "umfx"
+          },
+          "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/testnets/manifesttestnet/images/mfx.png",
+          "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/testnets/manifesttestnet/images/mfx.svg"
         }
       ]
     }


### PR DESCRIPTION
This pr adds the ibc representation of mfx from the manifesttestnet to the osmosistestnet and vice versa
