### PR TITLE
Correct POL and MATIC traces

### DIFF
--- a/_non-cosmos/polygon/assetlist.json
+++ b/_non-cosmos/polygon/assetlist.json
@@ -21,16 +21,6 @@
       "name": "Polygon (ex-MATIC)",
       "display": "pol",
       "symbol": "POL",
-      "traces": [
-        {
-          "type": "wrapped",
-          "counterparty": {
-            "chain_name": "polygon",
-            "base_denom": "wei"
-          },
-          "provider": "Polygon"
-        }
-      ],
       "logo_URIs": {
         "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/_non-cosmos/polygon/images/matic-purple.png",
         "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/_non-cosmos/polygon/images/matic-purple.svg"
@@ -69,6 +59,16 @@
       "name": "Polygon",
       "display": "matic",
       "symbol": "MATIC",
+      "traces": [
+        {
+          "type": "legacy-mintage",
+          "counterparty": {
+            "chain_name": "polygon",
+            "base_denom": "0x0000000000000000000000000000000000001010"
+          },
+          "provider": "Polygon"
+        }
+      ],
       "logo_URIs": {
         "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/_non-cosmos/polygon/images/matic-purple.png",
         "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/_non-cosmos/polygon/images/matic-purple.svg"


### PR DESCRIPTION
Correct POL and MATIC traces
POL is origin asset now
MATIC is a deprecated legacy-mintage of POL (doesn't even exist on-chain anymore)