### PR TITLE
feat: add satSolvBTC.e to babylon

### DIFF
--- a/_non-cosmos/ethereum/assetlist.json
+++ b/_non-cosmos/ethereum/assetlist.json
@@ -2290,6 +2290,37 @@
       "logo_URIs": {
         "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/_non-cosmos/ethereum/images/uniBTC.svg"
       }
+    },
+    {
+      "type_asset": "erc20",
+      "address": "0x17140b69FfaDfF9e87BF1D86D99119ee10AD24ff",
+      "denom_units": [
+        {
+          "denom": "0x17140b69FfaDfF9e87BF1D86D99119ee10AD24ff",
+          "exponent": 0
+        },
+        {
+          "denom": "satsolvbtc",
+          "exponent": 18
+        }
+      ],
+      "base": "0x17140b69FfaDfF9e87BF1D86D99119ee10AD24ff",
+      "name": "Satlayer SolvBTC.BBN",
+      "display": "satsolvbtc",
+      "symbol": "satSolvBTC",
+      "traces": [
+        {
+          "type": "liquid-stake",
+          "counterparty": {
+            "chain_name": "ethereum",
+            "base_denom": "0xd9d920aa40f578ab794426f5c90f6c731d159def"
+          },
+          "provider": "SatLayer"
+        }
+      ],
+      "logo_URIs": {
+        "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/_non-cosmos/ethereum/images/solvBTC.svg"
+      }
     }
   ]
 }

--- a/babylon/assetlist.json
+++ b/babylon/assetlist.json
@@ -807,6 +807,42 @@
           }
         }
       ]
+    },
+    {
+      "denom_units": [
+        {
+          "denom": "cw20:bbn1rl75n93kk075clrt72hqa7md6mwl78u28sghs380xuvlmksw6x3q07n2tc",
+          "exponent": 0
+        },
+        {
+          "denom": "satSolvBTC.e",
+          "exponent": 18
+        }
+      ],
+      "base": "cw20:bbn1rl75n93kk075clrt72hqa7md6mwl78u28sghs380xuvlmksw6x3q07n2tc",
+      "address": "bbn1rl75n93kk075clrt72hqa7md6mwl78u28sghs380xuvlmksw6x3q07n2tc",
+      "name": "SatLayer xSatSolvBTC Bridged",
+      "display": "satSolvBTC.e",
+      "symbol": "satSolvBTC.e",
+      "logo_URIs": {
+        "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/_non-cosmos/ethereum/images/solvBTC.svg"
+      },
+      "type_asset": "cw20",
+      "traces": [
+        {
+          "type": "ibc-bridge",
+          "provider": "Union",
+          "counterparty": {
+            "chain_name": "ethereum",
+            "base_denom": "0x17140b69FfaDfF9e87BF1D86D99119ee10AD24ff",
+            "channel_id": "1"
+          },
+          "chain": {
+            "channel_id": "3",
+            "path": "0"
+          }
+        }
+      ]
     }
   ]
 }


### PR DESCRIPTION
Adds new token for Union bridged asset to Babylon. The PR consists of a new cw20 for the supported asset