### PR TITLE
Update chain.json

### DIFF
--- a/juno/chain.json
+++ b/juno/chain.json
@@ -493,17 +493,6 @@
       "tx_page": "https://ping.pub/juno/tx/${txHash}"
     },
     {
-      "kind": "explorers.guru",
-      "url": "https://juno.explorers.guru",
-      "tx_page": "https://juno.explorers.guru/transaction/${txHash}"
-    },
-    {
-      "kind": "mintscan",
-      "url": "https://www.mintscan.io/juno",
-      "tx_page": "https://www.mintscan.io/juno/transactions/${txHash}",
-      "account_page": "https://www.mintscan.io/juno/accounts/${accountAddress}"
-    },
-    {
       "kind": "staking-explorer.com",
       "url": "https://staking-explorer.com/explorer/juno",
       "tx_page": "https://staking-explorer.com/transaction.php?chain=juno&tx=${txHash}",


### PR DESCRIPTION
Mintscan has stopped supporting Juno and juno.explorers.guru is inaccessible.