### PR TITLE
Update SEDA testnet to v1.0.0

### DIFF
--- a/testnets/sedatestnet/chain.json
+++ b/testnets/sedatestnet/chain.json
@@ -34,21 +34,20 @@
     },
     "codebase": {
       "git_repo": "https://github.com/sedaprotocol/seda-chain",
-      "recommended_version": "v0.1.9",
+      "recommended_version": "v1.0.0-rc.2",
       "compatible_versions": [
-        "v0.1.7",
-        "v0.1.9"
+        "v1.0.0-rc.2"
       ],
       "binaries": {
-        "linux/amd64": "https://github.com/sedaprotocol/seda-chain/releases/download/v0.1.9/sedad-amd64",
-        "linux/arm64": "https://github.com/sedaprotocol/seda-chain/releases/download/v0.1.9/sedad-arm64"
+        "linux/amd64": "https://github.com/sedaprotocol/seda-chain/releases/download/v1.0.0-rc.2/sedad-amd64",
+        "linux/arm64": "https://github.com/sedaprotocol/seda-chain/releases/download/v1.0.0-rc.2/sedad-arm64"
       },
       "genesis": {
-        "genesis_url": "https://raw.githubusercontent.com/sedaprotocol/seda-networks/main/mainnet/genesis.json"
+        "genesis_url": "https://raw.githubusercontent.com/sedaprotocol/seda-networks/main/testnet/genesis.json"
       },
       "language": {
         "type": "go",
-        "version": "1.22.11"
+        "version": "1.23.5"
       },
       "consensus": {
         "type": "cometbft",
@@ -56,16 +55,16 @@
       },
       "sdk": {
         "type": "cosmos",
-        "version": "v0.50.12"
+        "version": "v0.50.13"
       },
       "cosmwasm": {
-        "version": "0.50.0",
+        "version": "0.53.2",
         "repo": "https://github.com/CosmWasm/wasmd",
         "enabled": true
       },
       "ibc": {
         "type": "go",
-        "version": "v8.6.1"
+        "version": "v8.7.0"
       }
     },
     "logo_URIs": {

--- a/testnets/sedatestnet/versions.json
+++ b/testnets/sedatestnet/versions.json
@@ -70,6 +70,42 @@
           "version": "v8.6.1"
         },
         "previous_version_name": "v0",
+        "next_version_name": "v1.0.0"
+      },
+      {
+        "name": "v1.0.0",
+        "tag": "v1.0.0-rc.2",
+        "height": 4636000,
+        "recommended_version": "v1.0.0-rc.2",
+        "compatible_versions": [
+          "v1.0.0-rc.2"
+        ],
+        "binaries": {
+          "linux/amd64": "https://github.com/sedaprotocol/seda-chain/releases/download/v1.0.0-rc.2/sedad-amd64",
+          "linux/arm64": "https://github.com/sedaprotocol/seda-chain/releases/download/v1.0.0-rc.2/sedad-arm64"
+        },
+        "language": {
+          "type": "go",
+          "version": "1.23.5"
+        },
+        "consensus": {
+          "type": "cometbft",
+          "version": "v0.38.17"
+        },
+        "sdk": {
+          "type": "cosmos",
+          "version": "v0.50.13"
+        },
+        "cosmwasm": {
+          "version": "0.53.2",
+          "repo": "https://github.com/CosmWasm/wasmd",
+          "enabled": true
+        },
+        "ibc": {
+          "type": "go",
+          "version": "v8.7.0"
+        },
+        "previous_version_name": "v0.1.7",
         "next_version_name": ""
       }
     ]


### PR DESCRIPTION
Reflecting the recent upgrade of SEDA Testnet to binary version v1.0.0-rc.2.