### PR TITLE
Update chain.json for Terra2

### DIFF
--- a/terra2/chain.json
+++ b/terra2/chain.json
@@ -3,7 +3,7 @@
   "chain_name": "terra2",
   "status": "live",
   "network_type": "mainnet",
-  "website": "https://www.terra.money/",
+  "website": "https://www.phoenix.money/",
   "pretty_name": "Terra",
   "chain_type": "cosmos",
   "chain_id": "phoenix-1",
@@ -30,14 +30,14 @@
     ]
   },
   "codebase": {
-    "git_repo": "https://github.com/terra-money/core/",
-    "recommended_version": "v2.12.4",
+    "git_repo": "https://github.com/phoenix-directive/core/",
+    "recommended_version": "v2.16.0",
     "compatible_versions": [
-      "v2.12.4"
+      "v2.16.0"
     ],
     "binaries": {
-      "linux/arm64": "https://github.com/terra-money/core/releases/download/v2.12.4/terra_2.12.4_Linux_arm64.tar.gz",
-      "linux/amd64": "https://github.com/terra-money/core/releases/download/v2.12.4/terra_2.12.4_Linux_x86_64.tar.gz"
+      "linux/arm64": "https://github.com/phoenix-directive/core/releases/download/v2.16.0/terra_2.16.0_Linux_arm64.tar.gz",
+      "linux/amd64": "https://github.com/phoenix-directive/core/releases/download/v2.16.0/terra_2.16.0_Linux_x86_64.tar.gz"
     },
     "genesis": {
       "name": "v2.0",


### PR DESCRIPTION
The responsibility of maintaining Terra's blockchain software has moved over to the Phoenix Directive. The original terra-money organization has stopped updating the core software