### PR TITLE
Xarchain testnet RPC port fix

### DIFF
--- a/testnets/xarchaintestnet/chain.json
+++ b/testnets/xarchaintestnet/chain.json
@@ -87,13 +87,13 @@
   "apis": {
     "rpc": [
       {
-        "address": "https://cosmos01-dev.arcana.network",
+        "address": "https://cosmos01-dev.arcana.network:26650",
         "provider": "arcana"
       }
     ],
     "rest": [
       {
-        "address": "https://cosmos01-dev.arcana.network:26650",
+        "address": "https://cosmos01-dev.arcana.network",
         "provider": "arcana"
       }
     ],


### PR DESCRIPTION
Fixed the RPC url of xarchain testnet