### PR TITLE
Add MilkyWay's milkBABY traces

### DIFF
--- a/milkyway/assetlist.json
+++ b/milkyway/assetlist.json
@@ -457,6 +457,16 @@
       "name": "milkBABY",
       "display": "milkBABY",
       "symbol": "milkBABY",
+      "traces": [
+        {
+          "type": "liquid-stake",
+          "counterparty": {
+            "chain_name": "babylon",
+            "base_denom": "ubbn"
+          },
+          "provider": "MilkyWay"
+        }
+      ],
       "logo_URIs": {
         "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/milkyway/images/milkbaby.png",
         "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/milkyway/images/milkbaby.svg"


### PR DESCRIPTION
This PR adds milkBABY's missing `traces` property.