### PR TITLE
Update AtomOne version to v1.0.1

### DIFF
--- a/atomone/chain.json
+++ b/atomone/chain.json
@@ -34,24 +34,25 @@
   },
   "codebase": {
     "git_repo": "https://github.com/atomone-hub/atomone",
-    "recommended_version": "v1.0.0",
+    "recommended_version": "v1.0.1",
     "compatible_versions": [
-      "v1.0.0"
+      "v1.0.0",
+      "v1.0.1"
     ],
     "binaries": {
-      "linux/amd64": "https://github.com/atomone-hub/atomone/releases/download/v1.0.0/atomoned-v1.0.0-linux-amd64",
-      "linux/arm64": "https://github.com/atomone-hub/atomone/releases/download/v1.0.0/atomoned-v1.0.0-linux-arm64",
-      "darwin/amd64": "https://github.com/atomone-hub/atomone/releases/download/v1.0.0/atomoned-v1.0.0-darwin-amd64",
-      "darwin/arm64": "https://github.com/atomone-hub/atomone/releases/download/v1.0.0/atomoned-v1.0.0-darwin-arm64",
-      "windows/amd64": "https://github.com/atomone-hub/atomone/releases/download/v1.0.0/atomoned-v1.0.0-windows-amd64.exe",
-      "windows/arm64": "https://github.com/atomone-hub/atomone/releases/download/v1.0.0/atomoned-v1.0.0-windows-arm64.exe"
+      "linux/amd64": "https://github.com/atomone-hub/atomone/releases/download/v1.0.1/atomoned-v1.0.1-linux-amd64",
+      "linux/arm64": "https://github.com/atomone-hub/atomone/releases/download/v1.0.1/atomoned-v1.0.1-linux-arm64",
+      "darwin/amd64": "https://github.com/atomone-hub/atomone/releases/download/v1.0.1/atomoned-v1.0.1-darwin-amd64",
+      "darwin/arm64": "https://github.com/atomone-hub/atomone/releases/download/v1.0.1/atomoned-v1.0.1-darwin-arm64",
+      "windows/amd64": "https://github.com/atomone-hub/atomone/releases/download/v1.0.1/atomoned-v1.0.1-windows-amd64.exe",
+      "windows/arm64": "https://github.com/atomone-hub/atomone/releases/download/v1.0.1/atomoned-v1.0.1-windows-arm64.exe"
     },
     "genesis": {
       "genesis_url": "https://atomone.fra1.digitaloceanspaces.com/atomone-1/genesis.json"
     },
     "consensus": {
       "type": "cometbft",
-      "version": "v0.37.5"
+      "version": "v0.37.15"
     },
     "sdk": {
       "type": "cosmos",

--- a/atomone/versions.json
+++ b/atomone/versions.json
@@ -3,24 +3,25 @@
   "chain_name": "atomone",
   "versions": [
     {
-      "name": "v1.0.0",
-      "tag": "v1.0.0",
-      "recommended_version": "v1.0.0",
+      "name": "v1.0.1",
+      "tag": "v1.0.1",
+      "recommended_version": "v1.0.1",
       "compatible_versions": [
-        "v1.0.0"
+        "v1.0.0",
+        "v1.0.1"
       ],
       "consensus": {
         "type": "cometbft",
-        "version": "v0.37.5"
+        "version": "v0.37.15"
       },
       "height": 1,
       "binaries": {
-        "linux/amd64": "https://github.com/atomone-hub/atomone/releases/download/v1.0.0/atomoned-v1.0.0-linux-amd64",
-        "linux/arm64": "https://github.com/atomone-hub/atomone/releases/download/v1.0.0/atomoned-v1.0.0-linux-arm64",
-        "darwin/amd64": "https://github.com/atomone-hub/atomone/releases/download/v1.0.0/atomoned-v1.0.0-darwin-amd64",
-        "darwin/arm64": "https://github.com/atomone-hub/atomone/releases/download/v1.0.0/atomoned-v1.0.0-darwin-arm64",
-        "windows/amd64": "https://github.com/atomone-hub/atomone/releases/download/v1.0.0/atomoned-v1.0.0-windows-amd64.exe",
-        "windows/arm64": "https://github.com/atomone-hub/atomone/releases/download/v1.0.0/atomoned-v1.0.0-windows-arm64.exe"
+        "linux/amd64": "https://github.com/atomone-hub/atomone/releases/download/v1.0.1/atomoned-v1.0.1-linux-amd64",
+        "linux/arm64": "https://github.com/atomone-hub/atomone/releases/download/v1.0.1/atomoned-v1.0.1-linux-arm64",
+        "darwin/amd64": "https://github.com/atomone-hub/atomone/releases/download/v1.0.1/atomoned-v1.0.1-darwin-amd64",
+        "darwin/arm64": "https://github.com/atomone-hub/atomone/releases/download/v1.0.1/atomoned-v1.0.1-darwin-arm64",
+        "windows/amd64": "https://github.com/atomone-hub/atomone/releases/download/v1.0.1/atomoned-v1.0.1-windows-amd64.exe",
+        "windows/arm64": "https://github.com/atomone-hub/atomone/releases/download/v1.0.1/atomoned-v1.0.1-windows-arm64.exe"
       },
       "sdk": {
         "type": "cosmos",

--- a/testnets/atomonetestnet/chain.json
+++ b/testnets/atomonetestnet/chain.json
@@ -32,22 +32,22 @@
   },
   "codebase": {
     "git_repo": "https://github.com/atomone-hub/atomone",
-    "recommended_version": "v1.0.0",
-    "compatible_versions": ["v1.0.0"],
+    "recommended_version": "v1.0.1",
+    "compatible_versions": ["v1.0.0","v1.0.1"],
     "binaries": {
-      "linux/amd64": "https://github.com/atomone-hub/atomone/releases/download/v1.0.0/atomoned-v1.0.0-linux-amd64",
-      "linux/arm64": "https://github.com/atomone-hub/atomone/releases/download/v1.0.0/atomoned-v1.0.0-linux-arm64",
-      "darwin/amd64": "https://github.com/atomone-hub/atomone/releases/download/v1.0.0/atomoned-v1.0.0-darwin-amd64",
-      "darwin/arm64": "https://github.com/atomone-hub/atomone/releases/download/v1.0.0/atomoned-v1.0.0-darwin-arm64",
-      "windows/amd64": "https://github.com/atomone-hub/atomone/releases/download/v1.0.0/atomoned-v1.0.0-windows-amd64.exe",
-      "windows/arm64": "https://github.com/atomone-hub/atomone/releases/download/v1.0.0/atomoned-v1.0.0-windows-arm64.exe"
+      "linux/amd64": "https://github.com/atomone-hub/atomone/releases/download/v1.0.1/atomoned-v1.0.1-linux-amd64",
+      "linux/arm64": "https://github.com/atomone-hub/atomone/releases/download/v1.0.1/atomoned-v1.0.1-linux-arm64",
+      "darwin/amd64": "https://github.com/atomone-hub/atomone/releases/download/v1.0.1/atomoned-v1.0.1-darwin-amd64",
+      "darwin/arm64": "https://github.com/atomone-hub/atomone/releases/download/v1.0.1/atomoned-v1.0.1-darwin-arm64",
+      "windows/amd64": "https://github.com/atomone-hub/atomone/releases/download/v1.0.1/atomoned-v1.0.1-windows-amd64.exe",
+      "windows/arm64": "https://github.com/atomone-hub/atomone/releases/download/v1.0.1/atomoned-v1.0.1-windows-arm64.exe"
     },
     "genesis": {
       "genesis_url": "https://atomone.fra1.digitaloceanspaces.com/atomone-testnet-1/genesis.json"
     },
     "consensus": {
       "type": "cometbft",
-      "version": "v0.37.5"
+      "version": "v0.37.15"
     },
     "sdk": {
       "type": "cosmos",

--- a/testnets/atomonetestnet/versions.json
+++ b/testnets/atomonetestnet/versions.json
@@ -3,22 +3,25 @@
   "chain_name": "atomonetestnet",
   "versions": [
     {
-      "name": "v1.0.0",
-      "tag": "v1.0.0",
-      "recommended_version": "v1.0.0",
-      "compatible_versions": ["v1.0.0"],
+      "name": "v1.0.1",
+      "tag": "v1.0.1",
+      "recommended_version": "v1.0.1",
+      "compatible_versions": [
+        "v1.0.0",
+        "v1.0.1"
+      ],
       "consensus": {
         "type": "cometbft",
-        "version": "v0.37.5"
+        "version": "v0.37.15"
       },
       "height": 1,
       "binaries": {
-        "linux/amd64": "https://github.com/atomone-hub/atomone/releases/download/v1.0.0/atomoned-v1.0.0-linux-amd64",
-        "linux/arm64": "https://github.com/atomone-hub/atomone/releases/download/v1.0.0/atomoned-v1.0.0-linux-arm64",
-        "darwin/amd64": "https://github.com/atomone-hub/atomone/releases/download/v1.0.0/atomoned-v1.0.0-darwin-amd64",
-        "darwin/arm64": "https://github.com/atomone-hub/atomone/releases/download/v1.0.0/atomoned-v1.0.0-darwin-arm64",
-        "windows/amd64": "https://github.com/atomone-hub/atomone/releases/download/v1.0.0/atomoned-v1.0.0-windows-amd64.exe",
-        "windows/arm64": "https://github.com/atomone-hub/atomone/releases/download/v1.0.0/atomoned-v1.0.0-windows-arm64.exe"
+        "linux/amd64": "https://github.com/atomone-hub/atomone/releases/download/v1.0.1/atomoned-v1.0.1-linux-amd64",
+        "linux/arm64": "https://github.com/atomone-hub/atomone/releases/download/v1.0.1/atomoned-v1.0.1-linux-arm64",
+        "darwin/amd64": "https://github.com/atomone-hub/atomone/releases/download/v1.0.1/atomoned-v1.0.1-darwin-amd64",
+        "darwin/arm64": "https://github.com/atomone-hub/atomone/releases/download/v1.0.1/atomoned-v1.0.1-darwin-arm64",
+        "windows/amd64": "https://github.com/atomone-hub/atomone/releases/download/v1.0.1/atomoned-v1.0.1-windows-amd64.exe",
+        "windows/arm64": "https://github.com/atomone-hub/atomone/releases/download/v1.0.1/atomoned-v1.0.1-windows-arm64.exe"
       },
       "sdk": {
         "type": "cosmos",


### PR DESCRIPTION
v1.0.1 is the new latest release https://github.com/atomone-hub/atomone/releases/tag/v1.0.1