### PR TITLE
chore: mfx coin gecko id and version bump

### DIFF
--- a/manifest/assetlist.json
+++ b/manifest/assetlist.json
@@ -33,7 +33,8 @@
       "socials": {
         "website": "https://manifestai.org/",
         "twitter": "https://x.com/ManifestAIs/"
-      }
+      },
+      "coingecko_id": "manifest-2"
     },
     {
       "description": "Proof of Authority token for the Manifest network",

--- a/manifest/chain.json
+++ b/manifest/chain.json
@@ -31,10 +31,10 @@
   },
   "codebase": {
     "git_repo": "https://github.com/liftedinit/manifest-ledger",
-    "recommended_version": "v1.0.3",
-    "compatible_versions": ["v1.0.3"],
+    "recommended_version": "v1.0.5",
+    "compatible_versions": ["v1.0.3", "v1.0.5"],
     "binaries": {
-      "linux/amd64": "https://github.com/liftedinit/manifest-ledger/releases/download/v1.0.3/manifest-ledger-v1.0.3-linux-amd64.tar.gz"
+      "linux/amd64": "https://github.com/liftedinit/manifest-ledger/releases/download/v1.0.5/manifest-ledger-v1.0.5-linux-amd64.tar.gz"
     },
     "genesis": {
       "genesis_url": "https://nodes.liftedinit.app/manifest/rpc/genesis?"

--- a/manifest/versions.json
+++ b/manifest/versions.json
@@ -3,13 +3,14 @@
   "chain_name": "manifest",
   "versions": [
     {
-      "name": "v1.0.3",
-      "recommended_version": "v1.0.3",
+      "name": "v1.0.5",
+      "recommended_version": "v1.0.5",
       "compatible_versions": [
-        "v1.0.3"
+        "v1.0.3",
+        "v1.0.5"
       ],
       "binaries": {
-        "linux/amd64": "https://github.com/liftedinit/manifest-ledger/releases/download/v1.0.3/manifest-ledger-v1.0.3-linux-amd64.tar.gz"
+        "linux/amd64": "https://github.com/liftedinit/manifest-ledger/releases/download/v1.0.5/manifest-ledger-v1.0.5-linux-amd64.tar.gz"
       }
     }
   ]


### PR DESCRIPTION
This pull request updates the Manifest project configuration files to include metadata enhancements and support for a new version of the software. The most important changes involve adding a `coingecko_id` to the asset metadata and updating the recommended and compatible versions to include `v1.0.5`.

### Metadata Enhancements:
* [`manifest/assetlist.json`](diffhunk://#diff-812a1fd5341eb35e6dedee91b4a735ddb3de7041d659ffe41973d59562c660a3L36-R37): Added a new `coingecko_id` field with the value `"manifest-2"` to the asset metadata.

### Version Updates:
* [`manifest/chain.json`](diffhunk://#diff-3576371a3e7dfa60a87f4d4c29754b9604b145dd0cda313126bb43c3cc57d4adL34-R37): Updated the `recommended_version` to `"v1.0.5"` and added `"v1.0.5"` to the `compatible_versions` list. Also updated the binary URL to point to the new version's release.
* [`manifest/versions.json`](diffhunk://#diff-cf023ae8cf30ff12ee47f6ba699b8e031e3291c613aa1331a60ea4d1c3ddd528L6-R13): Updated the version information to include `"v1.0.5"` as the `recommended_version` and added it to the `compatible_versions` list. Updated the binary URL for the new version.