### PR TITLE
feat: add satLBTC.e to babylon

### DIFF
--- a/_non-cosmos/ethereum/assetlist.json
+++ b/_non-cosmos/ethereum/assetlist.json
@@ -2290,6 +2290,37 @@
       "logo_URIs": {
         "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/_non-cosmos/ethereum/images/uniBTC.svg"
       }
+    },
+    {
+      "type_asset": "erc20",
+      "address": "0x067e11Ac5471C853aea205B3C1933a5f6367152F",
+      "denom_units": [
+        {
+          "denom": "0x067e11Ac5471C853aea205B3C1933a5f6367152F",
+          "exponent": 0
+        },
+        {
+          "denom": "satlbtc",
+          "exponent": 8
+        }
+      ],
+      "base": "0x067e11Ac5471C853aea205B3C1933a5f6367152F",
+      "name": "Satlayer LBTC",
+      "display": "satlbtc",
+      "symbol": "satLBTC",
+      "traces": [
+        {
+          "type": "liquid-stake",
+          "counterparty": {
+            "chain_name": "ethereum",
+            "base_denom": "0x8236a87084f8B84306f72007F36F2618A5634494"
+          },
+          "provider": "SatLayer"
+        }
+      ],
+      "logo_URIs": {
+        "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/_non-cosmos/ethereum/images/lbtc.svg"
+      }
     }
   ]
 }

--- a/babylon/assetlist.json
+++ b/babylon/assetlist.json
@@ -807,6 +807,42 @@
           }
         }
       ]
+    },
+    {
+      "denom_units": [
+        {
+          "denom": "cw20:bbn1rluxqjaqsczmdaxl4kr0qa42pp78zszlmdrt248hel59z3fh8y9qrh4dvq",
+          "exponent": 0
+        },
+        {
+          "denom": "satLBTC.e",
+          "exponent": 8
+        }
+      ],
+      "base": "cw20:bbn1rluxqjaqsczmdaxl4kr0qa42pp78zszlmdrt248hel59z3fh8y9qrh4dvq",
+      "address": "bbn1rluxqjaqsczmdaxl4kr0qa42pp78zszlmdrt248hel59z3fh8y9qrh4dvq",
+      "name": "SatLayer LBTC Bridged",
+      "display": "satLBTC.e",
+      "symbol": "satLBTC.e",
+      "logo_URIs": {
+        "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/_non-cosmos/ethereum/images/lbtc.svg"
+      },
+      "type_asset": "cw20",
+      "traces": [
+        {
+          "type": "ibc-bridge",
+          "provider": "Union",
+          "counterparty": {
+            "chain_name": "ethereum",
+            "base_denom": "0x067e11Ac5471C853aea205B3C1933a5f6367152F",
+            "channel_id": "1"
+          },
+          "chain": {
+            "channel_id": "3",
+            "path": "0"
+          }
+        }
+      ]
     }
   ]
 }


### PR DESCRIPTION
Adds new token for Union bridged asset to Babylon. The PR consists of a new cw20 for the supported asset