### PR TITLE
add bitbadges grpc; add new versions v2-v6

### DIFF
--- a/bitbadges/assetlist.json
+++ b/bitbadges/assetlist.json
@@ -3,7 +3,7 @@
   "chain_name": "bitbadges",
   "assets": [
     {
-      "description": "$BADGE is the native in-app credits token for BitBadges, a platform for creating and sharing digital badges.",
+      "description": "$BADGE is the native in-app credits token for BitBadges.",
       "denom_units": [
         {
           "denom": "ubadge",

--- a/bitbadges/chain.json
+++ b/bitbadges/chain.json
@@ -31,17 +31,17 @@
   },
   "codebase": {
     "git_repo": "https://github.com/bitbadges/bitbadgeschain/",
-    "recommended_version": "v1.0-bb-mainnet",
+    "recommended_version": "v6",
     "compatible_versions": [
-      "v1.0-bb-mainnet"
+      "v6"
     ],
     "binaries": {
-      "linux/amd64": "https://github.com/BitBadges/bitbadgeschain/releases/download/v1.0-bb-mainnet/bitbadgeschain-linux-amd64",
-      "linux/arm64": "https://github.com/BitBadges/bitbadgeschain/releases/download/v1.0-bb-mainnet/bitbadgeschain-linux-arm64"
+      "linux/amd64": "https://github.com/BitBadges/bitbadgeschain/releases/download/v6/bitbadgeschain-linux-amd64",
+      "linux/arm64": "https://github.com/BitBadges/bitbadgeschain/releases/download/v6/bitbadgeschain-linux-arm64"
     },
     "sdk": {
       "type": "cosmos",
-      "version": "v0.50.10"
+      "version": "v0.50.11"
     },
     "ibc": {
       "type": "go",
@@ -94,7 +94,12 @@
         "provider": "\ud83d\ude80 WHEN MOON \ud83c\udf15 WHEN LAMBO \ud83d\udd25"
       }
     ],
-    "grpc": []
+    "grpc": [
+      {
+        "address": "http://134.122.12.165:9090",
+        "provider": "bitbadges"
+      }
+    ]
   },
   "explorers": [
     {

--- a/bitbadges/versions.json
+++ b/bitbadges/versions.json
@@ -2,7 +2,7 @@
   "$schema": "../versions.schema.json",
   "chain_name": "bitbadges",
   "versions": [
-    {
+     {
       "name": "v1.0-bb-mainnet",
       "recommended_version": "v1.0-bb-mainnet",
       "compatible_versions": [
@@ -20,6 +20,131 @@
       "sdk": {
         "type": "cosmos",
         "version": "v0.50.10"
+      },
+      "ibc": {
+        "type": "go",
+        "version": "v8.3.2"
+      },
+      "next_version_name": "v2"
+    },
+    {
+      "name": "v2",
+      "recommended_version": "v2",
+      "compatible_versions": [
+        "v2"
+      ],
+      "binaries": {
+        "linux/amd64": "https://github.com/BitBadges/bitbadgeschain/releases/download/v2/bitbadgeschain-linux-amd64",
+        "linux/arm64": "https://github.com/BitBadges/bitbadgeschain/releases/download/v2/bitbadgeschain-linux-arm64"
+      },
+      "consensus": {
+        "type": "cometbft",
+        "version": "v0.38.12",
+        "repo": "https://github.com/cometbft/cometbft"
+      },
+      "sdk": {
+        "type": "cosmos",
+        "version": "v0.50.11"
+      },
+      "ibc": {
+        "type": "go",
+        "version": "v8.3.2"
+      },
+      "next_version_name": "v3"
+    },
+     {
+      "name": "v3",
+      "recommended_version": "v3",
+      "compatible_versions": [
+        "v3"
+      ],
+      "binaries": {
+        "linux/amd64": "https://github.com/BitBadges/bitbadgeschain/releases/download/v3/bitbadgeschain-linux-amd64",
+        "linux/arm64": "https://github.com/BitBadges/bitbadgeschain/releases/download/v3/bitbadgeschain-linux-arm64"
+      },
+      "consensus": {
+        "type": "cometbft",
+        "version": "v0.38.12",
+        "repo": "https://github.com/cometbft/cometbft"
+      },
+      "sdk": {
+        "type": "cosmos",
+        "version": "v0.50.11"
+      },
+      "ibc": {
+        "type": "go",
+        "version": "v8.3.2"
+      },
+      "next_version_name": "v4"
+    },
+     {
+      "name": "v4",
+      "recommended_version": "v4",
+      "compatible_versions": [
+        "v4"
+      ],
+      "binaries": {
+        "linux/amd64": "https://github.com/BitBadges/bitbadgeschain/releases/download/v4/bitbadgeschain-linux-amd64",
+        "linux/arm64": "https://github.com/BitBadges/bitbadgeschain/releases/download/v4/bitbadgeschain-linux-arm64"
+      },
+      "consensus": {
+        "type": "cometbft",
+        "version": "v0.38.12",
+        "repo": "https://github.com/cometbft/cometbft"
+      },
+      "sdk": {
+        "type": "cosmos",
+        "version": "v0.50.11"
+      },
+      "ibc": {
+        "type": "go",
+        "version": "v8.3.2"
+      },
+      "next_version_name": "v5"
+    },
+     {
+      "name": "v5",
+      "recommended_version": "v5",
+      "compatible_versions": [
+        "v5"
+      ],
+      "binaries": {
+        "linux/amd64": "https://github.com/BitBadges/bitbadgeschain/releases/download/v5/bitbadgeschain-linux-amd64",
+        "linux/arm64": "https://github.com/BitBadges/bitbadgeschain/releases/download/v5/bitbadgeschain-linux-arm64"
+      },
+      "consensus": {
+        "type": "cometbft",
+        "version": "v0.38.12",
+        "repo": "https://github.com/cometbft/cometbft"
+      },
+      "sdk": {
+        "type": "cosmos",
+        "version": "v0.50.11"
+      },
+      "ibc": {
+        "type": "go",
+        "version": "v8.3.2"
+      },
+      "next_version_name": "v6"
+    },
+     {
+      "name": "v6",
+      "recommended_version": "v6",
+      "compatible_versions": [
+        "v6"
+      ],
+      "binaries": {
+        "linux/amd64": "https://github.com/BitBadges/bitbadgeschain/releases/download/v6/bitbadgeschain-linux-amd64",
+        "linux/arm64": "https://github.com/BitBadges/bitbadgeschain/releases/download/v6/bitbadgeschain-linux-arm64"
+      },
+      "consensus": {
+        "type": "cometbft",
+        "version": "v0.38.12",
+        "repo": "https://github.com/cometbft/cometbft"
+      },
+      "sdk": {
+        "type": "cosmos",
+        "version": "v0.50.11"
       },
       "ibc": {
         "type": "go",


### PR DESCRIPTION
This pull request updates the existing BitBadges configuration details with a newly supported grpc endpoint and adding the details about the new chain versions v2-v6.