### PR TITLE
Update planq assetlist-- add nRide Multihop representation

### DIFF
--- a/planq/assetlist.json
+++ b/planq/assetlist.json
@@ -85,6 +85,60 @@
         "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/_non-cosmos/binancesmartchain/images/srcx.png"
       },
       "type_asset": "sdk.coin"
+    },
+    {
+      "description": "nRide Token",
+      "extended_description": "nRide is developing a uber-like ride-hailing protocol, leveraging cosmwasm smart-contracts for payment, driver registration and text-messaging between the rider and the driver, to create a trustless public transportation environment for any cab or taxi company to use.",
+      "denom_units": [
+        {
+          "denom": "ibc/26B4B4BBF3C8D5DB1ADE993CCD865A7CC608B2BAEF20E0166F18B84E32184F63",
+          "exponent": 0,
+          "aliases": [
+            "cw20:juno1qmlchtmjpvu0cr7u0tad2pq8838h6farrrjzp39eqa9xswg7teussrswlq",
+            "ibc/E750D31033DC1CF4A044C3AA0A8117401316DC918FBEBC4E3D34F91B09D5F54C"
+          ]
+        },
+        {
+          "denom": "nride",
+          "exponent": 6
+        }
+      ],
+      "type_asset": "ics20",
+      "base": "ibc/26B4B4BBF3C8D5DB1ADE993CCD865A7CC608B2BAEF20E0166F18B84E32184F63",
+      "name": "nRide Token",
+      "display": "nride",
+      "symbol": "NRIDE",
+      "traces": [
+        {
+          "type": "ibc",
+          "counterparty": {
+            "chain_name": "osmosis",
+            "base_denom": "ibc/E750D31033DC1CF4A044C3AA0A8117401316DC918FBEBC4E3D34F91B09D5F54C",
+            "channel_id": "channel-492"
+          },
+          "chain": {
+            "channel_id": "channel-1",
+            "path": "transfer/channel-1/transfer/channel-169/cw20:juno1qmlchtmjpvu0cr7u0tad2pq8838h6farrrjzp39eqa9xswg7teussrswlq"
+          }
+        }
+      ],
+      "logo_URIs": {
+        "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/juno/images/nride.png",
+        "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/juno/images/nride.svg"
+      },
+      "images": [
+        {
+          "image_sync": {
+            "chain_name": "juno",
+            "base_denom": "cw20:juno1qmlchtmjpvu0cr7u0tad2pq8838h6farrrjzp39eqa9xswg7teussrswlq"
+          },
+          "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/juno/images/nride.png",
+          "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/juno/images/nride.svg",
+          "theme": {
+            "primary_color_hex": "#050505"
+          }
+        }
+      ]
     }
   ]
 }


### PR DESCRIPTION
This commits add the nRide Tokens representation on PlanQ Network to use their Delta-Bridge to Binance Smart Chain