### PR TITLE
use correct peer for arkeo

### DIFF
--- a/arkeo/chain.json
+++ b/arkeo/chain.json
@@ -68,7 +68,7 @@
       },
       {
         "id": "ebc272824924ea1a27ea3183dd0b9ba713494f83",
-        "address": "akash-mainnet-peer.autostake.com:27356",
+        "address": "arkeo-mainnet-peer.autostake.com:27356",
         "provider": "AutoStake \ud83d\udee1\ufe0f Slash Protected"
       }
     ]


### PR DESCRIPTION
I didn't add this, but noticed the peer was labeled wrong