### PR TITLE
Revert "chore: Add gas steps on Babylon testnet"

### DIFF
--- a/testnets/babylontestnet/chain.json
+++ b/testnets/babylontestnet/chain.json
@@ -23,10 +23,7 @@
   "staking": {
     "staking_tokens": [
       {
-        "denom": "ubbn",
-        "low_gas_price": 0.007,
-        "average_gas_price": 0.007,
-        "high_gas_price": 0.01
+        "denom": "ubbn"
       }
     ]
   },

--- a/testnets/babylontestnet/chain.json
+++ b/testnets/babylontestnet/chain.json
@@ -16,7 +16,10 @@
   "fees": {
     "fee_tokens": [
       {
-        "denom": "ubbn"
+        "denom": "ubbn",
+        "low_gas_price": 0.007,
+        "average_gas_price": 0.007,
+        "high_gas_price": 0.01
       }
     ]
   },


### PR DESCRIPTION
Reverts cosmos/chain-registry#6004

Moves the gas prices to fee_tokens (was incorrectly added to staking tokens)