### PR TITLE
Typo fix Update read.me file

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ The endpoints added here are being tested via CI daily at 00:00 UTC. It is expec
 - rest: `/status`
 - rpc: `/cosmos/base/tendermint/v1beta1/syncing`
 - grpc: not tested
-Endpoints that consistently fail to repond successfully may be removed without warning.
+Endpoints that consistently fail to respond successfully may be removed without warning.
 
 Providers ready to be tested daily should be whitelisted here: `.github/workflows/tests/apis.py`
 


### PR DESCRIPTION
## Pull Request Title
fix: typo correction in README.md ("repond" to "respond")

### Description
This pull request fixes a typo in the `README.md` file where "repond" was used instead of "respond."

### Changes Made
- Corrected the typo "repond" to "respond" in the documentation.

### Related Issues
- N/A

### Additional Notes
- This fix improves the clarity and correctness of the documentation.
