### PR TITLE
bump: gardia chain-id

### DIFF
--- a/testnets/zenrocktestnet/chain.json
+++ b/testnets/zenrocktestnet/chain.json
@@ -6,7 +6,7 @@
   "network_type": "testnet",
   "chain_type": "cosmos",
   "pretty_name": "Zenrock Gardia Testnet",
-  "chain_id": "gardia-4",
+  "chain_id": "gardia-5",
   "bech32_prefix": "zen",
   "daemon_name": "zenrockd",
   "node_home": "$HOME/.zenrockd",


### PR DESCRIPTION
This PR bumps the zenrock gardia testnet chain-id from `gardia-4` to `gardia-5`.