### PR TITLE
feat: add stBTC to bbn

### DIFF
--- a/_non-cosmos/ethereum/assetlist.json
+++ b/_non-cosmos/ethereum/assetlist.json
@@ -2047,6 +2047,16 @@
       "name": "Lorenzo stBTC",
       "display": "stbtc",
       "symbol": "stBTC",
+      "traces": [
+        {
+          "type": "liquid-stake",
+          "counterparty": {
+            "chain_name": "bitcoin",
+            "base_denom": "sat"
+          },
+          "provider": "Lorenzo"
+        }
+      ],
       "logo_URIs": {
         "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/_non-cosmos/ethereum/images/stbtc.svg"
       },

--- a/babylon/assetlist.json
+++ b/babylon/assetlist.json
@@ -591,6 +591,42 @@
           }
         }
       ]
+    },
+    {
+      "denom_units": [
+        {
+          "denom": "cw20:bbn1ccylwef8yfhafxpmtzq4ps24kxce9cfnz0wnkucsvf2rylfh0jzswhk5ks",
+          "exponent": 0
+        },
+        {
+          "denom": "stBTC",
+          "exponent": 18
+        }
+      ],
+      "base": "cw20:bbn1ccylwef8yfhafxpmtzq4ps24kxce9cfnz0wnkucsvf2rylfh0jzswhk5ks",
+      "address": "bbn1ccylwef8yfhafxpmtzq4ps24kxce9cfnz0wnkucsvf2rylfh0jzswhk5ks",
+      "name": "Lorenzo stBTC",
+      "display": "stBTC",
+      "symbol": "stBTC",
+      "logo_URIs": {
+        "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/_non-cosmos/ethereum/images/stbtc.svg"
+      },
+      "type_asset": "cw20",
+      "traces": [
+        {
+          "type": "ibc-bridge",
+          "provider": "Union",
+          "counterparty": {
+            "chain_name": "ethereum",
+            "base_denom": "0xf6718b2701d4a6498ef77d7c152b2137ab28b8a3",
+            "channel_id": "1"
+          },
+          "chain": {
+            "channel_id": "3",
+            "path": "0"
+          }
+        }
+      ]
     }
   ]
 }


### PR DESCRIPTION
Adds new token for Union bridged asset to Babylon. The PR consists of a new cw20 for the supported asset