### PR TITLE
bitbadges: ustake -> ubadge

### DIFF
--- a/bitbadges/assetlist.json
+++ b/bitbadges/assetlist.json
@@ -34,36 +34,6 @@
         "twitter": "https://twitter.com/bitbadges_io"
       },
       "type_asset": "sdk.coin"
-    },
-    {
-      "description": "The native staking denom for the BitBadges blockchain.",
-      "denom_units": [
-        {
-          "denom": "ustake",
-          "exponent": 0
-        },
-        {
-          "denom": "stake",
-          "exponent": 9
-        }
-      ],
-      "base": "ustake",
-      "name": "BitBadges Staking",
-      "display": "stake",
-      "symbol": "STAKE",
-      "logo_URIs": {
-        "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/bitbadges/images/bitbadgeslogo.png"
-      },
-      "images": [
-        {
-          "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/bitbadges/images/bitbadgeslogo.png"
-        }
-      ],
-      "socials": {
-        "website": "https://bitbadges.io/",
-        "twitter": "https://twitter.com/bitbadges_io"
-      },
-      "type_asset": "sdk.coin"
     }
   ]
 }

--- a/bitbadges/chain.json
+++ b/bitbadges/chain.json
@@ -25,7 +25,7 @@
   "staking": {
     "staking_tokens": [
       {
-        "denom": "ustake"
+        "denom": "ubadge"
       }
     ]
   },


### PR DESCRIPTION
Previously, we had two different denominations for staking and gas fees. In our latest upgrade, we have merged all "ustake" into "ubadge". "ubadge" is now our staking denomination as well. 

This can be seen via https://explorer.bitbadges.io/BitBadges%20Mainnet/supply - no more "ustake" 