### PR TITLE
Update Pryzm to v0.27

### DIFF
--- a/pryzm/chain.json
+++ b/pryzm/chain.json
@@ -108,15 +108,15 @@
   },
   "codebase": {
     "git_repo": "https://github.com/pryzm-finance/pryzm-core",
-    "recommended_version": "v0.26.0",
+    "recommended_version": "v0.27.0",
     "compatible_versions": [
-      "v0.26.0"
+      "v0.27.0"
     ],
     "binaries": {
-      "darwin/amd64": "https://storage.googleapis.com/pryzm-zone/core/0.26.0/pryzmd-0.26.0-darwin-amd64",
-      "darwin/arm64": "https://storage.googleapis.com/pryzm-zone/core/0.26.0/pryzmd-0.26.0-darwin-arm64",
-      "linux/amd64": "https://storage.googleapis.com/pryzm-zone/core/0.26.0/pryzmd-0.26.0-linux-amd64",
-      "linux/arm64": "https://storage.googleapis.com/pryzm-zone/core/0.26.0/pryzmd-0.26.0-linux-arm64"
+      "darwin/amd64": "https://storage.googleapis.com/pryzm-zone/core/0.27.0/pryzmd-0.27.0-darwin-amd64",
+      "darwin/arm64": "https://storage.googleapis.com/pryzm-zone/core/0.27.0/pryzmd-0.27.0-darwin-arm64",
+      "linux/amd64": "https://storage.googleapis.com/pryzm-zone/core/0.27.0/pryzmd-0.27.0-linux-amd64",
+      "linux/arm64": "https://storage.googleapis.com/pryzm-zone/core/0.27.0/pryzmd-0.27.0-linux-arm64"
     },
     "consensus": {
       "type": "cometbft",
@@ -131,11 +131,11 @@
     },
     "sdk": {
       "type": "cosmos",
-      "version": "v0.47.16"
+      "version": "v0.47.17"
     },
     "ibc": {
       "type": "go",
-      "version": "7.9.2",
+      "version": "7.10.0",
       "ics_enabled": [
         "ics20-1",
         "ics27-1"

--- a/pryzm/versions.json
+++ b/pryzm/versions.json
@@ -356,7 +356,7 @@
         "version": "0.37.5"
       },
       "previous_version_name": "v0.25",
-      "next_version_name": "",
+      "next_version_name": "v0.27",
       "cosmwasm": {
         "version": "v0.46.0",
         "enabled": true
@@ -368,6 +368,48 @@
       "ibc": {
         "type": "go",
         "version": "7.9.2",
+        "ics_enabled": [
+          "ics20-1",
+          "ics27-1"
+        ]
+      },
+      "language": {
+        "type": "go",
+        "version": "1.22"
+      }
+    },
+    {
+      "name": "v0.27",
+      "tag": "v0.27.0",
+      "proposal": 51,
+      "height": 4785000,
+      "recommended_version": "v0.27.0",
+      "compatible_versions": [
+        "v0.27.0"
+      ],
+      "binaries": {
+        "darwin/amd64": "https://storage.googleapis.com/pryzm-zone/core/0.27.0/pryzmd-0.27.0-darwin-amd64",
+        "darwin/arm64": "https://storage.googleapis.com/pryzm-zone/core/0.27.0/pryzmd-0.27.0-darwin-arm64",
+        "linux/amd64": "https://storage.googleapis.com/pryzm-zone/core/0.27.0/pryzmd-0.27.0-linux-amd64",
+        "linux/arm64": "https://storage.googleapis.com/pryzm-zone/core/0.27.0/pryzmd-0.27.0-linux-arm64"
+      },
+      "consensus": {
+        "type": "cometbft",
+        "version": "0.37.5"
+      },
+      "previous_version_name": "v0.26",
+      "next_version_name": "",
+      "cosmwasm": {
+        "version": "v0.46.0",
+        "enabled": true
+      },
+      "sdk": {
+        "type": "cosmos",
+        "version": "v0.47.17"
+      },
+      "ibc": {
+        "type": "go",
+        "version": "7.10.0",
         "ics_enabled": [
           "ics20-1",
           "ics27-1"


### PR DESCRIPTION
This PR updates the Pryzm chain version to the latest upgraded version.