### PR TITLE
Update assetlist.json - Detailing lore of bernese

### DIFF
--- a/osmosis/assetlist.json
+++ b/osmosis/assetlist.json
@@ -18401,7 +18401,7 @@
       ]
     },
     {
-      "description": "Bernese Mountain Dog. Thematic dog token to have fun and be friends with all other dog tokens. Fixed supply 132M",
+      "description": "Bernese Mountain Dog — a simple dog token with a fixed supply of 132M; non-mineable, non-stakeable, no inflation, no community pool, no dev allocation; initial genesis fairdrop was a tribute to stakers and LPs of the three-headed-dog chain before it stopped.",
       "denom_units": [
         {
           "denom": "factory/osmo1s6ht8qrm8x0eg8xag5x3ckx9mse9g4se248yss/BERNESE",


### PR DESCRIPTION
as per request of the community :), adding the following text:

Bernese Mountain Dog — a simple dog token with a fixed supply of 132M; non-mineable, non-stakeable, no inflation, no community pool, no dev allocation; initial genesis fairdrop was a tribute to stakers and LPs of the three-headed-dog chain before it stopped.