### PR TITLE
chore: bump manifest mainnet fees

### DIFF
--- a/manifest/chain.json
+++ b/manifest/chain.json
@@ -15,10 +15,10 @@
     "fee_tokens": [
       {
         "denom": "umfx",
-        "fixed_min_gas_price": 0.05,
-        "low_gas_price": 0.5,
-        "average_gas_price": 1.0,
-        "high_gas_price": 5.0
+        "fixed_min_gas_price": 1.0,
+        "low_gas_price": 1.05,
+        "average_gas_price": 1.1,
+        "high_gas_price": 3.0
       }
     ]
   },


### PR DESCRIPTION
Align mainnet fees with testnet and devnet.

CC @chalabi2 