### PR TITLE
Update Osmosis Version to v28.0.1+

### DIFF
--- a/osmosis/chain.json
+++ b/osmosis/chain.json
@@ -527,15 +527,18 @@
       "name": "v3",
       "genesis_url": "https://github.com/osmosis-labs/networks/raw/main/osmosis-1/genesis.json"
     },
-    "recommended_version": "28.0.0",
+    "recommended_version": "28.0.4",
     "compatible_versions": [
-      "28.0.0"
+      "28.0.1",
+      "28.0.2",
+      "28.0.3",
+      "28.0.4"
     ],
     "consensus": {
       "type": "cometbft",
-      "version": "0.38.15",
+      "version": "0.38.17",
       "repo": "https://github.com/osmosis-labs/cometbft",
-      "tag": "v0.38.15-v27-osmo-2"
+      "tag": "v0.38.17-v28-osmo-1"
     },
     "cosmwasm": {
       "version": "0.53.0",
@@ -545,9 +548,9 @@
     },
     "sdk": {
       "type": "cosmos",
-      "version": "0.50.10",
+      "version": "0.50.11",
       "repo": "https://github.com/osmosis-labs/cosmos-sdk",
-      "tag": "v0.50.10-v27-osmo-1"
+      "tag": "v0.50.11-v28-osmo-1"
     },
     "ibc": {
       "type": "go",
@@ -560,11 +563,11 @@
     },
     "language": {
       "type": "go",
-      "version": "1.22.7"
+      "version": "1.22.11"
     },
     "binaries": {
-      "linux/amd64": "https://github.com/osmosis-labs/osmosis/releases/download/v28.0.0/osmosisd-28.0.0-linux-amd64?checksum=8efbeca8f3e6a27c7b8ab02141bbfc457a6efbb089e338147942aa6fcb586545",
-      "linux/arm64": "https://github.com/osmosis-labs/osmosis/releases/download/v28.0.0/osmosisd-28.0.0-linux-arm64?checksum=7ac375a5c58a4407e15651fb15e83b5267cfdfd81c9656b348e0f9d38205c126"
+      "linux/amd64": "https://github.com/osmosis-labs/osmosis/releases/download/v28.0.4/osmosisd-28.0.4-linux-amd64",
+      "linux/arm64": "https://github.com/osmosis-labs/osmosis/releases/download/v28.0.4/osmosisd-28.0.4-linux-arm64"
     }
   },
   "images": [

--- a/osmosis/versions.json
+++ b/osmosis/versions.json
@@ -718,6 +718,55 @@
       },
       "previous_version_name": "v27",
       "next_version_name": ""
+    },
+    {
+      "name": "v28.0.1+",
+      "tag": "v28.0.4",
+      "height": 29743104,
+      "recommended_version": "28.0.4",
+      "compatible_versions": [
+        "28.0.1",
+        "28.0.2",
+        "28.0.3",
+        "28.0.4"
+      ],
+      "consensus": {
+        "type": "cometbft",
+        "version": "0.38.17",
+        "repo": "https://github.com/osmosis-labs/cometbft",
+        "tag": "v0.38.17-v28-osmo-1"
+      },
+      "cosmwasm": {
+        "version": "0.53.0",
+        "repo": "https://github.com/CosmWasm/wasmd",
+        "tag": "v0.53.0",
+        "enabled": true
+      },
+      "sdk": {
+        "type": "cosmos",
+        "version": "0.50.11",
+        "repo": "https://github.com/osmosis-labs/cosmos-sdk",
+        "tag": "v0.50.11-v28-osmo-1"
+      },
+      "ibc": {
+        "type": "go",
+        "version": "8.5.2",
+        "repo": "https://github.com/cosmos/ibc-go",
+        "tag": "v8.5.2",
+        "ics_enabled": [
+          "ics20-1"
+        ]
+      },
+      "language": {
+        "type": "go",
+        "version": "1.22.11"
+      },
+      "binaries": {
+        "linux/amd64": "https://github.com/osmosis-labs/osmosis/releases/download/v28.0.4/osmosisd-28.0.4-linux-amd64",
+        "linux/arm64": "https://github.com/osmosis-labs/osmosis/releases/download/v28.0.4/osmosisd-28.0.4-linux-arm64"
+      },
+      "previous_version_name": "v28",
+      "next_version_name": ""
     }
   ]
 }


### PR DESCRIPTION
Update Osmosis Version to v28.0.1+
v28.0.1 had an unintentional state-breaking change, and therefore created a new version to patch versions at an beyond v28.0.1 even though it's in the same major version number.