### PR TITLE
**feat(testnets/_IBC): add Injective testnet ↔ XRPL EVM testnet channel (connection-281/4)**

### DIFF
--- a/testnets/_IBC/injectivetestnet-xrplevmtestnet.json
+++ b/testnets/_IBC/injectivetestnet-xrplevmtestnet.json
@@ -1,0 +1,32 @@
+{
+    "$schema": "../../ibc_data.schema.json",
+    "chain_1": {
+      "chain_name": "injectivetestnet",
+      "client_id": "07-tendermint-321",
+      "connection_id": "connection-281"
+    },
+    "chain_2": {
+      "chain_name": "xrplevmtestnet",
+      "client_id": "07-tendermint-24",
+      "connection_id": "connection-4"
+    },
+    "channels": [
+      {
+        "chain_1": {
+          "channel_id": "channel-77038",
+          "port_id": "transfer"
+        },
+        "chain_2": {
+          "channel_id": "channel-4",
+          "port_id": "transfer"
+        },
+        "ordering": "unordered",
+        "version": "ics20-1",
+        "tags": {
+          "status": "live",
+          "preferred": true,
+          "dex": "osmosis"
+        }
+      }
+    ]
+  }


### PR DESCRIPTION

### **feat(testnets/_IBC): add Injective testnet ↔ XRPL EVM testnet channel (connection-281/4)**

---

### Description

Adds the newly established **ICS-20 IBC transfer path** between the following testnets:

- **injectivetestnet**
- **xrplevmtestnet**

#### Channel Metadata

| Chain              | `client_id`         | `connection_id`     | `channel_id`     | `port_id`  |
|--------------------|---------------------|----------------------|------------------|------------|
| injectivetestnet   | `07-tendermint-321` | `connection-281`     | `channel-77038`  | `transfer` |
| xrplevmtestnet     | `07-tendermint-24`  | `connection-4`       | `channel-4`      | `transfer` |

- **Ordering:** `unordered`  
- **Version:** `ics20-1`  
- **Tags:** `live`, `preferred: true`, `dex: osmosis`

---

### File Added

```txt
testnets/_IBC/injectivetestnet-xrplevmtestnet.json
```

---

### Validation ✅

- ✔️ Schema passes `ajv` validation.
- ✔️ Both LCD endpoints return `HTTP 200` for channel query:
  ```bash
  curl -f https://injective-testnet-api.polkachu.com/ibc/core/channel/v1/channels/channel-77038/ports/transfer?format=json
  curl -f http://cosmos.testnet.xrplevm.org:1317/ibc/core/channel/v1/channels/channel-4/ports/transfer?format=json
  ```
- ✔️ Channel state is `STATE_OPEN` on both ends.
- ✔️ Ready to be relayed.

Feedback welcome 👍