### PR TITLE
adjust gas prices for gardia and diamond

### DIFF
--- a/testnets/zenrocktestnet/chain.json
+++ b/testnets/zenrocktestnet/chain.json
@@ -18,10 +18,10 @@
     "fee_tokens": [
       {
         "denom": "urock",
-        "fixed_min_gas_price": 0.5,
-        "low_gas_price": 0.5,
-        "average_gas_price": 0.55,
-        "high_gas_price": 0.6
+        "fixed_min_gas_price": 2.5,
+        "low_gas_price": 2.5,
+        "average_gas_price": 2.75,
+        "high_gas_price": 3.0
       }
     ]
   },

--- a/zenrock/chain.json
+++ b/zenrock/chain.json
@@ -18,10 +18,10 @@
       "fee_tokens": [
         {
           "denom": "urock",
-          "fixed_min_gas_price": 0.5,
-          "low_gas_price": 0.5,
-          "average_gas_price": 0.55,
-          "high_gas_price": 0.6
+          "fixed_min_gas_price": 2.5,
+          "low_gas_price": 2.5,
+          "average_gas_price": 2.75,
+          "high_gas_price": 3.0
         }
       ]
     },


### PR DESCRIPTION
This PR adjusts the gas prices for `gardia` and `diamond` which result from increasing the `min_gas_prices` on both networks.