### PR TITLE
Set all Injective gas prices to 160000000inj

### DIFF
--- a/injective/chain.json
+++ b/injective/chain.json
@@ -19,9 +19,9 @@
       {
         "denom": "inj",
         "fixed_min_gas_price": 160000000,
-        "low_gas_price": 500000000,
-        "average_gas_price": 700000000,
-        "high_gas_price": 900000000
+        "low_gas_price": 160000000,
+        "average_gas_price": 160000000,
+        "high_gas_price": 160000000
       }
     ]
   },


### PR DESCRIPTION
Injective uses a fixed gas price model so have requested all be set to `160000000inj`.