### PR TITLE
Move dTIA to bottom of Osmosis' Assetlist

### DIFF
--- a/osmosis/assetlist.json
+++ b/osmosis/assetlist.json
@@ -25760,61 +25760,6 @@
       ]
     },
     {
-      "description": "Drop staked TIA",
-      "denom_units": [
-        {
-          "denom": "ibc/C7A810C6ED1FC3FFC7C834A534D400EADC94FF7D3BE13DDD4C042AEF1816DFB4",
-          "exponent": 0,
-          "aliases": [
-            "factory/neutron1ut4c6pv4u6vyu97yw48y8g7mle0cat54848v6m97k977022lzxtsaqsgmq/udtia"
-          ]
-        },
-        {
-          "denom": "dTIA",
-          "exponent": 6
-        }
-      ],
-      "type_asset": "ics20",
-      "base": "ibc/C7A810C6ED1FC3FFC7C834A534D400EADC94FF7D3BE13DDD4C042AEF1816DFB4",
-      "name": "dTIA",
-      "display": "dTIA",
-      "symbol": "dTIA",
-      "traces": [
-        {
-          "type": "liquid-stake",
-          "counterparty": {
-            "chain_name": "celestia",
-            "base_denom": "utia"
-          },
-          "provider": "Drop Protocol"
-        },
-        {
-          "type": "ibc",
-          "counterparty": {
-            "chain_name": "neutron",
-            "base_denom": "factory/neutron1ut4c6pv4u6vyu97yw48y8g7mle0cat54848v6m97k977022lzxtsaqsgmq/udtia",
-            "channel_id": "channel-10"
-          },
-          "chain": {
-            "channel_id": "channel-874",
-            "path": "transfer/channel-874/factory/neutron1ut4c6pv4u6vyu97yw48y8g7mle0cat54848v6m97k977022lzxtsaqsgmq/udtia"
-          }
-        }
-      ],
-      "logo_URIs": {
-        "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/neutron/images/dTIA.svg"
-      },
-      "images": [
-        {
-          "image_sync": {
-            "chain_name": "neutron",
-            "base_denom": "factory/neutron1ut4c6pv4u6vyu97yw48y8g7mle0cat54848v6m97k977022lzxtsaqsgmq/udtia"
-          },
-          "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/neutron/images/dTIA.svg"
-        }
-      ]
-    },
-    {
       "description": "Kima is an asset-agnostic interoperability infrastructure that connects blockchain networks and legacy financial systems, enabling secure, scalable cross-chain transactions and seamless communication across ecosystems.",
       "denom_units": [
         {
@@ -26703,6 +26648,61 @@
       "images": [
         {
           "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/osmosis/images/cult.png"
+        }
+      ]
+    },
+    {
+      "description": "Drop staked TIA",
+      "denom_units": [
+        {
+          "denom": "ibc/C7A810C6ED1FC3FFC7C834A534D400EADC94FF7D3BE13DDD4C042AEF1816DFB4",
+          "exponent": 0,
+          "aliases": [
+            "factory/neutron1ut4c6pv4u6vyu97yw48y8g7mle0cat54848v6m97k977022lzxtsaqsgmq/udtia"
+          ]
+        },
+        {
+          "denom": "dTIA",
+          "exponent": 6
+        }
+      ],
+      "type_asset": "ics20",
+      "base": "ibc/C7A810C6ED1FC3FFC7C834A534D400EADC94FF7D3BE13DDD4C042AEF1816DFB4",
+      "name": "dTIA",
+      "display": "dTIA",
+      "symbol": "dTIA",
+      "traces": [
+        {
+          "type": "liquid-stake",
+          "counterparty": {
+            "chain_name": "celestia",
+            "base_denom": "utia"
+          },
+          "provider": "Drop Protocol"
+        },
+        {
+          "type": "ibc",
+          "counterparty": {
+            "chain_name": "neutron",
+            "base_denom": "factory/neutron1ut4c6pv4u6vyu97yw48y8g7mle0cat54848v6m97k977022lzxtsaqsgmq/udtia",
+            "channel_id": "channel-10"
+          },
+          "chain": {
+            "channel_id": "channel-874",
+            "path": "transfer/channel-874/factory/neutron1ut4c6pv4u6vyu97yw48y8g7mle0cat54848v6m97k977022lzxtsaqsgmq/udtia"
+          }
+        }
+      ],
+      "logo_URIs": {
+        "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/neutron/images/dTIA.svg"
+      },
+      "images": [
+        {
+          "image_sync": {
+            "chain_name": "neutron",
+            "base_denom": "factory/neutron1ut4c6pv4u6vyu97yw48y8g7mle0cat54848v6m97k977022lzxtsaqsgmq/udtia"
+          },
+          "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/neutron/images/dTIA.svg"
         }
       ]
     }


### PR DESCRIPTION
Move dTIA to bottom of Osmosis' Assetlist because it was mistakenly added earlier.