### PR TITLE
Fix broken AtomScan directory URL in Web Endpoints section

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Once schemas have matured and client needs are better understood Chain Registry 
 
 ## Web Endpoints
 - https://registry.ping.pub (Update every 24H)
-- https://proxy.atomscan.com/directory/ (Update every 24H)
+- https://atomscan.com/directory (Update every 24H)
 - https://cosmoschains.thesilverfox.pro (Updated every 24H)
 
 ## APIs


### PR DESCRIPTION
Replace non-functioning proxy.atomscan.com/directory URL with the working atomscan.com/directory URL in the README.md file. The proxy URL was returning a 404 error, while the direct URL is correctly listed in the Web Interfaces section and is functioning properly. This ensures consistency across the documentation and provides users with a working resource for the Chain Registry.