### PR TITLE
xion mainnet release v20

### DIFF
--- a/xion/chain.json
+++ b/xion/chain.json
@@ -42,21 +42,21 @@
   },
   "codebase": {
     "git_repo": "https://github.com/burnt-labs/xion",
-    "tag": "v19.0.2",
-    "recommended_version": "v19.0.2",
+    "tag": "v20.0.0",
+    "recommended_version": "v20.0.0",
     "language": {
       "type": "go",
       "version": "v1.23"
     },
     "binaries": {
-      "darwin/amd64": "https://github.com/burnt-labs/xion/releases/download/v19.0.2/xiond_19.0.2_darwin_amd64.tar.gz?checksum=sha256:edda13aec2274f1eceb933874a885d055b14acbbe0de21ba61ed9c25c64813d6",
-      "darwin/arm64": "https://github.com/burnt-labs/xion/releases/download/v19.0.2/xiond_19.0.2_darwin_arm64.tar.gz?checksum=sha256:7b94d2fdf1baa1d3dff4f947858a2bac684257be27f8bf179fb973ee8dd4fdb8",
-      "linux/amd64": "https://github.com/burnt-labs/xion/releases/download/v19.0.2/xiond_19.0.2_linux_amd64.tar.gz?checksum=sha256:6072ce81d08f77f98e2d2ae7726007eca18579ea2b1690b5f76b4df782690dcb",
-      "linux/arm64": "https://github.com/burnt-labs/xion/releases/download/v19.0.2/xiond_19.0.2_linux_arm64.tar.gz?checksum=sha256:0a55360653b596da5ace43c3b4a3fef6c9785bfe0e73405f591768b449af0e70"
+      "darwin/amd64": "https://github.com/burnt-labs/xion/releases/download/v20.0.0/xiond_20.0.0_darwin_amd64.tar.gz?checksum=sha256:7476525f27194809a45e920bc6f7e934e64fdc58ab29007fe1f502c6cfc10265",
+      "darwin/arm64": "https://github.com/burnt-labs/xion/releases/download/v20.0.0/xiond_20.0.0_darwin_arm64.tar.gz?checksum=sha256:75ed3db62375fe0acddf72f72c2a9f7d4a70ddba2d4480bc08032caccd09a8eb",
+      "linux/amd64": "https://github.com/burnt-labs/xion/releases/download/v20.0.0/xiond_20.0.0_linux_amd64.tar.gz?checksum=sha256:a7a63a81e6a8095aa532e58f79b98164a7fbdffd0d0f6c98250880dc1c061a0b",
+      "linux/arm64": "https://github.com/burnt-labs/xion/releases/download/v20.0.0/xiond_20.0.0_linux_arm64.tar.gz?checksum=sha256:4c452a48078687b45b95710ccbe506b0e4cb186329b0bac243d3721a624a1001"
     },
     "sdk": {
       "type": "cosmos",
-      "version": "v0.53.0"
+      "version": "v0.53.3"
     },
     "consensus": {
       "type": "cometbft",

--- a/xion/versions.json
+++ b/xion/versions.json
@@ -371,6 +371,39 @@
                 "type": "go",
                 "version": "v8.7.0"
             }
+        },
+        {
+            "name": "v20",
+            "tag": "v20.0.0",
+            "recommended_version": "v20.0.0",
+            "height": 10930000,
+            "proposal": 44,
+            "language": {
+                "type": "go",
+                "version": "v1.23"
+            },
+            "binaries": {
+                "darwin/amd64": "https://github.com/burnt-labs/xion/releases/download/v20.0.0/xiond_20.0.0_darwin_amd64.tar.gz?checksum=sha256:7476525f27194809a45e920bc6f7e934e64fdc58ab29007fe1f502c6cfc10265",
+                "darwin/arm64": "https://github.com/burnt-labs/xion/releases/download/v20.0.0/xiond_20.0.0_darwin_arm64.tar.gz?checksum=sha256:75ed3db62375fe0acddf72f72c2a9f7d4a70ddba2d4480bc08032caccd09a8eb",
+                "linux/amd64": "https://github.com/burnt-labs/xion/releases/download/v20.0.0/xiond_20.0.0_linux_amd64.tar.gz?checksum=sha256:a7a63a81e6a8095aa532e58f79b98164a7fbdffd0d0f6c98250880dc1c061a0b",
+                "linux/arm64": "https://github.com/burnt-labs/xion/releases/download/v20.0.0/xiond_20.0.0_linux_arm64.tar.gz?checksum=sha256:4c452a48078687b45b95710ccbe506b0e4cb186329b0bac243d3721a624a1001"
+            },
+            "sdk": {
+                "type": "cosmos",
+                "version": "v0.53.3"
+            },
+            "consensus": {
+                "type": "cometbft",
+                "version": "v0.38.17"
+            },
+            "cosmwasm": {
+                "version": "v0.54.0",
+                "enabled": true
+            },
+            "ibc": {
+                "type": "go",
+                "version": "v8.7.0"
+            }
         }
     ]
 }


### PR DESCRIPTION
This pull request updates the Xion blockchain configuration to reflect the new `v20.0.0` release. The changes include updating version references, binaries, and associated metadata for the new release, as well as adding a new entry for `v20` in the version history.

### Updates for the `v20.0.0` release:

* **Version and binaries update in `xion/chain.json`:**
  - Updated `tag` and `recommended_version` to `v20.0.0`.
  - Updated binary URLs and checksums for `darwin/amd64`, `darwin/arm64`, `linux/amd64`, and `linux/arm64` to match the `v20.0.0` release.
  - Updated the SDK version to `v0.53.3`.

* **New `v20` entry in `xion/versions.json`:**
  - Added metadata for the `v20.0.0` release, including `tag`, `recommended_version`, block `height`, and proposal number.
  - Included updated binary URLs, SDK version (`v0.53.3`), consensus version (`v0.38.17`), CosmWasm version (`v0.54.0`), and IBC version (`v8.7.0`).