### PR TITLE
Update Neutron version

### DIFF
--- a/neutron/versions.json
+++ b/neutron/versions.json
@@ -183,6 +183,38 @@
         "type": "go",
         "version": "v8.5.2"
       }
+    },
+    {
+      "name": "v6.0.0",
+      "proposal": 65,
+      "height": 22041500,
+      "recommended_version": "v6.0.0",
+      "compatible_versions": [
+        "v6.0.0"
+      ],
+      "binaries": {
+        "linux/amd64": "https://github.com/neutron-org/neutron/releases/download/v6.0.0/neutrond-linux-amd64"
+      },
+      "consensus": {
+        "type": "cometbft",
+        "version": "v0.38.17"
+      },
+      "next_version_name": "",
+      "sdk": {
+        "type": "cosmos",
+        "repo": "https://github.com/neutron-org/cosmos-sdk",
+        "version": "v0.50.11",
+        "tag": "v0.50.11-neutron"
+      },
+      "cosmwasm": {
+        "version": "v0.53.2",
+        "repo": "https://github.com/neutron-org/wasmd",
+        "enabled": true
+      },
+      "ibc": {
+        "type": "go",
+        "version": "v8.7.0"
+      }
     }
   ]
 }


### PR DESCRIPTION
With Proposal https://governance.neutron.org/proposals/A/65 Neutron Mercury version 6.0.0 came into effect today.