### PR TITLE
Upgrade Cosmos ICS Testnet to Gaia v22.0.0-rc0

### DIFF
--- a/testnets/cosmosicsprovidertestnet/chain.json
+++ b/testnets/cosmosicsprovidertestnet/chain.json
@@ -33,30 +33,30 @@
   },
   "codebase": {
     "git_repo": "https://github.com/cosmos/gaia",
-    "recommended_version": "v21.0.1",
+    "recommended_version": "v22.0.0-rc0",
     "compatible_versions": [
-      "v21.0.1"
+      "v22.0.0-rc0"
     ],
     "consensus": {
       "type": "cometbft",
-      "version": "v0.38.11"
+      "version": "v0.38.15"
     },
     "binaries": {
-      "linux/amd64": "https://github.com/cosmos/gaia/releases/download/v21.0.1/gaiad-v21.0.1-linux-amd64",
-      "darwin/amd64": "https://github.com/cosmos/gaia/releases/download/v21.0.1/gaiad-v21.0.1-darwin-amd64",
-      "darwin/arm64": "https://github.com/cosmos/gaia/releases/download/v21.0.1/gaiad-v21.0.1-darwin-arm64"
+      "linux/amd64": "https://github.com/cosmos/gaia/releases/download/v22.0.0-rc0/gaiad-v22.0.0-rc0-linux-amd64",
+      "darwin/amd64": "https://github.com/cosmos/gaia/releases/download/v22.0.0-rc0/gaiad-v22.0.0-rc0-darwin-amd64",
+      "darwin/arm64": "https://github.com/cosmos/gaia/releases/download/v22.0.0-rc0/gaiad-v22.0.0-rc0-darwin-arm64"
     },
     "genesis": {
       "genesis_url": "https://raw.githubusercontent.com/cosmos/testnets/master/interchain-security/provider/provider-genesis.json"
     },
     "sdk": {
       "type": "cosmos",
-      "version": "v0.50.9",
-      "tag": "v0.50.9-lsm"
+      "version": "v0.50.11",
+      "tag": "v0.50.11-lsm"
     },
     "ibc": {
       "type": "go",
-      "version": "v8.5.1"
+      "version": "v8.5.2"
     }
   },
   "peers": {

--- a/testnets/cosmosicsprovidertestnet/versions.json
+++ b/testnets/cosmosicsprovidertestnet/versions.json
@@ -181,6 +181,33 @@
         "type": "go",
         "version": "v8.5.1"
       }
+    },
+    {
+      "name": "v22",
+      "tag": "v22.0.0-rc0",
+      "recommended_version": "v22.0.0-rc0",
+      "compatible_versions": [
+        "v22.0.0-rc0"
+      ],
+      "consensus": {
+        "type": "cometbft",
+        "version": "v0.38.15"
+      },
+      "binaries": {
+        "linux/amd64": "https://github.com/cosmos/gaia/releases/download/v22.0.0-rc0/gaiad-v22.0.0-rc0-linux-amd64",
+        "darwin/amd64": "https://github.com/cosmos/gaia/releases/download/v22.0.0-rc0/gaiad-v22.0.0-rc0-darwin-amd64",
+        "darwin/arm64": "https://github.com/cosmos/gaia/releases/download/v22.0.0-rc0/gaiad-v22.0.0-rc0-darwin-arm64"
+      },
+      "next_version_name": "v23",
+      "sdk": {
+        "type": "cosmos",
+        "version": "v0.50.11",
+        "tag": "v0.50.11-lsm"
+      },
+      "ibc": {
+        "type": "go",
+        "version": "v8.5.2"
+      }
     }
   ]
 }


### PR DESCRIPTION
* Upgraded chain from Gaia `v21.0.1` to Gaia `v22.0.0-rc0`