### PR TITLE
Update wardenprotocoltestnet to latest testnet

### DIFF
--- a/testnets/_IBC/cosmoshubtestnet-wardenprotocoltestnet.json
+++ b/testnets/_IBC/cosmoshubtestnet-wardenprotocoltestnet.json
@@ -1,0 +1,30 @@
+{
+  "$schema": "../../ibc_data.schema.json",
+  "chain_1": {
+    "chain_name": "cosmoshubtestnet",
+    "client_id": "07-tendermint-289",
+    "connection_id": "connection-207"
+  },
+  "chain_2": {
+    "chain_name": "wardenprotocoltestnet",
+    "client_id": "07-tendermint-0",
+    "connection_id": "connection-0"
+  },
+  "channels": [
+    {
+      "chain_1": {
+        "channel_id": "channel-373",
+        "port_id": "transfer"
+      },
+      "chain_2": {
+        "channel_id": "channel-0",
+        "port_id": "transfer"
+      },
+      "ordering": "unordered",
+      "version": "ics20-1",
+      "tags": {
+        "status": "live"
+      }
+    }
+  ]
+}

--- a/testnets/wardenprotocoltestnet/assetlist.json
+++ b/testnets/wardenprotocoltestnet/assetlist.json
@@ -3,21 +3,17 @@
   "chain_name": "wardenprotocoltestnet",
   "assets": [
     {
-      "description": "The native token of Warden Protocol Testnet",
+      "description": "Temporary staking token for Warden Protocol",
       "denom_units": [
         {
-          "denom": "uward",
+          "denom": "wSTAKE",
           "exponent": 0
-        },
-        {
-          "denom": "ward",
-          "exponent": 6
         }
       ],
-      "base": "uward",
-      "name": "Ward",
-      "display": "ward",
-      "symbol": "WARD",
+      "base": "wSTAKE",
+      "name": "wSTAKE",
+      "display": "wSTAKE",
+      "symbol": "wSTAKE",
       "logo_URIs": {
         "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/wardenprotocol/images/ward.png",
         "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/wardenprotocol/images/ward.svg"
@@ -29,6 +25,59 @@
         }
       ],
       "type_asset": "sdk.coin"
+    },
+    {
+      "description": "IBC token from Cosmos Provider network to Warden Protocol Testnet",
+      "denom_units": [
+        {
+          "denom": "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
+          "exponent": 0,
+          "aliases": [
+            "uatom"
+          ]
+        },
+        {
+          "denom": "atom",
+          "exponent": 6
+        }
+      ],
+      "type_asset": "ics20",
+      "base": "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
+      "name": "IBC atom",
+      "display": "atom",
+      "symbol": "ATOM",
+      "traces": [
+        {
+          "type": "ibc",
+          "counterparty": {
+            "chain_name": "cosmoshubtestnet",
+            "base_denom": "uatom",
+            "channel_id": "channel-373"
+          },
+          "chain": {
+            "channel_id": "channel-0",
+            "path": "transfer/channel-0/uatom"
+          }
+        }
+      ],
+      "images": [
+        {
+          "image_sync": {
+            "chain_name": "cosmoshubtestnet",
+            "base_denom": "uatom"
+          },
+          "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/cosmoshub/images/atom.png",
+          "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/cosmoshub/images/atom.svg",
+          "theme": {
+            "primary_color_hex": "#272d45"
+          }
+        }
+      ],
+      "logo_URIs": {
+        "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/cosmoshub/images/atom.png",
+        "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/cosmoshub/images/atom.svg"
+      },
+      "coingecko_id": "cosmos"
     }
   ]
 }

--- a/testnets/wardenprotocoltestnet/chain.json
+++ b/testnets/wardenprotocoltestnet/chain.json
@@ -3,75 +3,98 @@
   "chain_name": "wardenprotocoltestnet",
   "status": "live",
   "network_type": "testnet",
-  "pretty_name": "Warden Protocol Buenavista",
+  "pretty_name": "Warden Protocol Docas",
   "chain_type": "cosmos",
-  "chain_id": "buenavista-1",
+  "chain_id": "docas_10100-1",
   "bech32_prefix": "warden",
   "daemon_name": "wardend",
   "node_home": "$HOME/.warden",
   "key_algos": [
+    "ethsecp256k1",
     "secp256k1"
   ],
   "slip44": 118,
   "fees": {
     "fee_tokens": [
       {
-        "denom": "uward",
-        "fixed_min_gas_price": 0.005,
+        "denom": "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
+        "fixed_min_gas_price": 0.001,
         "low_gas_price": 0.01,
         "average_gas_price": 0.025,
-        "high_gas_price": 0.03
+        "high_gas_price": 1
       }
     ]
   },
   "staking": {
     "staking_tokens": [
       {
-        "denom": "uward"
+        "denom": "wSTAKE"
       }
     ]
   },
   "codebase": {
     "git_repo": "https://github.com/warden-protocol/wardenprotocol",
-    "recommended_version": "v0.3.0",
+    "recommended_version": "v0.6.2",
     "compatible_versions": [
-      "v0.3.0"
+      "v0.6.2"
     ],
     "consensus": {
       "type": "cometbft",
       "version": "0.38"
     },
     "genesis": {
-      "genesis_url": "https://raw.githubusercontent.com/warden-protocol/networks/main/testnets/buenavista/genesis.json"
+      "genesis_url": "https://raw.githubusercontent.com/warden-protocol/networks/main/testnets/docas/genesis.json"
     },
     "sdk": {
       "type": "cosmos",
       "version": "0.50"
     },
     "cosmwasm": {
-      "enabled": false
+      "enabled": true
     }
   },
   "peers": {
-    "seeds": [],
-    "persistent_peers": []
+    "seeds": [
+      {
+        "id": "aa5343f22f758d7838a71f456702a47e1edc2bc4",
+        "address": "3.251.9.92:26656",
+        "provider": "Warden Labs"
+      },
+      {
+        "id": "f89230b10229269f09d397db7ffc602afc6ea591",
+        "address": "52.48.66.133:26656",
+        "provider": "Warden Labs"
+      }
+    ],
+    "persistent_peers": [
+      {
+        "id": "aa5343f22f758d7838a71f456702a47e1edc2bc4",
+        "address": "3.251.9.92:26656",
+        "provider": "Warden Labs"
+      },
+      {
+        "id": "f89230b10229269f09d397db7ffc602afc6ea591",
+        "address": "52.48.66.133:26656",
+        "provider": "Warden Labs"
+      }
+    ]
   },
   "apis": {
     "rpc": [
       {
-        "address": "https://rpc.buenavista.wardenprotocol.org/",
+        "address": "https://rpc.docas.wardenprotocol.org/",
         "provider": "Warden Protocol"
       }
     ],
     "rest": [
       {
-        "address": "https://api.buenavista.wardenprotocol.org/",
+        "address": "https://api.docas.wardenprotocol.org/",
         "provider": "Warden Protocol"
       }
     ],
     "grpc": [
       {
-        "address": "https://grpc.buenavista.wardenprotocol.org/",
+        "address": "https://grpc.docas.wardenprotocol.org/",
         "provider": "Warden Protocol"
       }
     ]

--- a/testnets/wardenprotocoltestnet/versions.json
+++ b/testnets/wardenprotocoltestnet/versions.json
@@ -3,10 +3,10 @@
   "chain_name": "wardenprotocoltestnet",
   "versions": [
     {
-      "name": "v0.3.0",
-      "recommended_version": "v0.3.0",
+      "name": "v0.6.2",
+      "recommended_version": "v0.6.2",
       "compatible_versions": [
-        "v0.3.0"
+        "v0.6.2"
       ],
       "consensus": {
         "type": "cometbft",
@@ -17,8 +17,9 @@
         "version": "0.50"
       },
       "cosmwasm": {
-        "enabled": false
+        "enabled": true
       }
     }
   ]
 }
+


### PR DESCRIPTION
This will update wardenprotocoltestnet to the latest testnet that Warden Protocol has.
Buenavista-1 testnet has been deprecated.