### PR TITLE
Update pretty names for Fetch.ai and Fetch.ai Testnet; add logo to testnet

### DIFF
--- a/fetchhub/chain.json
+++ b/fetchhub/chain.json
@@ -3,7 +3,7 @@
   "chain_name": "fetchhub",
   "status": "live",
   "network_type": "mainnet",
-  "pretty_name": "Fetch.ai",
+  "pretty_name": "ASI ALLIANCE",
   "chain_type": "cosmos",
   "chain_id": "fetchhub-4",
   "bech32_prefix": "fetch",

--- a/testnets/fetchhubtestnet/chain.json
+++ b/testnets/fetchhubtestnet/chain.json
@@ -3,7 +3,7 @@
   "chain_name": "fetchhubtestnet",
   "status": "live",
   "network_type": "testnet",
-  "pretty_name": "Fetch.ai Testnet",
+  "pretty_name": "ASI Testnet",
   "chain_type": "cosmos",
   "chain_id": "dorado-1",
   "bech32_prefix": "fetch",
@@ -36,6 +36,10 @@
     "genesis": {
       "genesis_url": "https://storage.googleapis.com/fetch-ai-testnet-genesis/genesis-dorado-827201.json"
     }
+  },
+  "logo_URIs": {
+    "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/fetchhub/images/fet.png",
+    "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/fetchhub/images/fet.svg"
   },
   "peers": {
     "seeds": [


### PR DESCRIPTION
1. I changed "Fetch.ai" to "ASI Alliance". refer. [https://network.fetch.ai/docs](https://network.fetch.ai/docs)
2. I added a logo for the Fetch.ai Testnet, using the same logo as the main Fetch.ai network.