### PR TITLE
feat add solvBTC to bbn

### DIFF
--- a/babylon/assetlist.json
+++ b/babylon/assetlist.json
@@ -591,6 +591,42 @@
           }
         }
       ]
+    },
+    {
+      "denom_units": [
+        {
+          "denom": "cw20:bbn1tyvxlr8qjt7yx48lhhle7xzxfxkyqwzkaxey3jekrl0gql260jlqlxgfst",
+          "exponent": 0
+        },
+        {
+          "denom": "SolvBTC",
+          "exponent": 18
+        }
+      ],
+      "base": "cw20:bbn1tyvxlr8qjt7yx48lhhle7xzxfxkyqwzkaxey3jekrl0gql260jlqlxgfst",
+      "address": "bbn1tyvxlr8qjt7yx48lhhle7xzxfxkyqwzkaxey3jekrl0gql260jlqlxgfst",
+      "name": "Solv BTC",
+      "display": "SolvBTC",
+      "symbol": "SolvBTC",
+      "logo_URIs": {
+        "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/_non-cosmos/ethereum/images/solvBTC.svg"
+      },
+      "type_asset": "cw20",
+      "traces": [
+        {
+          "type": "ibc-bridge",
+          "provider": "Union",
+          "counterparty": {
+            "chain_name": "ethereum",
+            "base_denom": "0x7a56e1c57c7475ccf742a1832b028f0456652f97",
+            "channel_id": "1"
+          },
+          "chain": {
+            "channel_id": "3",
+            "path": "0"
+          }
+        }
+      ]
     }
   ]
 }


### PR DESCRIPTION
Adds new token for Union bridged asset to Babylon. The PR consists of a new cw20 for the supported asset