### PR TITLE
Changed used channels between Noble and Kopi

### DIFF
--- a/_IBC/kopi-noble.json
+++ b/_IBC/kopi-noble.json
@@ -3,22 +3,22 @@
     "chain_1": {
         "chain_name": "kopi",
         "client_id": "07-tendermint-0",
-        "connection_id": "connection-0"
+        "connection_id": "connection-1"
     },
     "chain_2": {
         "chain_name": "noble",
-        "client_id": "07-tendermint-124",
-        "connection_id": "connection-120"
+        "client_id": "07-tendermint-140",
+        "connection_id": "connection-135"
     },
 
     "channels": [
         {
             "chain_1": {
-                "channel_id": "channel-0",
+                "channel_id": "channel-9",
                 "port_id": "transfer"
             },
             "chain_2": {
-                "channel_id": "channel-109",
+                "channel_id": "channel-122",
                 "port_id": "transfer"
             },
             "ordering": "unordered",

--- a/kopi/assetlist.json
+++ b/kopi/assetlist.json
@@ -182,7 +182,7 @@
       "description": "USDC from Noble Chain",
       "denom_units": [
         {
-          "denom": "ibc/8E27BA2D5493AF5636760E354E46004562C46AB7EC0CC4C1CA14E9E20E2545B5",
+          "denom": "ibc/295548A78785A1007F232DE286149A6FF512F180AF5657780FC89C009E2C348F",
           "exponent": 0
         },
         {
@@ -190,7 +190,7 @@
           "exponent": 6
         }
       ],
-      "base": "ibc/8E27BA2D5493AF5636760E354E46004562C46AB7EC0CC4C1CA14E9E20E2545B5",
+      "base": "ibc/295548A78785A1007F232DE286149A6FF512F180AF5657780FC89C009E2C348F",
       "name": "USDC",
       "display": "USDC",
       "symbol": "USDC",
@@ -213,11 +213,11 @@
           "counterparty": {
             "chain_name": "noble",
             "base_denom": "uusdc",
-            "channel_id": "channel-109"
+            "channel_id": "channel-122"
           },
           "chain": {
-            "channel_id": "channel-0",
-            "path": "transfer/channel-0/uusdc"
+            "channel_id": "channel-9",
+            "path": "transfer/channel-9/uusdc"
           }
         }
       ],


### PR DESCRIPTION
A while ago our client on Noble-chain expired. We reached out to Noble on various channels but have not (yet) received a solid response or any official information on how to get the old client re-instated. Since we want to move on (our main-net release is currently on hold because of this situation), we kindly request this PR is accepted which changes the channel used for Noble.
The funds stuck in the previous channel are limited and are our funds which have been sent for testing: https://rest.kopi.money/cosmos/bank/v1beta1/supply/by_denom?denom=ibc%2F8E27BA2D5493AF5636760E354E46004562C46AB7EC0CC4C1CA14E9E20E2545B5
If at some point the old client gets recovered, we can return those funds back to noble chain.