### PR TITLE
feat(babylon): add new CW20 assets to chain registry

### DIFF
--- a/babylon/assetlist.json
+++ b/babylon/assetlist.json
@@ -703,6 +703,78 @@
     {
       "denom_units": [
         {
+          "denom": "cw20:bbn1rgsgnu9hcssn97hprmavtt58vt3qg5y4qha4ky6q09urczsuzwlss60thh",
+          "exponent": 0
+        },
+        {
+          "denom": "eBTC",
+          "exponent": 8
+        }
+      ],
+      "base": "cw20:bbn1rgsgnu9hcssn97hprmavtt58vt3qg5y4qha4ky6q09urczsuzwlss60thh",
+      "address": "bbn1rgsgnu9hcssn97hprmavtt58vt3qg5y4qha4ky6q09urczsuzwlss60thh",
+      "name": "ether.fi BTC",
+      "display": "eBTC",
+      "symbol": "eBTC",
+      "logo_URIs": {
+        "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/_non-cosmos/ethereum/images/eBTC.png"
+      },
+      "type_asset": "cw20",
+      "traces": [
+        {
+          "type": "ibc-bridge",
+          "provider": "Union",
+          "counterparty": {
+            "chain_name": "ethereum",
+            "base_denom": "0x657e8c867d8b37dcc18fa4caead9c45eb088c642",
+            "channel_id": "1"
+          },
+          "chain": {
+            "channel_id": "3",
+            "path": "0"
+          }
+        }
+      ]
+    },
+    {
+      "denom_units": [
+        {
+          "denom": "cw20:bbn1j7yz208yls9v5vcgsekwaf096wk2ysyrdn0u747868v80fd05tjsalq9ll",
+          "exponent": 0
+        },
+        {
+          "denom": "mBTC",
+          "exponent": 8
+        }
+      ],
+      "base": "cw20:bbn1j7yz208yls9v5vcgsekwaf096wk2ysyrdn0u747868v80fd05tjsalq9ll",
+      "address": "bbn1j7yz208yls9v5vcgsekwaf096wk2ysyrdn0u747868v80fd05tjsalq9ll",
+      "name": "Liquid Staked BTC",
+      "display": "mBTC",
+      "symbol": "mBTC",
+      "logo_URIs": {
+        "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/_non-cosmos/ethereum/images/mBTC.png"
+      },
+      "type_asset": "cw20",
+      "traces": [
+        {
+          "type": "ibc-bridge",
+          "provider": "Union",
+          "counterparty": {
+            "chain_name": "ethereum",
+            "base_denom": "0xbdf245957992bfbc62b07e344128a1eec7b7ee3f",
+            "channel_id": "1"
+          },
+          "chain": {
+            "channel_id": "3",
+            "path": "0"
+          }
+        }
+      ]
+    },
+    {
+      "denom_units": [
+        {
           "denom": "cw20:bbn1jr0xpgy90hqmaafdq3jtapr2p63tv59s9hcced5j4qqgs5ed9x7sr3sv0d",
           "exponent": 0
         },


### PR DESCRIPTION
Adds new tokens for Union-bridged assets on Babylon. This PR includes two new CW20 entries for the supported assets (mBTC and eBTC)