### PR TITLE
Update XPLA Explorer Url

### DIFF
--- a/xpla/chain.json
+++ b/xpla/chain.json
@@ -212,7 +212,7 @@
   },
   "explorers": [
     {
-      "kind": "explorer.xpla",
+      "kind": "explorer.xpla/mainnet",
       "url": "https://explorer.xpla.io",
       "tx_page": "https://explorer.xpla.io/mainnet/tx/${txHash}"
     },


### PR DESCRIPTION
Fix XPLA Explorer mainnet links

When accessing transaction or block information via https://explorer.xpla.io, users encounter a "Page not found" error. This PR updates all explorer links to use the correct format: https://explorer.xpla.io/mainnet

References:
- Correct explorer URL: https://explorer.xpla.io/mainnet
- Chain information: https://chainlist.wtf/chain/37/