### PR TITLE
Specify Dungeon Chain Logo

### DIFF
--- a/dungeon/chain.json
+++ b/dungeon/chain.json
@@ -116,5 +116,8 @@
         "address": "217.182.124.26:26656"
       }
     ]
+  },
+  "logo_URIs": {
+    "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/dungeon/images/DGN.png"
   }
 }


### PR DESCRIPTION
Specify Dungeon Chain Logo.
The png was already in the images directory