### PR TITLE
feat: add WETH to bbn

### DIFF
--- a/babylon/assetlist.json
+++ b/babylon/assetlist.json
@@ -591,6 +591,42 @@
           }
         }
       ]
+    },
+    {
+      "denom_units": [
+        {
+          "denom": "cw20:bbn1300se0vwue77hn6s8wph64ey6d55zaf48jrveg9wafsquncn3e4scssgvd",
+          "exponent": 0
+        },
+        {
+          "denom": "WETH",
+          "exponent": 18
+        }
+      ],
+      "base": "cw20:bbn1300se0vwue77hn6s8wph64ey6d55zaf48jrveg9wafsquncn3e4scssgvd",
+      "address": "bbn1300se0vwue77hn6s8wph64ey6d55zaf48jrveg9wafsquncn3e4scssgvd",
+      "name": "Wrapped Ether",
+      "display": "WETH",
+      "symbol": "WETH",
+      "logo_URIs": {
+        "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/_non-cosmos/ethereum/images/weth.svg"
+      },
+      "type_asset": "cw20",
+      "traces": [
+        {
+          "type": "ibc-bridge",
+          "provider": "Union",
+          "counterparty": {
+            "chain_name": "ethereum",
+            "base_denom": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
+            "channel_id": "1"
+          },
+          "chain": {
+            "channel_id": "3",
+            "path": "0"
+          }
+        }
+      ]
     }
   ]
 }


### PR DESCRIPTION
Adds new token for Union bridged asset to Babylon. The PR consists of a new cw20 for the supported asset