### PR TITLE
fix: manifest block explorer urls

### DIFF
--- a/manifest/chain.json
+++ b/manifest/chain.json
@@ -71,8 +71,9 @@
   "explorers": [
     {
       "kind": "Default Explorer",
-      "url": "https://manifest.explorers.guru/",
-      "tx_page": "https://manifest.explorers.guru/transactions"
+      "url": "https://explorer.manifest.network/",
+      "tx_page": "https://explorer.manifest.network/transaction/${txHash}",
+      "account_page": "https://explorer.manifest.network/account/${accountAddress}"
     }
   ],
   "logo_URIs": {

--- a/testnets/manifestdevnet/chain.json
+++ b/testnets/manifestdevnet/chain.json
@@ -64,7 +64,8 @@
     {
       "kind": "Default Explorer",
       "url": "https://testnet.manifest.explorers.guru/",
-      "tx_page": "https://testnet.manifest.explorers.guru/transactions"
+      "tx_page": "https://testnet.manifest.explorers.guru/transaction/${txHash}",
+      "account_page": "https://testnet.manifest.explorers.guru/account/${accountAddress}"
     }
   ],
   "logo_URIs": {

--- a/testnets/manifesttestnet/chain.json
+++ b/testnets/manifesttestnet/chain.json
@@ -64,7 +64,8 @@
     {
       "kind": "Default Explorer",
       "url": "https://testnet.manifest.explorers.guru/",
-      "tx_page": "https://testnet.manifest.explorers.guru/transactions"
+      "tx_page": "https://testnet.manifest.explorers.guru/transaction/${txHash}",
+      "account_page": "https://testnet.manifest.explorers.guru/account/${accountAddress}"
     }
   ],
   "logo_URIs": {


### PR DESCRIPTION
This pull request updates the blockchain explorer URLs in multiple `chain.json` files to improve functionality by adding support for account-specific pages and refining transaction page URLs.

### Updates to blockchain explorer configurations:

* [`manifest/chain.json`](diffhunk://#diff-3576371a3e7dfa60a87f4d4c29754b9604b145dd0cda313126bb43c3cc57d4adL74-R76): Updated the mainnet explorer URLs to point to `https://explorer.manifest.network/`, added support for account-specific pages via `account_page`, and refined the transaction page URL to include `${txHash}`.
* [`testnets/manifestdevnet/chain.json`](diffhunk://#diff-0868ee64e25575090ce401ab22480cc5e16494da039b4e1f37076c5660273584L67-R68): Enhanced the devnet explorer configuration by adding an `account_page` URL and refining the transaction page URL to include `${txHash}`.
* [`testnets/manifesttestnet/chain.json`](diffhunk://#diff-09bc938be8c64ed20e52e3c20b71189849952c6d5861162918b1c91093d7e64cL67-R68): Made similar improvements to the testnet explorer configuration by introducing an `account_page` URL and updating the transaction page URL to include `${txHash}`.