### PR TITLE
bump quicksilver to v1.7.7

### DIFF
--- a/quicksilver/chain.json
+++ b/quicksilver/chain.json
@@ -34,12 +34,12 @@
   },
   "codebase": {
     "git_repo": "https://github.com/quicksilver-zone/quicksilver",
-    "recommended_version": "v1.7.6",
+    "recommended_version": "v1.7.7",
     "compatible_versions": [
-      "v1.7.6"
+      "v1.7.7"
     ],
     "binaries": {
-      "linux/amd64": "https://github.com/quicksilver-zone/quicksilver/releases/download/v1.7.6/quicksilverd-v1.7.6-amd64"
+      "linux/amd64": "https://github.com/quicksilver-zone/quicksilver/releases/download/v1.7.7/quicksilverd-v1.7.7-amd64"
     },
     "sdk": {
       "type": "cosmos",

--- a/quicksilver/versions.json
+++ b/quicksilver/versions.json
@@ -632,6 +632,35 @@
         "type": "go",
         "version": "1.23.3"
       },
+      "next_version_name": "v1.7.7"
+    },
+    {
+      "name": "v1.7.7",
+      "proposal": 59,
+      "height": 11490000,
+      "recommended_version": "v1.7.7",
+      "compatible_versions": [
+        "v1.7.7"
+      ],
+      "binaries": {
+        "linux/amd64": "https://github.com/quicksilver-zone/quicksilver/releases/download/v1.7.7/quicksilverd-v1.7.7-amd64"
+      },
+      "consensus": {
+        "type": "cometbft",
+        "version": "v0.34.33"
+      },
+      "sdk": {
+        "type": "cosmos",
+        "version": "v0.46.16"
+      },
+      "ibc": {
+        "type": "go",
+        "version": "v6.3.1"
+      },
+      "language": {
+        "type": "go",
+        "version": "1.23.3"
+      },
       "next_version_name": ""
     }
   ]


### PR DESCRIPTION
Update chain.json and versions.json to reflect Quicksilver v1.7.7 release.