### PR TITLE
Update ATONE asset on Osmosis with new IBC channels & denom

### DIFF
--- a/osmosis/assetlist.json
+++ b/osmosis/assetlist.json
@@ -25380,7 +25380,7 @@
       "description": "The native staking and governance token of AtomOne",
       "denom_units": [
         {
-          "denom": "ibc/715283E4A955EB803AB1DD30B488587A4D63BF0B51BADA537053DEE479BA10D6",
+          "denom": "ibc/BC26A7A805ECD6822719472BCB7842A48EF09DF206182F8F259B2593EB5D23FB",
           "exponent": 0,
           "aliases": [
             "uatone"
@@ -25392,7 +25392,7 @@
         }
       ],
       "type_asset": "ics20",
-      "base": "ibc/715283E4A955EB803AB1DD30B488587A4D63BF0B51BADA537053DEE479BA10D6",
+      "base": "ibc/BC26A7A805ECD6822719472BCB7842A48EF09DF206182F8F259B2593EB5D23FB",
       "name": "AtomOne",
       "display": "atone",
       "symbol": "ATONE",
@@ -25402,11 +25402,11 @@
           "counterparty": {
             "chain_name": "atomone",
             "base_denom": "uatone",
-            "channel_id": "channel-0"
+            "channel_id": "channel-2"
           },
           "chain": {
-            "channel_id": "channel-85309",
-            "path": "transfer/channel-85309/uatone"
+            "channel_id": "channel-94814",
+            "path": "transfer/channel-94814/uatone"
           }
         }
       ],


### PR DESCRIPTION
A new IBC connection has been setup for AtomOne <-> Osmosis, and PR #5812 has already been merged to reflect the new IBC connection.

Now updating assets on Osmosis, see below the confirmation of the IBC asset denom: 
```bash
$ echo -n transfer/channel-94814/uatone | sha256sum
bc26a7a805ecd6822719472bcb7842a48ef09df206182f8f259b2593eb5d23fb  -
```