### PR TITLE
Add Validating For CGID Groupings

### DIFF
--- a/.github/workflows/utility/chain_registry.mjs
+++ b/.github/workflows/utility/chain_registry.mjs
@@ -384,6 +384,24 @@ export function getAssetTraces(chainName, baseDenom) {
   return fullTrace;
 }
 
+export function getOriginAssetCustom(chainName, baseDenom, allowedTraceTypes) {
+  let originAsset = {
+    chainName: chainName,
+    baseDenom: baseDenom
+  }
+  const traces = getAssetTraces(chainName, baseDenom);
+  if (!traces) { return originAsset; }
+  for (let i = traces.length - 1; i >= 0; --i) {
+    if (allowedTraceTypes.includes(traces[i].type)) {
+      originAsset.chainName = traces[i].counterparty.chain_name;
+      originAsset.baseDenom = traces[i].counterparty.base_denom;
+    } else {
+      break;
+    }
+  };
+  return originAsset;
+}
+
 export function getAssetPointersByChain(chainName) {
   let assetPointers = [];
   const assets = getFileProperty(chainName, "assetlist", "assets");

--- a/.github/workflows/utility/coingecko_data.mjs
+++ b/.github/workflows/utility/coingecko_data.mjs
@@ -44,13 +44,29 @@ export async function saveCoingeckoState(data) {
   await fs.writeFile(COINGECKO_JSON_PATH, JSON.stringify(data, null, 2));
 }
 
-export function createCoingeckoEntry(chainName, baseDenom, coingeckoId) {
+export function createCoingeckoEntry(coingeckoId, chainName, baseDenom) {
   let coingeckoEntry = {
     coingecko_id: coingeckoId,
     assets: []
   };
-  coingeckoEntry.assets.push({ chainName, baseDenom });
+  coingeckoEntry.assets.push({ chain_name: chainName, base_denom: baseDenom });
   return coingeckoEntry;
+}
+
+export function addAssetToCoingeckoEntry(coingeckoEntry, chainName, baseDenom) {
+  // Check if the asset already exists in the assets array
+  const assetExists = coingeckoEntry.assets.some(
+    asset => asset.chainName === chainName && asset.baseDenom === baseDenom
+  );
+
+  // If the asset is not found, add it to the array
+  if (!assetExists) {
+    coingeckoEntry.assets.push({ chain_name: chainName, base_denom: baseDenom });
+  }
+}
+
+export function getCoingeckoEntryFromState(coingeckoId, state) {
+  return state?.coingecko_data?.find(entry => entry.coingecko_id === coingeckoId);
 }
 
 function main() {

--- a/.github/workflows/utility/coingecko_data.mjs
+++ b/.github/workflows/utility/coingecko_data.mjs
@@ -10,6 +10,12 @@ export const cgidOriginTraces = [
   "test-mintage"
 ];
 
+export const cgidOriginTracesWithoutTest = [
+  "ibc",
+  "ibc-cw20",
+  "additional-mintage"
+];
+
 export const coingecko_data = {
   api_response: null,
   state: {

--- a/.github/workflows/utility/coingecko_data.mjs
+++ b/.github/workflows/utility/coingecko_data.mjs
@@ -3,6 +3,13 @@ import fs from 'fs/promises';
 const COINGECKO_API_URL = 'https://api.coingecko.com/api/v3/coins/list';
 const COINGECKO_JSON_PATH = './state/coingecko.json';
 
+export const cgidOriginTraces = [
+  "ibc",
+  "ibc-cw20",
+  "additional-mintage",
+  "test-mintage"
+];
+
 export const coingecko_data = {
   api_response: null,
   state: {
@@ -35,6 +42,15 @@ export async function loadCoingeckoState() {
 
 export async function saveCoingeckoState(data) {
   await fs.writeFile(COINGECKO_JSON_PATH, JSON.stringify(data, null, 2));
+}
+
+export function createCoingeckoEntry(chainName, baseDenom, coingeckoId) {
+  let coingeckoEntry = {
+    coingecko_id: coingeckoId,
+    assets: []
+  };
+  coingeckoEntry.assets.push({ chainName, baseDenom });
+  return coingeckoEntry;
 }
 
 function main() {

--- a/.github/workflows/utility/state/coingecko.json
+++ b/.github/workflows/utility/state/coingecko.json
@@ -365,16 +365,6 @@
       ]
     },
     {
-      "coingecko_id": "ripple-usd",
-      "_comment": "RLUSD $RLUSD",
-      "assets": [
-        {
-          "chain_name": "coreum",
-          "base_denom": "xrpl570c00a604-core1zhs909jp9yktml6qqx9f0ptcq2xnhhj99cja03j3lfcsp2pgm86studdrz"
-        }
-      ]
-    },
-    {
       "coingecko_id": "pulsara",
       "_comment": "Sara $SARA",
       "assets": [

--- a/.github/workflows/utility/validate_data.mjs
+++ b/.github/workflows/utility/validate_data.mjs
@@ -544,20 +544,55 @@ function checkCoingeckoId_in_State(chain_name, asset, assets_cgidNotInState) {
 
 }
 
+function checkCoingeckoIdAssetsShareOrigin(assets_cgidNotInState, assets_cgidOriginConflict) {
+
+  if (!coingecko_data?.state) { return true; }
+  if (assets_cgidNotInState.length <= 0) { return true; }
+
+  //iterate assets_cgidNotInState
+  assets_cgidNotInState.forEach((chain_asset_pair) => {
+
+    const coingeckoEntry = coingecko_data?.state?.coingecko_data?.find(entry => entry.coingecko_id === chain_asset_pair.asset.coingecko_id);
+    if (!coingeckoEntry) {
+      return;
+    }
+    const firstAssetInState = coingeckoEntry.assets[0];
+    const coinGeckoEntryOriginAsset = chain_reg.getOriginAssetCustom(
+      firstAssetInState.chain_name,
+      firstAssetInState.base_denom,
+      coingecko.cgidOriginTraces
+    );
+
+    console.log(`Origin asset for ${coingeckoEntry.coingecko_id} is: ${coinGeckoEntryOriginAsset.chainName}, ${coinGeckoEntryOriginAsset.baseDenom}`);
+
+    const originAsset = chain_reg.getOriginAssetCustom(
+      chain_asset_pair.chain_name,
+      chain_asset_pair.asset.base,
+      coingecko.cgidOriginTraces
+    );
+
+    if (!deepEqual(coinGeckoEntryOriginAsset, originAsset)) {
+      console.log(`
+Coingecko Entry (ID: ${coingeckoEntry.coingecko_id}) Origin Asset: ${coinGeckoEntryOriginAsset.chainName}, ${coinGeckoEntryOriginAsset.baseDenom}
+does not match origin (${originAsset.chainName}, ${originAsset.baseDenom}) of this asset (${chain_asset_pair.chain_name},${chain_asset_pair.asset.base}}).
+`);
+      assets_cgidOriginConflict.push(chain_asset_pair);
+    }
+
+
+  });
+
+}
+
 async function checkCoingeckoId_in_API(assets_cgidAssetNotMainnet, assets_cgidNotInState, assets_cgidInvalid) {
 
-  const equivalentIbcTraces = [
-    "ibc",
-    "ibc-cw20",
-    "additional-mintage",
-    "test-mintage"
-  ];
-
+  
   //Abort if we already know that non-mainnet assets have coingecko IDs.
   if (assets_cgidAssetNotMainnet.length > 0) {
     console.log(assets_cgidAssetNotMainnet.length);
     throw new Error(`CoinGecko IDs  may only be registered to mainnet assets.`);
   }
+  //Currently unused ^
 
   //Abort if there are no new CGIDs to check
   if (!assets_cgidNotInState.length) { return; }
@@ -583,13 +618,13 @@ async function checkCoingeckoId_in_API(assets_cgidAssetNotMainnet, assets_cgidNo
       chain_asset_pair.chain_name,
       chain_asset_pair.asset.base,
       "name",
-      equivalentIbcTraces
+      coingecko.cgidOriginTraces
     );
     const originAssetSymbol = chain_reg.getAssetPropertyFromOriginWithTraceCustom(
       chain_asset_pair.chain_name,
       chain_asset_pair.asset.base,
       "symbol",
-      equivalentIbcTraces
+      coingecko.cgidOriginTraces
     );
     if (
       originAssetName != coingecko_API_object.name &&
@@ -606,7 +641,7 @@ Coingecko: "${coingecko_API_object.name} $${coingecko_API_object.symbol.toUpperC
   }*/
 }
 
-function reportErrors(assets_cgidInvalid, assets_ibcInvalid) {
+function reportErrors(assets_cgidInvalid, assets_ibcInvalid, assets_cgidOriginConflict) {
 
   let err = false;
   if (assets_cgidInvalid.length > 0) {
@@ -615,6 +650,10 @@ function reportErrors(assets_cgidInvalid, assets_ibcInvalid) {
   }
   if (assets_ibcInvalid.length > 0) {
     console.log(`Some Trace IBC references are not valid! ${assets_ibcInvalid}`);
+    err = true;
+  }
+  if (assets_cgidOriginConflict.length > 0) {
+    console.log(`Some Assets with the same Coingecko ID have different origins! ${assets_cgidOriginConflict}`);
     err = true;
   }
 
@@ -638,6 +677,7 @@ export async function validate_chain_files() {
   let assets_cgidNotInState = [];
   let assets_cgidAssetNotMainnet = [];
   let assets_cgidInvalid = [];
+  let assets_cgidOriginConflict = [];
   let assets_ibcInvalid = [];
 
   //iterate each chain
@@ -698,7 +738,7 @@ export async function validate_chain_files() {
       //checkCoingeckoIdMainnetAssetsOnly(chain_name, asset, chainNetworkType, assets_cgidAssetNotMainnet);
 
       //check that coingecko IDs are in the state
-      checkCoingeckoId_in_State(chain_name, asset, assets_cgidNotInState);      
+      checkCoingeckoId_in_State(chain_name, asset, assets_cgidNotInState);
 
     });
 
@@ -707,8 +747,11 @@ export async function validate_chain_files() {
   //check that new coingecko IDs are in the API
   await checkCoingeckoId_in_API(assets_cgidAssetNotMainnet, assets_cgidNotInState, assets_cgidInvalid);
 
+  //check that assets with a newly defined CGID have the same origin asset as other assets that share the same CGID
+  checkCoingeckoIdAssetsShareOrigin(assets_cgidNotInState, assets_cgidOriginConflict);
+
   //now that we've collected errors in bulk, throw error if positive
-  reportErrors(assets_cgidInvalid, assets_ibcInvalid);
+  reportErrors(assets_cgidInvalid, assets_ibcInvalid, assets_cgidOriginConflict);
 
 }
 

--- a/.github/workflows/utility/validate_data.mjs
+++ b/.github/workflows/utility/validate_data.mjs
@@ -589,16 +589,37 @@ function checkCoingeckoIdAssetsShareOrigin(assets_cgidNotInState, assets_cgidOri
       );
 
       if (!deepEqual(firstAssetOriginAsset, originAsset)) {
+
+        const originAssetTraces = chain_reg.getAssetTraces(
+          originAsset.chainName,
+          originAsset.baseDenom
+        );
+
+        const firstAssetOriginAssetTraces = chain_reg.getAssetTraces(
+          firstAssetOriginAsset.chainName,
+          firstAssetOriginAsset.baseDenom
+        );
+
+        if (originAssetTraces && firstAssetOriginAssetTraces) {
+          const originAssetLastTrace = originAssetTraces[originAssetTraces.length - 1];
+          const firstAssetOriginAssetLastTrace = firstAssetOriginAssetTraces[firstAssetOriginAssetTraces.length - 1];
+
+          if (
+            originAssetLastTrace.type === firstAssetOriginAssetLastTrace.type &&
+            originAssetLastTrace.provider === firstAssetOriginAssetLastTrace.provider
+          ) {
+            return;
+          }
+        }
+
         console.warn(`
 Coingecko Entry (ID: ${coingeckoEntry.coingecko_id}) Origin Asset: ${firstAssetOriginAsset.chainName}, ${firstAssetOriginAsset.baseDenom}
 does not match origin (${originAsset.chainName}, ${originAsset.baseDenom}) of this asset (${asset.chain_name}, ${asset.base_denom}}).
 `);
-
         assets_cgidOriginConflict.push(asset);
+          
       }
-
     });
-
   });
 
 }

--- a/coreum/assetlist.json
+++ b/coreum/assetlist.json
@@ -171,7 +171,6 @@
           "provider": "Coreum"
         }
       ],
-      "coingecko_id": "ripple-usd",
       "images": [
         {
           "image_sync": {

--- a/testnets/_non-cosmos/avalanchetestnet/assetlist.json
+++ b/testnets/_non-cosmos/avalanchetestnet/assetlist.json
@@ -19,6 +19,16 @@
       "name": "Avalanche",
       "display": "avax",
       "symbol": "AVAX",
+      "traces": [
+        {
+          "type": "test-mintage",
+          "counterparty": {
+            "chain_name": "avalanche",
+            "base_denom": "wei"
+          },
+          "provider": "Avalanche"
+        }
+      ],
       "logo_URIs": {
         "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/_non-cosmos/avalanche/images/avax.png",
         "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/_non-cosmos/avalanche/images/avax.svg"

--- a/testnets/_non-cosmos/binancesmartchaintestnet/assetlist.json
+++ b/testnets/_non-cosmos/binancesmartchaintestnet/assetlist.json
@@ -19,6 +19,16 @@
       "name": "Binance Coin",
       "display": "bnb",
       "symbol": "BNB",
+      "traces": [
+        {
+          "type": "test-mintage",
+          "counterparty": {
+            "chain_name": "binancesmartchain",
+            "base_denom": "wei"
+          },
+          "provider": "Binance Smart Chain"
+        }
+      ],
       "logo_URIs": {
         "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/_non-cosmos/binancesmartchain/images/bnb.png",
         "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/_non-cosmos/binancesmartchain/images/bnb.svg"

--- a/testnets/_non-cosmos/ethereumtestnet/assetlist.json
+++ b/testnets/_non-cosmos/ethereumtestnet/assetlist.json
@@ -26,6 +26,16 @@
       "name": "Ether",
       "display": "eth",
       "symbol": "ETH",
+      "traces": [
+        {
+          "type": "test-mintage",
+          "counterparty": {
+            "chain_name": "ethereum",
+            "base_denom": "wei"
+          },
+          "provider": "Ethereum"
+        }
+      ],
       "logo_URIs": {
         "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/_non-cosmos/ethereum/images/eth.svg"
       },

--- a/testnets/_non-cosmos/moonbeamtestnet/assetlist.json
+++ b/testnets/_non-cosmos/moonbeamtestnet/assetlist.json
@@ -25,6 +25,16 @@
       "name": "Glimmer",
       "display": "GLMR",
       "symbol": "GLMR",
+      "traces": [
+        {
+          "type": "test-mintage",
+          "counterparty": {
+            "chain_name": "moonbeam",
+            "base_denom": "Wei"
+          },
+          "provider": "Moonbeam"
+        }
+      ],
       "logo_URIs": {
         "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/_non-cosmos/moonbeam/images/glmr.svg"
       },

--- a/testnets/_non-cosmos/polkadottestnet/assetlist.json
+++ b/testnets/_non-cosmos/polkadottestnet/assetlist.json
@@ -56,6 +56,16 @@
       "name": "Polkadot",
       "display": "DOT",
       "symbol": "DOT",
+      "traces": [
+        {
+          "type": "test-mintage",
+          "counterparty": {
+            "chain_name": "polkadot",
+            "base_denom": "Planck"
+          },
+          "provider": "Polkadot"
+        }
+      ],
       "logo_URIs": {
         "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/_non-cosmos/polkadot/images/dot.svg"
       },

--- a/testnets/_non-cosmos/polygontestnet/assetlist.json
+++ b/testnets/_non-cosmos/polygontestnet/assetlist.json
@@ -22,6 +22,16 @@
       "name": "Matic",
       "display": "matic",
       "symbol": "MATIC",
+      "traces": [
+        {
+          "type": "test-mintage",
+          "counterparty": {
+            "chain_name": "polygon",
+            "base_denom": "wei"
+          },
+          "provider": "Polygon"
+        }
+      ],
       "logo_URIs": {
         "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/_non-cosmos/polygon/images/matic.png",
         "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/_non-cosmos/polygon/images/matic.svg"

--- a/testnets/axelartestnet/assetlist.json
+++ b/testnets/axelartestnet/assetlist.json
@@ -18,6 +18,16 @@
       "name": "Axelar",
       "display": "axl",
       "symbol": "AXL",
+      "traces": [
+        {
+          "type": "test-mintage",
+          "counterparty": {
+            "chain_name": "axelar",
+            "base_denom": "uaxl"
+          },
+          "provider": "Axelar"
+        }
+      ],
       "logo_URIs": {
         "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/axelar/images/axl.png",
         "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/axelar/images/axl.svg"

--- a/testnets/bitcannadevnet/assetlist.json
+++ b/testnets/bitcannadevnet/assetlist.json
@@ -18,6 +18,16 @@
       "display": "bcna",
       "name": "BitCanna",
       "symbol": "BCNA",
+      "traces": [
+        {
+          "type": "test-mintage",
+          "counterparty": {
+            "chain_name": "bitcanna",
+            "base_denom": "ubcna"
+          },
+          "provider": "Bitcanna"
+        }
+      ],
       "logo_URIs": {
         "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/testnets/bitcannadevnet/images/bcna.png",
         "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/testnets/bitcannadevnet/images/bcna.svg"

--- a/testnets/bitcannadevnet2/assetlist.json
+++ b/testnets/bitcannadevnet2/assetlist.json
@@ -18,6 +18,16 @@
       "display": "bcna",
       "name": "BitCanna",
       "symbol": "BCNA",
+      "traces": [
+        {
+          "type": "test-mintage",
+          "counterparty": {
+            "chain_name": "bitcanna",
+            "base_denom": "ubcna"
+          },
+          "provider": "Bitcanna"
+        }
+      ],
       "logo_URIs": {
         "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/testnets/bitcannadevnet2/images/bcna.png",
         "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/testnets/bitcannadevnet2/images/bcna.svg"

--- a/testnets/cheqdtestnet/assetlist.json
+++ b/testnets/cheqdtestnet/assetlist.json
@@ -18,6 +18,16 @@
       "display": "cheq",
       "name": "cheqd",
       "symbol": "CHEQ",
+      "traces": [
+        {
+          "type": "test-mintage",
+          "counterparty": {
+            "chain_name": "cheqd",
+            "base_denom": "ncheq"
+          },
+          "provider": "Cheqd"
+        }
+      ],
       "logo_URIs": {
         "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/testnets/cheqdtestnet/images/cheq.png",
         "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/testnets/cheqdtestnet/images/cheq.svg"

--- a/testnets/coreumtestnet/assetlist.json
+++ b/testnets/coreumtestnet/assetlist.json
@@ -18,6 +18,16 @@
       "name": "Coreum",
       "display": "testcore",
       "symbol": "TESTCORE",
+      "traces": [
+        {
+          "type": "test-mintage",
+          "counterparty": {
+            "chain_name": "coreum",
+            "base_denom": "ucore"
+          },
+          "provider": "Coreum"
+        }
+      ],
       "logo_URIs": {
         "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/coreum/images/coreum.png",
         "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/coreum/images/coreum.svg"

--- a/testnets/fetchhubtestnet/assetlist.json
+++ b/testnets/fetchhubtestnet/assetlist.json
@@ -18,6 +18,16 @@
       "name": "fetch-ai",
       "display": "testfet",
       "symbol": "FET",
+      "traces": [
+        {
+          "type": "test-mintage",
+          "counterparty": {
+            "chain_name": "fetchhub",
+            "base_denom": "afet"
+          },
+          "provider": "Bitcanna"
+        }
+      ],
       "logo_URIs": {
         "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/fetchhub/images/fet.png",
         "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/fetchhub/images/fet.svg"

--- a/testnets/impacthubdevnet/assetlist.json
+++ b/testnets/impacthubdevnet/assetlist.json
@@ -18,6 +18,16 @@
       "name": "IXO",
       "display": "ixo",
       "symbol": "IXO",
+      "traces": [
+        {
+          "type": "test-mintage",
+          "counterparty": {
+            "chain_name": "impacthub",
+            "base_denom": "uixo"
+          },
+          "provider": "impacthub"
+        }
+      ],
       "logo_URIs": {
         "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/testnets/impacthubdevnet/images/ixo.png",
         "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/testnets/impacthubdevnet/images/ixo.svg"

--- a/testnets/injectivetestnet/assetlist.json
+++ b/testnets/injectivetestnet/assetlist.json
@@ -18,6 +18,16 @@
       "name": "Injective",
       "display": "INJ",
       "symbol": "INJ",
+      "traces": [
+        {
+          "type": "test-mintage",
+          "counterparty": {
+            "chain_name": "injective",
+            "base_denom": "inj"
+          },
+          "provider": "Injective"
+        }
+      ],
       "logo_URIs": {
         "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/injective/images/inj.png",
         "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/injective/images/inj.svg"

--- a/testnets/osmosistestnet/assetlist.json
+++ b/testnets/osmosistestnet/assetlist.json
@@ -21,6 +21,16 @@
       "name": "Osmosis Testnet",
       "display": "osmo",
       "symbol": "OSMO",
+      "traces": [
+        {
+          "type": "test-mintage",
+          "counterparty": {
+            "chain_name": "osmosis",
+            "base_denom": "uosmo"
+          },
+          "provider": "Osmosis"
+        }
+      ],
       "logo_URIs": {
         "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/osmosis/images/osmo.png",
         "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/osmosis/images/osmo.svg"
@@ -32,7 +42,7 @@
         }
       ],
       "coingecko_id": "osmosis",
-      "keywords": ["dex", "staking"]
+      "keywords": [ "dex", "staking" ]
     },
     {
       "denom_units": [
@@ -50,6 +60,16 @@
       "name": "Ion",
       "display": "ion",
       "symbol": "ION",
+      "traces": [
+        {
+          "type": "test-mintage",
+          "counterparty": {
+            "chain_name": "osmosis",
+            "base_denom": "uion"
+          },
+          "provider": "Osmosis"
+        }
+      ],
       "logo_URIs": {
         "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/osmosis/images/ion.png",
         "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/osmosis/images/ion.svg"
@@ -61,7 +81,7 @@
         }
       ],
       "coingecko_id": "ion",
-      "keywords": ["memecoin"]
+      "keywords": [ "memecoin" ]
     },
     {
       "description": "The native staking and governance token of the Theta testnet version of the Cosmos Hub.",

--- a/testnets/osmosistestnet4/assetlist.json
+++ b/testnets/osmosistestnet4/assetlist.json
@@ -20,6 +20,16 @@
       "name": "Osmosis",
       "display": "osmo",
       "symbol": "OSMO",
+      "traces": [
+        {
+          "type": "test-mintage",
+          "counterparty": {
+            "chain_name": "osmosis",
+            "base_denom": "uosmo"
+          },
+          "provider": "Osmosis"
+        }
+      ],
       "logo_URIs": {
         "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/osmosis/images/osmo.png",
         "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/osmosis/images/osmo.svg"
@@ -52,6 +62,16 @@
       "name": "Ion",
       "display": "ion",
       "symbol": "ION",
+      "traces": [
+        {
+          "type": "test-mintage",
+          "counterparty": {
+            "chain_name": "osmosis",
+            "base_denom": "uion"
+          },
+          "provider": "Osmosis"
+        }
+      ],
       "logo_URIs": {
         "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/osmosis/images/ion.png",
         "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/osmosis/images/ion.svg"

--- a/testnets/persistencetestnet/assetlist.json
+++ b/testnets/persistencetestnet/assetlist.json
@@ -18,6 +18,16 @@
       "name": "Persistence",
       "display": "xprt",
       "symbol": "XPRT",
+      "traces": [
+        {
+          "type": "test-mintage",
+          "counterparty": {
+            "chain_name": "persistence",
+            "base_denom": "uxprt"
+          },
+          "provider": "Persistence"
+        }
+      ],
       "logo_URIs": {
         "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/persistence/images/xprt.png",
         "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/persistence/images/xprt.svg"

--- a/testnets/persistencetestnet2/assetlist.json
+++ b/testnets/persistencetestnet2/assetlist.json
@@ -18,6 +18,16 @@
       "name": "Persistence",
       "display": "xprt",
       "symbol": "XPRT",
+      "traces": [
+        {
+          "type": "test-mintage",
+          "counterparty": {
+            "chain_name": "persistence",
+            "base_denom": "uxprt"
+          },
+          "provider": "Persistence"
+        }
+      ],
       "logo_URIs": {
         "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/persistence/images/xprt.png",
         "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/persistence/images/xprt.svg"

--- a/testnets/quicksilvertestnet/assetlist.json
+++ b/testnets/quicksilvertestnet/assetlist.json
@@ -20,6 +20,16 @@
       "name": "Quicksilver",
       "display": "qck",
       "symbol": "QCK",
+      "traces": [
+        {
+          "type": "test-mintage",
+          "counterparty": {
+            "chain_name": "quicksilver",
+            "base_denom": "uqck"
+          },
+          "provider": "Quicksilver"
+        }
+      ],
       "logo_URIs": {
         "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/quicksilver/images/qck.png"
       },

--- a/testnets/secretnetworktestnet/assetlist.json
+++ b/testnets/secretnetworktestnet/assetlist.json
@@ -18,6 +18,16 @@
       "name": "Secret Network",
       "display": "scrt",
       "symbol": "SCRT",
+      "traces": [
+        {
+          "type": "test-mintage",
+          "counterparty": {
+            "chain_name": "secretnetwork",
+            "base_denom": "uscrt"
+          },
+          "provider": "Secret Network"
+        }
+      ],
       "logo_URIs": {
         "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/secretnetwork/images/scrt.png",
         "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/secretnetwork/images/scrt.svg"

--- a/testnets/stargazetestnet/assetlist.json
+++ b/testnets/stargazetestnet/assetlist.json
@@ -18,6 +18,16 @@
       "name": "Stargaze",
       "display": "stars",
       "symbol": "STARS",
+      "traces": [
+        {
+          "type": "test-mintage",
+          "counterparty": {
+            "chain_name": "stargaze",
+            "base_denom": "ustars"
+          },
+          "provider": "Stargaze"
+        }
+      ],
       "logo_URIs": {
         "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/stargaze/images/stars.png"
       },

--- a/testnets/terra2testnet/assetlist.json
+++ b/testnets/terra2testnet/assetlist.json
@@ -18,6 +18,16 @@
       "name": "Luna",
       "display": "luna",
       "symbol": "LUNA",
+      "traces": [
+        {
+          "type": "test-mintage",
+          "counterparty": {
+            "chain_name": "terra2",
+            "base_denom": "uluna"
+          },
+          "provider": "Terra"
+        }
+      ],
       "logo_URIs": {
         "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/terra2/images/luna.png",
         "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/terra2/images/luna.svg"

--- a/testnets/xplatestnet/assetlist.json
+++ b/testnets/xplatestnet/assetlist.json
@@ -18,6 +18,16 @@
       "name": "Xpla",
       "display": "xpla",
       "symbol": "XPLA",
+      "traces": [
+        {
+          "type": "test-mintage",
+          "counterparty": {
+            "chain_name": "xpla",
+            "base_denom": "axpla"
+          },
+          "provider": "XPLA"
+        }
+      ],
       "logo_URIs": {
         "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/xpla/images/xpla.png",
         "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/xpla/images/xpla.svg"


### PR DESCRIPTION
Add Validating For CGID Groupings
Ensures that assets with the same coingecko ID are related.
Bulk update of assets (mostly adding test--mintage trace)