### PR TITLE
Kill Mars Chain

### DIFF
--- a/_IBC/crescent-mars.json
+++ b/_IBC/crescent-mars.json
@@ -23,7 +23,7 @@
       "ordering": "unordered",
       "version": "ics20-1",
       "tags": {
-        "status": "live",
+        "status": "killed",
         "preferred": true,
         "dex": "crescent"
       }

--- a/_IBC/juno-mars.json
+++ b/_IBC/juno-mars.json
@@ -23,7 +23,7 @@
       "ordering": "unordered",
       "version": "ics20-1",
       "tags": {
-        "status": "live",
+        "status": "killed",
         "preferred": true
       }
     }

--- a/_IBC/kujira-mars.json
+++ b/_IBC/kujira-mars.json
@@ -23,7 +23,7 @@
       "ordering": "unordered",
       "version": "ics20-1",
       "tags": {
-        "status": "live",
+        "status": "killed",
         "preferred": true
       }
     }

--- a/_IBC/mars-neutron.json
+++ b/_IBC/mars-neutron.json
@@ -23,7 +23,7 @@
       "ordering": "unordered",
       "version": "ics20-1",
       "tags": {
-        "status": "live",
+        "status": "killed",
         "preferred": true
       }
     }

--- a/_IBC/mars-osmosis.json
+++ b/_IBC/mars-osmosis.json
@@ -23,7 +23,7 @@
       "ordering": "unordered",
       "version": "ics20-1",
       "tags": {
-        "status": "live",
+        "status": "killed",
         "preferred": true
       }
     }

--- a/_IBC/mars-terra2.json
+++ b/_IBC/mars-terra2.json
@@ -23,7 +23,7 @@
       "ordering": "unordered",
       "version": "ics20-1",
       "tags": {
-        "status": "live",
+        "status": "killed",
         "preferred": true
       }
     }

--- a/mars/assetlist.json
+++ b/mars/assetlist.json
@@ -3,6 +3,7 @@
   "chain_name": "mars",
   "assets": [
     {
+      "deprecated": true,
       "description": "Mars Protocol token (pre-migration)",
       "denom_units": [
         {

--- a/mars/chain.json
+++ b/mars/chain.json
@@ -1,7 +1,7 @@
 {
   "$schema": "../chain.schema.json",
   "chain_name": "mars",
-  "status": "live",
+  "status": "killed",
   "network_type": "mainnet",
   "website": "https://www.marsprotocol.io/",
   "pretty_name": "Mars Hub",


### PR DESCRIPTION
Kill Mars Chain
Chain status to killed
All IBC channels to killed
MARS Asset (only the one from Mars Hub--not neutron's) to deprecated: true

as per https://x.com/mars_protocol/status/1902642598013018424