### PR TITLE
xion-v19.0.2

### DIFF
--- a/testnets/xiontestnet2/assetlist.json
+++ b/testnets/xiontestnet2/assetlist.json
@@ -39,7 +39,8 @@
         "twitter": "https://x.com/burnt_xion",
         "website": "https://xion.burnt.com"
       },
-      "type_asset": "sdk.coin"
+      "type_asset": "sdk.coin",
+      "coingecko_id": "xion-2"
     },
     {
       "denom_units": [

--- a/testnets/xiontestnet2/chain.json
+++ b/testnets/xiontestnet2/chain.json
@@ -42,17 +42,17 @@
   },
   "codebase": {
     "git_repo": "https://github.com/burnt-labs/xion",
-    "tag": "v19.0.1",
-    "recommended_version": "v19.0.1",
+    "tag": "v19.0.2",
+    "recommended_version": "v19.0.2",
     "language": {
       "type": "go",
       "version": "v1.23"
     },
     "binaries": {
-      "darwin/amd64": "https://github.com/burnt-labs/xion/releases/download/v19.0.1/xiond_19.0.1_darwin_amd64.tar.gz?checksum=sha256:f350e2ab0cc08c18acce0d6518bd4f29ac88f1c331eb10d3ca43ec3e74103521",
-      "darwin/arm64": "https://github.com/burnt-labs/xion/releases/download/v19.0.1/xiond_19.0.1_darwin_arm64.tar.gz?checksum=sha256:9c2944de98c54f4e8517259d0782daca4c43900887b7d7c19044ba75b6e2976d",
-      "linux/amd64": "https://github.com/burnt-labs/xion/releases/download/v19.0.1/xiond_19.0.1_linux_amd64.tar.gz?checksum=sha256:5350ccf4fb83f086f772ceebd8a1c3788c2fa64ad1976d92052842e23a1977c3",
-      "linux/arm64": "https://github.com/burnt-labs/xion/releases/download/v19.0.1/xiond_19.0.1_linux_arm64.tar.gz?checksum=sha256:efed79d4b240c6edaa4488b54e7efcbff89313c0f0ed6e1682dab0f1d97315c2"
+      "darwin/amd64": "https://github.com/burnt-labs/xion/releases/download/v19.0.2/xiond_19.0.2_darwin_amd64.tar.gz?checksum=sha256:edda13aec2274f1eceb933874a885d055b14acbbe0de21ba61ed9c25c64813d6",
+      "darwin/arm64": "https://github.com/burnt-labs/xion/releases/download/v19.0.2/xiond_19.0.2_darwin_arm64.tar.gz?checksum=sha256:7b94d2fdf1baa1d3dff4f947858a2bac684257be27f8bf179fb973ee8dd4fdb8",
+      "linux/amd64": "https://github.com/burnt-labs/xion/releases/download/v19.0.2/xiond_19.0.2_linux_amd64.tar.gz?checksum=sha256:6072ce81d08f77f98e2d2ae7726007eca18579ea2b1690b5f76b4df782690dcb",
+      "linux/arm64": "https://github.com/burnt-labs/xion/releases/download/v19.0.2/xiond_19.0.2_linux_arm64.tar.gz?checksum=sha256:0a55360653b596da5ace43c3b4a3fef6c9785bfe0e73405f591768b449af0e70"
     },
     "sdk": {
       "type": "cosmos",

--- a/testnets/xiontestnet2/versions.json
+++ b/testnets/xiontestnet2/versions.json
@@ -188,10 +188,11 @@
     },
     {
       "name": "v19",
-      "tag": "v19.0.1",
-      "recommended_version": "v19.0.1",
+      "tag": "v19.0.2",
+      "recommended_version": "v19.0.2",
       "compatible_versions": [
-        "v19.0.1"
+        "v19.0.1",
+        "v19.0.2"
       ],
       "height": 7420000,
       "proposal": 37,
@@ -200,10 +201,10 @@
         "version": "v1.23"
       },
       "binaries": {
-        "darwin/amd64": "https://github.com/burnt-labs/xion/releases/download/v19.0.1/xiond_19.0.1_darwin_amd64.tar.gz?checksum=sha256:f350e2ab0cc08c18acce0d6518bd4f29ac88f1c331eb10d3ca43ec3e74103521",
-        "darwin/arm64": "https://github.com/burnt-labs/xion/releases/download/v19.0.1/xiond_19.0.1_darwin_arm64.tar.gz?checksum=sha256:9c2944de98c54f4e8517259d0782daca4c43900887b7d7c19044ba75b6e2976d",
-        "linux/amd64": "https://github.com/burnt-labs/xion/releases/download/v19.0.1/xiond_19.0.1_linux_amd64.tar.gz?checksum=sha256:5350ccf4fb83f086f772ceebd8a1c3788c2fa64ad1976d92052842e23a1977c3",
-        "linux/arm64": "https://github.com/burnt-labs/xion/releases/download/v19.0.1/xiond_19.0.1_linux_arm64.tar.gz?checksum=sha256:efed79d4b240c6edaa4488b54e7efcbff89313c0f0ed6e1682dab0f1d97315c2"
+        "darwin/amd64": "https://github.com/burnt-labs/xion/releases/download/v19.0.2/xiond_19.0.2_darwin_amd64.tar.gz?checksum=sha256:edda13aec2274f1eceb933874a885d055b14acbbe0de21ba61ed9c25c64813d6",
+        "darwin/arm64": "https://github.com/burnt-labs/xion/releases/download/v19.0.2/xiond_19.0.2_darwin_arm64.tar.gz?checksum=sha256:7b94d2fdf1baa1d3dff4f947858a2bac684257be27f8bf179fb973ee8dd4fdb8",
+        "linux/amd64": "https://github.com/burnt-labs/xion/releases/download/v19.0.2/xiond_19.0.2_linux_amd64.tar.gz?checksum=sha256:6072ce81d08f77f98e2d2ae7726007eca18579ea2b1690b5f76b4df782690dcb",
+        "linux/arm64": "https://github.com/burnt-labs/xion/releases/download/v19.0.2/xiond_19.0.2_linux_arm64.tar.gz?checksum=sha256:0a55360653b596da5ace43c3b4a3fef6c9785bfe0e73405f591768b449af0e70"
       },
       "sdk": {
         "type": "cosmos",

--- a/xion/chain.json
+++ b/xion/chain.json
@@ -42,17 +42,17 @@
   },
   "codebase": {
     "git_repo": "https://github.com/burnt-labs/xion",
-    "tag": "v19.0.1",
-    "recommended_version": "v19.0.1",
+    "tag": "v19.0.2",
+    "recommended_version": "v19.0.2",
     "language": {
       "type": "go",
       "version": "v1.23"
     },
     "binaries": {
-      "darwin/amd64": "https://github.com/burnt-labs/xion/releases/download/v19.0.1/xiond_19.0.1_darwin_amd64.tar.gz?checksum=sha256:f350e2ab0cc08c18acce0d6518bd4f29ac88f1c331eb10d3ca43ec3e74103521",
-      "darwin/arm64": "https://github.com/burnt-labs/xion/releases/download/v19.0.1/xiond_19.0.1_darwin_arm64.tar.gz?checksum=sha256:9c2944de98c54f4e8517259d0782daca4c43900887b7d7c19044ba75b6e2976d",
-      "linux/amd64": "https://github.com/burnt-labs/xion/releases/download/v19.0.1/xiond_19.0.1_linux_amd64.tar.gz?checksum=sha256:5350ccf4fb83f086f772ceebd8a1c3788c2fa64ad1976d92052842e23a1977c3",
-      "linux/arm64": "https://github.com/burnt-labs/xion/releases/download/v19.0.1/xiond_19.0.1_linux_arm64.tar.gz?checksum=sha256:efed79d4b240c6edaa4488b54e7efcbff89313c0f0ed6e1682dab0f1d97315c2"
+      "darwin/amd64": "https://github.com/burnt-labs/xion/releases/download/v19.0.2/xiond_19.0.2_darwin_amd64.tar.gz?checksum=sha256:edda13aec2274f1eceb933874a885d055b14acbbe0de21ba61ed9c25c64813d6",
+      "darwin/arm64": "https://github.com/burnt-labs/xion/releases/download/v19.0.2/xiond_19.0.2_darwin_arm64.tar.gz?checksum=sha256:7b94d2fdf1baa1d3dff4f947858a2bac684257be27f8bf179fb973ee8dd4fdb8",
+      "linux/amd64": "https://github.com/burnt-labs/xion/releases/download/v19.0.2/xiond_19.0.2_linux_amd64.tar.gz?checksum=sha256:6072ce81d08f77f98e2d2ae7726007eca18579ea2b1690b5f76b4df782690dcb",
+      "linux/arm64": "https://github.com/burnt-labs/xion/releases/download/v19.0.2/xiond_19.0.2_linux_arm64.tar.gz?checksum=sha256:0a55360653b596da5ace43c3b4a3fef6c9785bfe0e73405f591768b449af0e70"
     },
     "sdk": {
       "type": "cosmos",
@@ -224,12 +224,6 @@
     ]
   },
   "explorers": [
-    {
-      "kind": "Chainroot",
-      "url": "https://explorer.chainroot.io/xion",
-      "tx_page": "https://explorer.chainroot.io/xion/transactions/${txHash}",
-      "account_page": "https://explorer.chainroot.io/xion/accounts/${accountAddress}"
-    },
     {
       "kind": "mintscan",
       "url": "https://www.mintscan.io/xion",

--- a/xion/chain.json
+++ b/xion/chain.json
@@ -225,6 +225,12 @@
   },
   "explorers": [
     {
+      "kind": "Chainroot",
+      "url": "https://explorer.chainroot.io/xion",
+      "tx_page": "https://explorer.chainroot.io/xion/transactions/${txHash}",
+      "account_page": "https://explorer.chainroot.io/xion/accounts/${accountAddress}"
+    },
+    {
       "kind": "mintscan",
       "url": "https://www.mintscan.io/xion",
       "tx_page": "https://www.mintscan.io/xion/transactions/${txHash}",

--- a/xion/versions.json
+++ b/xion/versions.json
@@ -337,10 +337,11 @@
         },
         {
             "name": "v19",
-            "tag": "v19.0.1",
-            "recommended_version": "v19.0.1",
+            "tag": "v19.0.2",
+            "recommended_version": "v19.0.2",
             "compatible_versions": [
-                "v19.0.1"
+                "v19.0.1",
+                "v19.0.2"
             ],
             "height": 9150000,
             "proposal": 40,
@@ -349,10 +350,10 @@
                 "version": "v1.23"
             },
             "binaries": {
-                "darwin/amd64": "https://github.com/burnt-labs/xion/releases/download/v19.0.1/xiond_19.0.1_darwin_amd64.tar.gz?checksum=sha256:f350e2ab0cc08c18acce0d6518bd4f29ac88f1c331eb10d3ca43ec3e74103521",
-                "darwin/arm64": "https://github.com/burnt-labs/xion/releases/download/v19.0.1/xiond_19.0.1_darwin_arm64.tar.gz?checksum=sha256:9c2944de98c54f4e8517259d0782daca4c43900887b7d7c19044ba75b6e2976d",
-                "linux/amd64": "https://github.com/burnt-labs/xion/releases/download/v19.0.1/xiond_19.0.1_linux_amd64.tar.gz?checksum=sha256:5350ccf4fb83f086f772ceebd8a1c3788c2fa64ad1976d92052842e23a1977c3",
-                "linux/arm64": "https://github.com/burnt-labs/xion/releases/download/v19.0.1/xiond_19.0.1_linux_arm64.tar.gz?checksum=sha256:efed79d4b240c6edaa4488b54e7efcbff89313c0f0ed6e1682dab0f1d97315c2"
+                "darwin/amd64": "https://github.com/burnt-labs/xion/releases/download/v19.0.2/xiond_19.0.2_darwin_amd64.tar.gz?checksum=sha256:edda13aec2274f1eceb933874a885d055b14acbbe0de21ba61ed9c25c64813d6",
+                "darwin/arm64": "https://github.com/burnt-labs/xion/releases/download/v19.0.2/xiond_19.0.2_darwin_arm64.tar.gz?checksum=sha256:7b94d2fdf1baa1d3dff4f947858a2bac684257be27f8bf179fb973ee8dd4fdb8",
+                "linux/amd64": "https://github.com/burnt-labs/xion/releases/download/v19.0.2/xiond_19.0.2_linux_amd64.tar.gz?checksum=sha256:6072ce81d08f77f98e2d2ae7726007eca18579ea2b1690b5f76b4df782690dcb",
+                "linux/arm64": "https://github.com/burnt-labs/xion/releases/download/v19.0.2/xiond_19.0.2_linux_arm64.tar.gz?checksum=sha256:0a55360653b596da5ace43c3b4a3fef6c9785bfe0e73405f591768b449af0e70"
             },
             "sdk": {
                 "type": "cosmos",


### PR DESCRIPTION
This pull request updates the asset and chain configuration files for the Xion testnet and mainnet. Key changes include adding a new `coingecko_id` for an asset, updating the version tag and recommended version across multiple files, and replacing outdated binary links with links to the latest release. Additionally, the Chainroot explorer entry has been removed from the mainnet configuration.

### Asset Updates:
* Added a `coingecko_id` field (`xion-2`) to the `type_asset` object in `testnets/xiontestnet2/assetlist.json`.

### Version Updates:
* Updated version tag and recommended version from `v19.0.1` to `v19.0.2` in `testnets/xiontestnet2/chain.json`, `testnets/xiontestnet2/versions.json`, `xion/chain.json`, and `xion/versions.json`. [[1]](diffhunk://#diff-e2f5d5773a676e60da86fbb479d23f9e87ad4b79abf3b2c8fb2a19a3f190d887L45-R55) [[2]](diffhunk://#diff-73618bfabd522d42b5132861975ebc44643c112ede5cf5f002f15406a8c0ce66L191-R195) [[3]](diffhunk://#diff-13f06b2c9e92b87a2cc49f4e750541e96a2a84ed1e608080263b0f6dfaa3928eL45-R55) [[4]](diffhunk://#diff-ce8246f8bbec6815bcb0afa87e8859479ed9e5fceb32606417a72b988e21e45eL340-R344)

### Binary Links:
* Replaced outdated binary links for version `v19.0.1` with links to binaries for version `v19.0.2` in `testnets/xiontestnet2/chain.json`, `testnets/xiontestnet2/versions.json`, `xion/chain.json`, and `xion/versions.json`. [[1]](diffhunk://#diff-73618bfabd522d42b5132861975ebc44643c112ede5cf5f002f15406a8c0ce66L203-R207) [[2]](diffhunk://#diff-13f06b2c9e92b87a2cc49f4e750541e96a2a84ed1e608080263b0f6dfaa3928eL227-L232) [[3]](diffhunk://#diff-ce8246f8bbec6815bcb0afa87e8859479ed9e5fceb32606417a72b988e21e45eL352-R356)

