### PR TITLE
Remove dead chain-registry.netlify.com link from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,6 @@ Once schemas have matured and client needs are better understood Chain Registry 
 
 ## Web Interfaces
 - https://cosmos.directory
-- https://chain-registry.netlify.com
 - https://atomscan.com/directory
 
 ## Tooling


### PR DESCRIPTION
The link to https://chain-registry.netlify.com in the Web Interfaces section of the README was removed because the site is no longer available. Only active and relevant web interfaces are now listed.