### PR TITLE
update manifest average_gas_price

### DIFF
--- a/testnets/manifestdevnet/chain.json
+++ b/testnets/manifestdevnet/chain.json
@@ -17,7 +17,7 @@
         "denom": "umfx",
         "fixed_min_gas_price": 0.001,
         "low_gas_price": 0.01,
-        "average_gas_price": 0.007,
+        "average_gas_price": 0.02,
         "high_gas_price": 0.1
       }
     ]

--- a/testnets/manifesttestnet/chain.json
+++ b/testnets/manifesttestnet/chain.json
@@ -17,7 +17,7 @@
         "denom": "umfx",
         "fixed_min_gas_price": 0.001,
         "low_gas_price": 0.01,
-        "average_gas_price": 0.007,
+        "average_gas_price": 0.02,
         "high_gas_price": 0.1
       }
     ]


### PR DESCRIPTION
The average gas price was lower than the low gas price in both manfiesttestnet and manifestdevnet

