### PR TITLE
Fixed xpla explorers url

### DIFF
--- a/xpla/chain.json
+++ b/xpla/chain.json
@@ -212,8 +212,8 @@
   },
   "explorers": [
     {
-      "kind": "explorer.xpla/mainnet",
-      "url": "https://explorer.xpla.io",
+      "kind": "explorer.xpla",
+      "url": "https://explorer.xpla.io/mainnet",
       "tx_page": "https://explorer.xpla.io/mainnet/tx/${txHash}"
     },
     {


### PR DESCRIPTION
Fix XPLA Explorer mainnet links

When accessing transaction or block information via https://explorer.xpla.io/, users encounter a "Page not found" error. This PR updates all explorer links to use the correct format: https://explorer.xpla.io/mainnet

References:

Correct explorer URL: https://explorer.xpla.io/mainnet
Chain information: https://chainlist.wtf/chain/37/

In this PR (https://github.com/cosmos/chain-registry/pull/6079), I mistakenly modified the kind instead of the url. I am now correcting that mistake.