### PR TITLE
bitbadges: fix IBC client info

### DIFF
--- a/_IBC/bitbadges-osmosis.json
+++ b/_IBC/bitbadges-osmosis.json
@@ -2,13 +2,13 @@
   "$schema": "../ibc_data.schema.json",
   "chain_1": {
     "chain_name": "bitbadges",
-    "client_id": "07-tendermint-1",
-    "connection_id": "connection-0"
+    "client_id": "07-tendermint-2",
+    "connection_id": "connection-1"
   },
   "chain_2": {
     "chain_name": "osmosis",
-    "client_id": "07-tendermint-3497",
-    "connection_id": "connection-10745"
+    "client_id": "07-tendermint-3498",
+    "connection_id": "connection-10746"
   },
   "channels": [
     {


### PR DESCRIPTION
There was an initial mixup in the IBC configuration file in this registry. This fixes the configuration here to the actual clients used live (not an experimental one I accidentally created). This is just a registry configuration issue.

As seen with the following link, connection-1 uses 07-tendermint-2 and uses transfer/channel-104311.
https://explorer.bitbadges.io/BitBadges%20Mainnet/ibc/connection/connection-1

Whereas connection-0 isn't even open,
https://explorer.bitbadges.io/BitBadges%20Mainnet/ibc/connection/connection-0