### PR TITLE
Bulk Update of Osmosis Assetlist

### DIFF
--- a/osmosis/assetlist.json
+++ b/osmosis/assetlist.json
@@ -1907,7 +1907,7 @@
       "type_asset": "ics20",
       "base": "ibc/FE2CD1E6828EC0FAB8AF39BAC45BC25B965BA67CCBC50C13A14BD610B0D1E2C4",
       "name": "bostrom",
-      "display": "boot",
+      "display": "ibc/FE2CD1E6828EC0FAB8AF39BAC45BC25B965BA67CCBC50C13A14BD610B0D1E2C4",
       "symbol": "BOOT",
       "traces": [
         {
@@ -6972,7 +6972,7 @@
       "type_asset": "ics20",
       "base": "ibc/E27CD305D33F150369AB526AEB6646A76EC3FFB1A6CA58A663B5DE657A89D55D",
       "name": "Dyson Protocol",
-      "display": "dys",
+      "display": "ibc/E27CD305D33F150369AB526AEB6646A76EC3FFB1A6CA58A663B5DE657A89D55D",
       "symbol": "DYS",
       "traces": [
         {
@@ -7475,7 +7475,7 @@
       "type_asset": "ics20",
       "base": "ibc/573FCD90FACEE750F55A8864EF7D38265F07E5A9273FA0E8DAFD39951332B580",
       "name": "Mars",
-      "display": "mars",
+      "display": "MARS.old",
       "symbol": "MARS.old",
       "traces": [
         {
@@ -12498,7 +12498,7 @@
       "type_asset": "ics20",
       "base": "ibc/4F3B0EC2FE2D370D10C3671A1B7B06D2A964C721470C305CBB846ED60E6CAA20",
       "name": "Bostrom Hydrogen",
-      "display": "hydrogen",
+      "display": "ibc/4F3B0EC2FE2D370D10C3671A1B7B06D2A964C721470C305CBB846ED60E6CAA20",
       "symbol": "HYDROGEN",
       "traces": [
         {
@@ -12543,7 +12543,7 @@
       "type_asset": "ics20",
       "base": "ibc/BCDB35B7390806F35E716D275E1E017999F8281A81B6F128F087EF34D1DFA761",
       "name": "Bostrom Tocyb",
-      "display": "tocyb",
+      "display": "ibc/BCDB35B7390806F35E716D275E1E017999F8281A81B6F128F087EF34D1DFA761",
       "symbol": "TOCYB",
       "traces": [
         {
@@ -14583,7 +14583,7 @@
       "type_asset": "ics20",
       "base": "ibc/2BF9656CAB0384A31167DB9B0254F0FB1CB4346A229BD7E5CBDCBB911C3740F7",
       "name": "Teledisko DAO - Legacy",
-      "display": "berlin-legacy",
+      "display": "berlin",
       "symbol": "BERLIN-legacy",
       "traces": [
         {
@@ -18456,7 +18456,7 @@
       "type_asset": "ics20",
       "base": "ibc/46579C587A0B8CF8B0A1FF6B0EFA2082F11876578E47FC81A9CAAD31F424AF98",
       "name": "Juris Protocol",
-      "display": "juris",
+      "display": "rakoff",
       "symbol": "JURIS",
       "traces": [
         {
@@ -22136,7 +22136,7 @@
       "type_asset": "ics20",
       "base": "ibc/3B95D63B520C283BCA86F8CD426D57584039463FD684A5CBA31D2780B86A1995",
       "name": "Dragon Coin (old)",
-      "display": "DGN",
+      "display": "OLDDGN",
       "symbol": "DGN",
       "traces": [
         {
@@ -22884,7 +22884,7 @@
       "type_asset": "ics20",
       "base": "ibc/3D00ACF371FC6B7BC871399B1909DDE18749FA19DE6B7A4F74E1D96BC073B3BC",
       "name": "wirelibertyfence",
-      "display": "WLF",
+      "display": "wirelibertyfence",
       "symbol": "WLF",
       "traces": [
         {
@@ -23528,7 +23528,7 @@
       "type_asset": "ics20",
       "base": "ibc/3C85C44DCB6BCC4FFB9D295EE79ED412E1FAD5D775C99E6AA51CCEF5CA32409C",
       "name": "Quicksilver Liquid Staked INJ",
-      "display": "qINJ",
+      "display": "qinj",
       "symbol": "qINJ",
       "traces": [
         {

--- a/osmosis/assetlist.json
+++ b/osmosis/assetlist.json
@@ -95,26 +95,10 @@
       ],
       "type_asset": "ics20",
       "base": "ibc/D189335C6E4A68B513C10AB227BF1C1D38C746766278BA3EEB4FB14124F1D858",
-      "name": "USDC (Ethereum via Axelar)",
+      "name": "USD Coin",
       "display": "usdc",
-      "symbol": "USDC.eth.axl",
+      "symbol": "USDC",
       "traces": [
-        {
-          "type": "synthetic",
-          "counterparty": {
-            "chain_name": "forex",
-            "base_denom": "USD"
-          },
-          "provider": "Circle"
-        },
-        {
-          "type": "bridge",
-          "counterparty": {
-            "chain_name": "ethereum",
-            "base_denom": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48"
-          },
-          "provider": "Axelar"
-        },
         {
           "type": "ibc",
           "counterparty": {
@@ -141,7 +125,8 @@
           "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/axelar/images/usdc.png",
           "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/axelar/images/usdc.svg"
         }
-      ]
+      ],
+      "coingecko_id": "axlusdc"
     },
     {
       "description": "Ethereum (ETH) is a decentralized, open-source blockchain system featuring smart contract functionality. It's the native cryptocurrency of the Ethereum platform, often regarded as the second most popular digital currency after Bitcoin. Ethereum was proposed in late 2013 and development was crowdfunded in 2014, leading to its network going live on 30 July 2015.\n\nETH, as a digital currency, is used for a variety of purposes within the Ethereum ecosystem, including the execution of decentralized smart contracts and as a mode of payment. Unlike Bitcoin, Ethereum was designed to be a platform for applications that can operate without the need for intermediaries, using blockchain technology. This has made Ethereum a leading platform for various applications, including decentralized finance (DeFi), non-fungible tokens (NFTs), and more. Ethereum is constantly evolving, with a significant upgrade termed Ethereum 2.0, which aims to improve its scalability, security, and sustainability.",
@@ -160,26 +145,10 @@
       ],
       "type_asset": "ics20",
       "base": "ibc/EA1D43981D5C9A1C4AAEA9C23BB1D4FA126BA9BC7020A25E0AE4AA841EA25DC5",
-      "name": "Ethereum (Axelar)",
+      "name": "Wrapped Ether",
       "display": "weth",
-      "symbol": "ETH.axl",
+      "symbol": "WETH",
       "traces": [
-        {
-          "type": "wrapped",
-          "counterparty": {
-            "chain_name": "ethereum",
-            "base_denom": "wei"
-          },
-          "provider": "Ethereum"
-        },
-        {
-          "type": "bridge",
-          "counterparty": {
-            "chain_name": "ethereum",
-            "base_denom": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2"
-          },
-          "provider": "Axelar"
-        },
         {
           "type": "ibc",
           "counterparty": {
@@ -220,7 +189,8 @@
           },
           "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/axelar/images/weth.png"
         }
-      ]
+      ],
+      "coingecko_id": "axlweth"
     },
     {
       "description": "Wrapped Bitcoin on Axelar",
@@ -239,26 +209,10 @@
       ],
       "type_asset": "ics20",
       "base": "ibc/D1542AA8762DB13087D8364F3EA6509FD6F009A34F00426AF9E4F9FA85CBBF1F",
-      "name": "Wrapped Bitcoin (Ethereum via Axelar)",
+      "name": "Wrapped Bitcoin",
       "display": "wbtc",
-      "symbol": "WBTC.eth.axl",
+      "symbol": "WBTC",
       "traces": [
-        {
-          "type": "bridge",
-          "counterparty": {
-            "chain_name": "bitcoin",
-            "base_denom": "sat"
-          },
-          "provider": "BitGo, Kyber, and Ren"
-        },
-        {
-          "type": "bridge",
-          "counterparty": {
-            "chain_name": "ethereum",
-            "base_denom": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599"
-          },
-          "provider": "Axelar"
-        },
         {
           "type": "ibc",
           "counterparty": {
@@ -290,7 +244,8 @@
           },
           "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/axelar/images/wbtc.png"
         }
-      ]
+      ],
+      "coingecko_id": "axlwbtc"
     },
     {
       "description": "Tether's USD stablecoin on Axelar",
@@ -309,26 +264,10 @@
       ],
       "type_asset": "ics20",
       "base": "ibc/8242AD24008032E457D2E12D46588FD39FB54FB29680C6C7663D296B383C37C4",
-      "name": "Tether USD (Ethereum via Axelar)",
+      "name": "Tether USD",
       "display": "usdt",
-      "symbol": "USDT.eth.axl",
+      "symbol": "USDT",
       "traces": [
-        {
-          "type": "synthetic",
-          "counterparty": {
-            "chain_name": "forex",
-            "base_denom": "USD"
-          },
-          "provider": "Tether"
-        },
-        {
-          "type": "bridge",
-          "counterparty": {
-            "chain_name": "ethereum",
-            "base_denom": "0xdac17f958d2ee523a2206206994597c13d831ec7"
-          },
-          "provider": "Axelar"
-        },
         {
           "type": "ibc",
           "counterparty": {
@@ -358,7 +297,8 @@
             "circle": true
           }
         }
-      ]
+      ],
+      "coingecko_id": "axelar-usdt"
     },
     {
       "description": "Multi-Collateral Dai, brings a lot of new and exciting features, such as support for new CDP collateral types and Dai Savings Rate.",
@@ -381,22 +321,6 @@
       "display": "dai",
       "symbol": "DAI",
       "traces": [
-        {
-          "type": "synthetic",
-          "counterparty": {
-            "chain_name": "forex",
-            "base_denom": "USD"
-          },
-          "provider": "MakerDAO"
-        },
-        {
-          "type": "bridge",
-          "counterparty": {
-            "chain_name": "ethereum",
-            "base_denom": "0x6b175474e89094c44da98b954eedeac495271d0f"
-          },
-          "provider": "Axelar"
-        },
         {
           "type": "ibc",
           "counterparty": {
@@ -444,22 +368,6 @@
       "display": "busd",
       "symbol": "BUSD",
       "traces": [
-        {
-          "type": "synthetic",
-          "counterparty": {
-            "chain_name": "forex",
-            "base_denom": "USD"
-          },
-          "provider": "Binance"
-        },
-        {
-          "type": "bridge",
-          "counterparty": {
-            "chain_name": "ethereum",
-            "base_denom": "0x4fabb145d64652a948d72533023f6e7a623c7c53"
-          },
-          "provider": "Axelar"
-        },
         {
           "type": "ibc",
           "counterparty": {
@@ -535,7 +443,8 @@
           "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/cosmoshub/images/atom.png",
           "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/cosmoshub/images/atom.svg"
         }
-      ]
+      ],
+      "coingecko_id": "cosmos"
     },
     {
       "description": "CRO is the native token of the Crypto.org Chain, referred to as Native CRO.",
@@ -593,7 +502,8 @@
             "dark_mode": true
           }
         }
-      ]
+      ],
+      "coingecko_id": "crypto-com-chain"
     },
     {
       "description": "BNB powers the BNB Chain ecosystem and is the native coin of the BNB Beacon Chain and BNB Smart Chain.",
@@ -612,29 +522,10 @@
       ],
       "type_asset": "ics20",
       "base": "ibc/F4A070A6D78496D53127EA85C094A9EC87DFC1F36071B8CCDDBD020F933D213D",
-      "name": "Binance Coin (Axelar)",
+      "name": "Wrapped BNB",
       "display": "wbnb",
-      "symbol": "BNB.axl",
+      "symbol": "WBNB",
       "traces": [
-        {
-          "type": "wrapped",
-          "counterparty": {
-            "chain_name": "binancesmartchain",
-            "base_denom": "wei"
-          },
-          "chain": {
-            "contract": "0xbb4CdB9CBd36B01bD1cBaEBF2De08d9173bc095c"
-          },
-          "provider": "Binance"
-        },
-        {
-          "type": "bridge",
-          "counterparty": {
-            "chain_name": "binancesmartchain",
-            "base_denom": "0xbb4CdB9CBd36B01bD1cBaEBF2De08d9173bc095c"
-          },
-          "provider": "Axelar"
-        },
         {
           "type": "ibc",
           "counterparty": {
@@ -688,26 +579,10 @@
       ],
       "type_asset": "ics20",
       "base": "ibc/AB589511ED0DD5FA56171A39978AFBF1371DB986EC1C3526CE138A16377E39BB",
-      "name": "Polygon (ex-MATIC) (Axelar)",
+      "name": "Wrapped Matic",
       "display": "wmatic",
-      "symbol": "POL.axl",
+      "symbol": "WMATIC",
       "traces": [
-        {
-          "type": "wrapped",
-          "counterparty": {
-            "chain_name": "polygon",
-            "base_denom": "0x0000000000000000000000000000000000001010"
-          },
-          "provider": "Polygon"
-        },
-        {
-          "type": "bridge",
-          "counterparty": {
-            "chain_name": "polygon",
-            "base_denom": "0x0d500b1d8e8ef31e21c99d1db9a6444d3adf1270"
-          },
-          "provider": "Axelar"
-        },
         {
           "type": "ibc",
           "counterparty": {
@@ -763,24 +638,8 @@
       "base": "ibc/6F62F01D913E3FFE472A38C78235B8F021B511BC6596ADFF02615C8F83D3B373",
       "name": "Avalanche",
       "display": "avax",
-      "symbol": "AVAX",
+      "symbol": "WAVAX",
       "traces": [
-        {
-          "type": "wrapped",
-          "counterparty": {
-            "chain_name": "avalanche",
-            "base_denom": "wei"
-          },
-          "provider": "Avalanche"
-        },
-        {
-          "type": "bridge",
-          "counterparty": {
-            "chain_name": "avalanche",
-            "base_denom": "0xb31f66aa3c1e785363f0875a1b74e27b85fd66c7"
-          },
-          "provider": "Axelar"
-        },
         {
           "type": "ibc",
           "counterparty": {
@@ -867,7 +726,8 @@
           "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/terra/images/luna.png",
           "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/terra/images/luna.svg"
         }
-      ]
+      ],
+      "coingecko_id": "terra-luna"
     },
     {
       "description": "The native token of JUNO Chain",
@@ -916,7 +776,8 @@
           "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/juno/images/juno.png",
           "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/juno/images/juno.svg"
         }
-      ]
+      ],
+      "coingecko_id": "juno-network"
     },
     {
       "description": "Wrapped Polkadot on Axelar",
@@ -935,26 +796,10 @@
       ],
       "type_asset": "ics20",
       "base": "ibc/3FF92D26B407FD61AE95D975712A7C319CDE28DE4D80BDC9978D935932B991D7",
-      "name": "Polkadot (Moonbeam via Axelar)",
+      "name": "Wrapped Polkadot",
       "display": "dot",
-      "symbol": "DOT.glmr.axl",
+      "symbol": "DOT",
       "traces": [
-        {
-          "type": "bridge",
-          "counterparty": {
-            "chain_name": "polkadot",
-            "base_denom": "Planck"
-          },
-          "provider": "Polkadot Parachain"
-        },
-        {
-          "type": "bridge",
-          "counterparty": {
-            "chain_name": "moonbeam",
-            "base_denom": "0xffffffff1fcacbd218edc0eba20fc2308c778080"
-          },
-          "provider": "Axelar"
-        },
         {
           "type": "ibc",
           "counterparty": {
@@ -1030,7 +875,8 @@
           "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/evmos/images/evmos.png",
           "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/evmos/images/evmos.svg"
         }
-      ]
+      ],
+      "coingecko_id": "evmos"
     },
     {
       "description": "The native staking and governance token of Kava",
@@ -1079,7 +925,8 @@
           "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/kava/images/kava.png",
           "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/kava/images/kava.svg"
         }
-      ]
+      ],
+      "coingecko_id": "kava"
     },
     {
       "description": "The native token of Secret Network",
@@ -1128,7 +975,8 @@
           "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/secretnetwork/images/scrt.png",
           "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/secretnetwork/images/scrt.svg"
         }
-      ]
+      ],
+      "coingecko_id": "secret"
     },
     {
       "description": "The USD stablecoin of Terra Classic.",
@@ -1188,7 +1036,8 @@
           "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/terra/images/ust.png",
           "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/terra/images/ust.svg"
         }
-      ]
+      ],
+      "coingecko_id": "terrausd"
     },
     {
       "description": "The native token of Stargaze",
@@ -1237,7 +1086,8 @@
           "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/stargaze/images/stars.png",
           "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/stargaze/images/stars.svg"
         }
-      ]
+      ],
+      "coingecko_id": "stargaze"
     },
     {
       "description": "The native token of Chihuahua Chain",
@@ -1286,7 +1136,8 @@
           "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/chihuahua/images/huahua.png",
           "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/chihuahua/images/huahua.svg"
         }
-      ]
+      ],
+      "coingecko_id": "chihuahua-token"
     },
     {
       "description": "The XPRT token is primarily a governance token for the Persistence chain.",
@@ -1338,7 +1189,8 @@
             "circle": true
           }
         }
-      ]
+      ],
+      "coingecko_id": "persistence"
     },
     {
       "description": "pSTAKE is a liquid staking protocol unlocking the liquidity of staked assets. Stakers of PoS tokens can stake their assets while maintaining the liquidity of these assets. Users earn staking rewards + receive 1:1 pegged staked representative tokens which can be used to generate additional yield.",
@@ -1363,34 +1215,6 @@
       "display": "pstake",
       "symbol": "PSTAKE",
       "traces": [
-        {
-          "type": "liquid-stake",
-          "counterparty": {
-            "chain_name": "persistence",
-            "base_denom": "uxprt"
-          },
-          "provider": "Persistence"
-        },
-        {
-          "type": "bridge",
-          "counterparty": {
-            "chain_name": "ethereum",
-            "base_denom": "0xfB5c6815cA3AC72Ce9F5006869AE67f18bF77006"
-          },
-          "provider": "Gravity Bridge"
-        },
-        {
-          "type": "ibc",
-          "counterparty": {
-            "chain_name": "gravitybridge",
-            "base_denom": "gravity0xfB5c6815cA3AC72Ce9F5006869AE67f18bF77006",
-            "channel_id": "channel-24"
-          },
-          "chain": {
-            "channel_id": "channel-38",
-            "path": "transfer/channel-38/gravity0xfB5c6815cA3AC72Ce9F5006869AE67f18bF77006"
-          }
-        },
         {
           "type": "ibc",
           "counterparty": {
@@ -1466,7 +1290,8 @@
           "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/akash/images/akt.png",
           "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/akash/images/akt.svg"
         }
-      ]
+      ],
+      "coingecko_id": "akash-network"
     },
     {
       "description": "REGEN coin is the token for the Regen Network Platform",
@@ -1515,7 +1340,8 @@
           "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/regen/images/regen.png",
           "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/regen/images/regen.svg"
         }
-      ]
+      ],
+      "coingecko_id": "regen"
     },
     {
       "description": "DVPN is the native token of the Sentinel Hub.",
@@ -1564,7 +1390,8 @@
           "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/sentinel/images/dvpn.png",
           "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/sentinel/images/dvpn.svg"
         }
-      ]
+      ],
+      "coingecko_id": "sentinel"
     },
     {
       "description": "The IRIS token is the native governance token for the IrisNet chain.",
@@ -1613,7 +1440,8 @@
           "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/irisnet/images/iris.png",
           "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/irisnet/images/iris.svg"
         }
-      ]
+      ],
+      "coingecko_id": "iris-network"
     },
     {
       "description": "IOV coin is the token for the Starname (IOV) Asset Name Service",
@@ -1662,7 +1490,8 @@
           "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/starname/images/iov.png",
           "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/starname/images/iov.svg"
         }
-      ]
+      ],
+      "coingecko_id": "starname"
     },
     {
       "description": "e-Money NGM staking token. In addition to earning staking rewards the token is bought back and burned based on e-Money stablecoin inflation.",
@@ -1711,7 +1540,8 @@
           "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/emoney/images/ngm.png",
           "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/emoney/images/ngm.svg"
         }
-      ]
+      ],
+      "coingecko_id": "e-money"
     },
     {
       "description": "e-Money EUR stablecoin. Audited and backed by fiat EUR deposits and government bonds.",
@@ -1760,7 +1590,8 @@
           "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/emoney/images/eeur.png",
           "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/emoney/images/eeur.svg"
         }
-      ]
+      ],
+      "coingecko_id": "e-money-eur"
     },
     {
       "description": "LIKE is the native staking and governance token of LikeCoin chain, a Decentralized Publishing Infrastructure to empower content ownership, authenticity, and provenance.",
@@ -1809,7 +1640,8 @@
           "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/likecoin/images/like.png",
           "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/likecoin/images/like.svg"
         }
-      ]
+      ],
+      "coingecko_id": "likecoin"
     },
     {
       "description": "The native token of IXO Chain",
@@ -1858,7 +1690,8 @@
           "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/impacthub/images/ixo.png",
           "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/impacthub/images/ixo.svg"
         }
-      ]
+      ],
+      "coingecko_id": "ixo"
     },
     {
       "description": "The BCNA coin is the transactional token within the BitCanna network, serving the legal cannabis industry through its payment network, supply chain and trust network.",
@@ -1907,7 +1740,8 @@
           "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/bitcanna/images/bcna.png",
           "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/bitcanna/images/bcna.svg"
         }
-      ]
+      ],
+      "coingecko_id": "bitcanna"
     },
     {
       "description": "BitSong Native Token",
@@ -1956,7 +1790,8 @@
           "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/bitsong/images/btsg.png",
           "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/bitsong/images/btsg.svg"
         }
-      ]
+      ],
+      "coingecko_id": "bitsong"
     },
     {
       "description": "The native token of Ki Chain",
@@ -2005,7 +1840,8 @@
           "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/kichain/images/xki.png",
           "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/kichain/images/xki.svg"
         }
-      ]
+      ],
+      "coingecko_id": "ki"
     },
     {
       "description": "Panacea is a public blockchain launched by MediBloc, which is the key infrastructure for reinventing the patient-centered healthcare data ecosystem",
@@ -2054,7 +1890,8 @@
           "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/panacea/images/med.png",
           "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/panacea/images/med.svg"
         }
-      ]
+      ],
+      "coingecko_id": "medibloc"
     },
     {
       "description": "The staking token of Bostrom",
@@ -2070,7 +1907,7 @@
       "type_asset": "ics20",
       "base": "ibc/FE2CD1E6828EC0FAB8AF39BAC45BC25B965BA67CCBC50C13A14BD610B0D1E2C4",
       "name": "bostrom",
-      "display": "ibc/FE2CD1E6828EC0FAB8AF39BAC45BC25B965BA67CCBC50C13A14BD610B0D1E2C4",
+      "display": "boot",
       "symbol": "BOOT",
       "traces": [
         {
@@ -2099,7 +1936,8 @@
           "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/bostrom/images/boot.png",
           "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/bostrom/images/boot.svg"
         }
-      ]
+      ],
+      "coingecko_id": "bostrom"
     },
     {
       "description": "Native Token of Comdex Protocol",
@@ -2148,7 +1986,8 @@
           "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/comdex/images/cmdx.png",
           "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/comdex/images/cmdx.svg"
         }
-      ]
+      ],
+      "coingecko_id": "comdex"
     },
     {
       "description": "Native token for the cheqd network",
@@ -2197,7 +2036,8 @@
           "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/cheqd/images/cheq.png",
           "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/cheqd/images/cheq.svg"
         }
-      ]
+      ],
+      "coingecko_id": "cheqd-network"
     },
     {
       "description": "Native token of the Lum Network",
@@ -2246,7 +2086,8 @@
           "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/lumnetwork/images/lum.png",
           "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/lumnetwork/images/lum.svg"
         }
-      ]
+      ],
+      "coingecko_id": "lum-network"
     },
     {
       "description": "The native token of Vidulum",
@@ -2265,18 +2106,10 @@
       ],
       "type_asset": "ics20",
       "base": "ibc/E7B35499CFBEB0FF5778127ABA4FB2C4B79A6B8D3D831D4379C4048C238796BD",
-      "name": "Vidulum (Vidulum)",
+      "name": "Vidulum",
       "display": "vdl",
-      "symbol": "VDL.vdl",
+      "symbol": "VDL",
       "traces": [
-        {
-          "type": "legacy-mintage",
-          "counterparty": {
-            "chain_name": "beezee",
-            "base_denom": "factory/bze13gzq40che93tgfm9kzmkpjamah5nj0j73pyhqk/uvdl"
-          },
-          "provider": "Vidulum"
-        },
         {
           "type": "ibc",
           "counterparty": {
@@ -2308,6 +2141,7 @@
           "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/vidulum/images/vdl.svg"
         }
       ],
+      "coingecko_id": "vidulum",
       "keywords": [
         "osmosis_unstable"
       ]
@@ -2359,7 +2193,8 @@
           "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/desmos/images/dsm.png",
           "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/desmos/images/dsm.svg"
         }
-      ]
+      ],
+      "coingecko_id": "desmos"
     },
     {
       "description": "Native token of Dig Chain",
@@ -2466,7 +2301,8 @@
           "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/sommelier/images/somm.png",
           "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/sommelier/images/somm.svg"
         }
-      ]
+      ],
+      "coingecko_id": "sommelier"
     },
     {
       "description": "The native token of BandChain",
@@ -2515,7 +2351,8 @@
           "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/bandchain/images/band.png",
           "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/bandchain/images/band.svg"
         }
-      ]
+      ],
+      "coingecko_id": "band-protocol"
     },
     {
       "description": "The native token of Konstellation Network",
@@ -2565,6 +2402,7 @@
           "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/konstellation/images/darc.svg"
         }
       ],
+      "coingecko_id": "darcmatter-coin",
       "keywords": [
         "osmosis_unstable"
       ]
@@ -2616,7 +2454,8 @@
           "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/umee/images/umee.png",
           "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/umee/images/umee.svg"
         }
-      ]
+      ],
+      "coingecko_id": "umee"
     },
     {
       "description": "The native token of Gravity Bridge",
@@ -2665,7 +2504,8 @@
           "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/gravitybridge/images/grav.png",
           "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/gravitybridge/images/grav.svg"
         }
-      ]
+      ],
+      "coingecko_id": "graviton"
     },
     {
       "description": "The native token of Decentr",
@@ -2714,7 +2554,8 @@
           "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/decentr/images/dec.png",
           "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/decentr/images/dec.svg"
         }
-      ]
+      ],
+      "coingecko_id": "decentr"
     },
     {
       "description": "The native token cw20 for Marble DAO on Juno Chain",
@@ -2817,7 +2658,8 @@
           "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/carbon/images/swth.png",
           "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/carbon/images/swth.svg"
         }
-      ]
+      ],
+      "coingecko_id": "switcheo"
     },
     {
       "description": "The native token of Cerberus Chain",
@@ -2867,6 +2709,7 @@
           "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/cerberus/images/crbrus.svg"
         }
       ],
+      "coingecko_id": "cerberus-2",
       "keywords": [
         "osmosis_unstable"
       ]
@@ -2888,9 +2731,9 @@
       ],
       "type_asset": "ics20",
       "base": "ibc/5D1F516200EE8C6B2354102143B78A2DEDA25EDE771AC0F8DC3C1837C8FD4447",
-      "name": "Fetch.ai (Fetch.ai)",
+      "name": "fetch-ai",
       "display": "fet",
-      "symbol": "FET.fetch",
+      "symbol": "FET",
       "traces": [
         {
           "type": "ibc",
@@ -2918,7 +2761,8 @@
           "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/fetchhub/images/fet.png",
           "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/fetchhub/images/fet.svg"
         }
-      ]
+      ],
+      "coingecko_id": "fetch-ai"
     },
     {
       "description": "The native token of Asset Mantle",
@@ -2967,7 +2811,8 @@
           "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/assetmantle/images/mntl.png",
           "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/assetmantle/images/mntl.svg"
         }
-      ]
+      ],
+      "coingecko_id": "assetmantle"
     },
     {
       "description": "The native token cw20 for Neta on Juno Chain",
@@ -3018,7 +2863,8 @@
           "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/juno/images/neta.png",
           "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/juno/images/neta.svg"
         }
-      ]
+      ],
+      "coingecko_id": "neta"
     },
     {
       "description": "The INJ token is the native governance token for the Injective chain.",
@@ -3067,7 +2913,8 @@
           "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/injective/images/inj.png",
           "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/injective/images/inj.svg"
         }
-      ]
+      ],
+      "coingecko_id": "injective-protocol"
     },
     {
       "description": "The KRW stablecoin of Terra Classic.",
@@ -3228,7 +3075,8 @@
           "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/sifchain/images/rowan.png",
           "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/sifchain/images/rowan.svg"
         }
-      ]
+      ],
+      "coingecko_id": "sifchain"
     },
     {
       "description": "The native token of Shentu",
@@ -3277,7 +3125,8 @@
           "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/shentu/images/ctk.png",
           "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/shentu/images/ctk.svg"
         }
-      ]
+      ],
+      "coingecko_id": "certik"
     },
     {
       "description": "Hope Galaxy is an NFT collection based on its own native Token $HOPE, a cw20 token on Juno chain.",
@@ -3347,18 +3196,10 @@
       ],
       "type_asset": "ics20",
       "base": "ibc/6BDB4C8CCD45033F9604E4B93ED395008A753E01EECD6992E7D1EA23D9D3B788",
-      "name": "Racoon (Juno)",
+      "name": "Racoon",
       "display": "rac",
-      "symbol": "RAC.juno",
+      "symbol": "RAC",
       "traces": [
-        {
-          "type": "additional-mintage",
-          "counterparty": {
-            "chain_name": "migaloo",
-            "base_denom": "factory/migaloo1eqntnl6tzcj9h86psg4y4h6hh05g2h9nj8e09l/urac"
-          },
-          "provider": "Racoon"
-        },
         {
           "type": "ibc-cw20",
           "counterparty": {
@@ -3387,7 +3228,8 @@
           "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/juno/images/rac.png",
           "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/juno/images/rac.svg"
         }
-      ]
+      ],
+      "coingecko_id": "racoon"
     },
     {
       "description": "Frax is a fractional-algorithmic stablecoin protocol. It aims to provide a highly scalable, decentralized, algorithmic money in place of fixed-supply assets like BTC. Additionally, FXS is the value accrual and governance token of the entire Frax ecosystem.",
@@ -3410,22 +3252,6 @@
       "display": "frax",
       "symbol": "FRAX",
       "traces": [
-        {
-          "type": "synthetic",
-          "counterparty": {
-            "chain_name": "forex",
-            "base_denom": "USD"
-          },
-          "provider": "Frax Protocol"
-        },
-        {
-          "type": "bridge",
-          "counterparty": {
-            "chain_name": "ethereum",
-            "base_denom": "0x853d955acef822db058eb8505911ed77f175b99e"
-          },
-          "provider": "Axelar"
-        },
         {
           "type": "ibc",
           "counterparty": {
@@ -3469,26 +3295,10 @@
       ],
       "type_asset": "ics20",
       "base": "ibc/C9B0D48FD2C5B91135F118FF2484551888966590D7BDC20F6A87308DBA670796",
-      "name": "Wrapped Bitcoin (Ethereum via Gravity Bridge)",
+      "name": "Wrapped Bitcoin",
       "display": "gwbtc",
-      "symbol": "WBTC.eth.grv",
+      "symbol": "WBTC",
       "traces": [
-        {
-          "type": "bridge",
-          "counterparty": {
-            "chain_name": "bitcoin",
-            "base_denom": "sat"
-          },
-          "provider": "BitGo, Kyber, and Ren"
-        },
-        {
-          "type": "bridge",
-          "counterparty": {
-            "chain_name": "ethereum",
-            "base_denom": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599"
-          },
-          "provider": "Gravity Bridge"
-        },
         {
           "type": "ibc",
           "counterparty": {
@@ -3534,26 +3344,10 @@
       ],
       "type_asset": "ics20",
       "base": "ibc/65381C5F3FD21442283D56925E62EA524DED8B6927F0FF94E21E0020954C40B5",
-      "name": "Ethereum (Gravity Bridge)",
+      "name": "Wrapped Ethereum",
       "display": "gweth",
-      "symbol": "ETH.grv",
+      "symbol": "WETH",
       "traces": [
-        {
-          "type": "wrapped",
-          "counterparty": {
-            "chain_name": "ethereum",
-            "base_denom": "wei"
-          },
-          "provider": "Ethereum"
-        },
-        {
-          "type": "bridge",
-          "counterparty": {
-            "chain_name": "ethereum",
-            "base_denom": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2"
-          },
-          "provider": "Gravity Bridge"
-        },
         {
           "type": "ibc",
           "counterparty": {
@@ -3597,26 +3391,10 @@
       ],
       "type_asset": "ics20",
       "base": "ibc/9F9B07EF9AD291167CF5700628145DE1DEB777C2CFC7907553B24446515F6D0E",
-      "name": "USDC (Ethereum via Gravity Bridge)",
+      "name": "USD Coin",
       "display": "gusdc",
-      "symbol": "USDC.eth.grv",
+      "symbol": "USDC",
       "traces": [
-        {
-          "type": "synthetic",
-          "counterparty": {
-            "chain_name": "forex",
-            "base_denom": "USD"
-          },
-          "provider": "Circle"
-        },
-        {
-          "type": "bridge",
-          "counterparty": {
-            "chain_name": "ethereum",
-            "base_denom": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48"
-          },
-          "provider": "Gravity Bridge"
-        },
         {
           "type": "ibc",
           "counterparty": {
@@ -3665,26 +3443,10 @@
       ],
       "type_asset": "ics20",
       "base": "ibc/F292A17CF920E3462C816CBE6B042E779F676CAB59096904C4C1C966413E3DF5",
-      "name": "Dai Stablecoin (Gravity Bridge)",
+      "name": "Dai Stablecoin",
       "display": "gdai",
-      "symbol": "DAI.grv",
+      "symbol": "DAI",
       "traces": [
-        {
-          "type": "synthetic",
-          "counterparty": {
-            "chain_name": "forex",
-            "base_denom": "USD"
-          },
-          "provider": "MakerDAO"
-        },
-        {
-          "type": "bridge",
-          "counterparty": {
-            "chain_name": "ethereum",
-            "base_denom": "0x6b175474e89094c44da98b954eedeac495271d0f"
-          },
-          "provider": "Gravity Bridge"
-        },
         {
           "type": "ibc",
           "counterparty": {
@@ -3728,26 +3490,10 @@
       ],
       "type_asset": "ics20",
       "base": "ibc/71B441E27F1BBB44DD0891BCD370C2794D404D60A4FFE5AECCD9B1E28BC89805",
-      "name": "Tether USD (Ethereum via Gravity Bridge)",
+      "name": "Tether USD",
       "display": "gusdt",
-      "symbol": "USDT.eth.grv",
+      "symbol": "USDT",
       "traces": [
-        {
-          "type": "synthetic",
-          "counterparty": {
-            "chain_name": "forex",
-            "base_denom": "USD"
-          },
-          "provider": "Tether"
-        },
-        {
-          "type": "bridge",
-          "counterparty": {
-            "chain_name": "ethereum",
-            "base_denom": "0xdac17f958d2ee523a2206206994597c13d831ec7"
-          },
-          "provider": "Gravity Bridge"
-        },
         {
           "type": "ibc",
           "counterparty": {
@@ -3877,7 +3623,8 @@
           "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/provenance/images/prov.png",
           "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/provenance/images/prov.svg"
         }
-      ]
+      ],
+      "coingecko_id": "hash-2"
     },
     {
       "description": "GLX is the staking token of the Galaxy Chain",
@@ -4074,7 +3821,8 @@
           "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/meme/images/meme.png",
           "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/meme/images/meme.svg"
         }
-      ]
+      ],
+      "coingecko_id": "meme-network"
     },
     {
       "description": "Profit sharing token for Another.Software validator. Hold and receive dividends from Another.Software validator commissions!",
@@ -4221,7 +3969,8 @@
           "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/terra2/images/luna.png",
           "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/terra2/images/luna.svg"
         }
-      ]
+      ],
+      "coingecko_id": "terra-luna-2"
     },
     {
       "description": "Native token of Rizon Chain",
@@ -4270,7 +4019,8 @@
           "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/rizon/images/atolo.png",
           "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/rizon/images/atolo.svg"
         }
-      ]
+      ],
+      "coingecko_id": "rizon"
     },
     {
       "description": "Governance token of Kava Lend Protocol",
@@ -4319,7 +4069,8 @@
           "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/kava/images/hard.png",
           "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/kava/images/hard.svg"
         }
-      ]
+      ],
+      "coingecko_id": "kava-lend"
     },
     {
       "description": "Governance token of Kava Swap Protocol",
@@ -4368,7 +4119,8 @@
           "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/kava/images/swp.png",
           "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/kava/images/swp.svg"
         }
-      ]
+      ],
+      "coingecko_id": "kava-swap"
     },
     {
       "description": "A blockchain-based middleware, acting as a bridge between cryptocurrency smart contracts, data feeds, APIs and traditional bank account payments.",
@@ -4387,18 +4139,10 @@
       ],
       "type_asset": "ics20",
       "base": "ibc/D3327A763C23F01EC43D1F0DB3CEFEC390C362569B6FD191F40A5192F8960049",
-      "name": "Chainlink (Axelar)",
+      "name": "Chainlink",
       "display": "link",
-      "symbol": "LINK.axl",
+      "symbol": "LINK",
       "traces": [
-        {
-          "type": "bridge",
-          "counterparty": {
-            "chain_name": "ethereum",
-            "base_denom": "0x514910771af9ca656af840dff83e8264ecf986ca"
-          },
-          "provider": "Axelar"
-        },
         {
           "type": "ibc",
           "counterparty": {
@@ -4501,14 +4245,6 @@
       "symbol": "AAVE",
       "traces": [
         {
-          "type": "bridge",
-          "counterparty": {
-            "chain_name": "ethereum",
-            "base_denom": "0x7fc66500c84a76ad7e9c93437bfc5ac33e2ddae9"
-          },
-          "provider": "Axelar"
-        },
-        {
           "type": "ibc",
           "counterparty": {
             "chain_name": "axelar",
@@ -4558,14 +4294,6 @@
       "display": "ape",
       "symbol": "APE",
       "traces": [
-        {
-          "type": "bridge",
-          "counterparty": {
-            "chain_name": "ethereum",
-            "base_denom": "0x4d224452801aced8b2f0aebe155379bb5d594381"
-          },
-          "provider": "Axelar"
-        },
         {
           "type": "ibc",
           "counterparty": {
@@ -4617,14 +4345,6 @@
       "symbol": "MKR",
       "traces": [
         {
-          "type": "bridge",
-          "counterparty": {
-            "chain_name": "ethereum",
-            "base_denom": "0x9f8f72aa9304c8b593d555f12ef6589cc3a579a2"
-          },
-          "provider": "Axelar"
-        },
-        {
           "type": "ibc",
           "counterparty": {
             "chain_name": "axelar",
@@ -4672,22 +4392,6 @@
       "symbol": "RAI",
       "traces": [
         {
-          "type": "synthetic",
-          "counterparty": {
-            "chain_name": "forex",
-            "base_denom": "USD"
-          },
-          "provider": "RAI Finance"
-        },
-        {
-          "type": "bridge",
-          "counterparty": {
-            "chain_name": "ethereum",
-            "base_denom": "0x03ab458634910aad20ef5f1c8ee96f1d6ac54919"
-          },
-          "provider": "Axelar"
-        },
-        {
           "type": "ibc",
           "counterparty": {
             "chain_name": "axelar",
@@ -4730,18 +4434,10 @@
       ],
       "type_asset": "ics20",
       "base": "ibc/19305E20681911F14D1FB275E538CDE524C3BF88CF9AE5D5F78F4D4DA05E85B2",
-      "name": "Shiba Inu (Axelar)",
+      "name": "Shiba Inu",
       "display": "shib",
-      "symbol": "SHIB.axl",
+      "symbol": "SHIB",
       "traces": [
-        {
-          "type": "bridge",
-          "counterparty": {
-            "chain_name": "ethereum",
-            "base_denom": "0x95ad61b0a150d79219dcf64e1e6cc01f0b64c4ce"
-          },
-          "provider": "Axelar"
-        },
         {
           "type": "ibc",
           "counterparty": {
@@ -4818,7 +4514,8 @@
           "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/kujira/images/kuji.png",
           "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/kujira/images/kuji.svg"
         }
-      ]
+      ],
+      "coingecko_id": "kujira"
     },
     {
       "description": "The native token of Tgrade",
@@ -4963,7 +4660,8 @@
           "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/odin/images/odin.png",
           "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/odin/images/odin.svg"
         }
-      ]
+      ],
+      "coingecko_id": "odin-protocol"
     },
     {
       "description": "GEO token for ODIN Protocol",
@@ -5088,7 +4786,7 @@
       "base": "ibc/AD185F62399F770CCCE8A36A180A77879FF6C26A0398BD3D2A74E087B0BFA121",
       "name": "LVN",
       "display": "lvn",
-      "symbol": "LVN.ki",
+      "symbol": "LVN",
       "traces": [
         {
           "type": "ibc-cw20",
@@ -5137,24 +4835,8 @@
       "base": "ibc/1E26DB0E5122AED464D98462BD384FCCB595732A66B3970AE6CE0B58BAE0FC49",
       "name": "Moonbeam",
       "display": "wglmr",
-      "symbol": "GLMR",
+      "symbol": "WGLMR",
       "traces": [
-        {
-          "type": "wrapped",
-          "counterparty": {
-            "chain_name": "moonbeam",
-            "base_denom": "Wei"
-          },
-          "provider": "Moonbeam"
-        },
-        {
-          "type": "bridge",
-          "counterparty": {
-            "chain_name": "moonbeam",
-            "base_denom": "0xacc15dc74880c9944775448304b263d191c6077f"
-          },
-          "provider": "Axelar"
-        },
         {
           "type": "ibc",
           "counterparty": {
@@ -5200,18 +4882,10 @@
       ],
       "type_asset": "ics20",
       "base": "ibc/52C57FCA7D6854AA178E7A183DDBE4EF322B904B1D719FC485F6FFBC1F72A19E",
-      "name": "Gelotto (Juno)",
+      "name": "Gelotto",
       "display": "glto",
-      "symbol": "GLTO.juno",
+      "symbol": "GLTO",
       "traces": [
-        {
-          "type": "legacy-mintage",
-          "counterparty": {
-            "chain_name": "ethereum",
-            "base_denom": "0xd73175f9eb15eee81745d367ae59309Ca2ceb5e2"
-          },
-          "provider": "Gelotto"
-        },
         {
           "type": "ibc-cw20",
           "counterparty": {
@@ -5460,7 +5134,8 @@
             "dark_mode": false
           }
         }
-      ]
+      ],
+      "coingecko_id": "oraichain-token"
     },
     {
       "description": "The native token of the Cudos blockchain",
@@ -5510,7 +5185,8 @@
           "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/cudos/images/cudos.png",
           "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/cudos/images/cudos.svg"
         }
-      ]
+      ],
+      "coingecko_id": "cudos"
     },
     {
       "description": "The native stablecoin of Kava",
@@ -5559,7 +5235,8 @@
           "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/kava/images/usdx.png",
           "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/kava/images/usdx.svg"
         }
-      ]
+      ],
+      "coingecko_id": "usdx"
     },
     {
       "description": "BLD is the token used to secure the Agoric chain through staking and to backstop Inter Protocol.",
@@ -5608,7 +5285,8 @@
           "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/agoric/images/bld.png",
           "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/agoric/images/bld.svg"
         }
-      ]
+      ],
+      "coingecko_id": "agoric"
     },
     {
       "description": "IST is the stable token used by the Agoric chain for execution fees and commerce.",
@@ -5657,7 +5335,8 @@
           "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/agoric/images/ist.png",
           "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/agoric/images/ist.svg"
         }
-      ]
+      ],
+      "coingecko_id": "inter-stable-token"
     },
     {
       "description": "Staking derivative seJUNO for staked JUNO",
@@ -5808,7 +5487,8 @@
           "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/stride/images/strd.png",
           "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/stride/images/strd.svg"
         }
-      ]
+      ],
+      "coingecko_id": "stride"
     },
     {
       "denom_units": [
@@ -5830,14 +5510,6 @@
       "display": "statom",
       "symbol": "stATOM",
       "traces": [
-        {
-          "type": "liquid-stake",
-          "counterparty": {
-            "chain_name": "cosmoshub",
-            "base_denom": "uatom"
-          },
-          "provider": "Stride"
-        },
         {
           "type": "ibc",
           "counterparty": {
@@ -5864,7 +5536,8 @@
           "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/stride/images/statom.png",
           "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/stride/images/statom.svg"
         }
-      ]
+      ],
+      "coingecko_id": "stride-staked-atom"
     },
     {
       "denom_units": [
@@ -5886,14 +5559,6 @@
       "display": "ststars",
       "symbol": "stSTARS",
       "traces": [
-        {
-          "type": "liquid-stake",
-          "counterparty": {
-            "chain_name": "stargaze",
-            "base_denom": "ustars"
-          },
-          "provider": "Stride"
-        },
         {
           "type": "ibc",
           "counterparty": {
@@ -5920,7 +5585,8 @@
           "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/stride/images/ststars.png",
           "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/stride/images/ststars.svg"
         }
-      ]
+      ],
+      "coingecko_id": "stride-staked-stars"
     },
     {
       "description": "Solarbank DAO Governance Token for speeding up the shift to renewable and green energy",
@@ -6071,7 +5737,8 @@
           "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/axelar/images/axl.png",
           "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/axelar/images/axl.svg"
         }
-      ]
+      ],
+      "coingecko_id": "axelar"
     },
     {
       "description": "REBUS, the native coin of the Rebus chain.",
@@ -6120,7 +5787,8 @@
           "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/rebus/images/rebus.png",
           "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/rebus/images/rebus.svg"
         }
-      ]
+      ],
+      "coingecko_id": "rebus"
     },
     {
       "description": "The native token of Teritori",
@@ -6169,7 +5837,8 @@
           "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/teritori/images/utori.png",
           "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/teritori/images/utori.svg"
         }
-      ]
+      ],
+      "coingecko_id": "teritori"
     },
     {
       "denom_units": [
@@ -6191,14 +5860,6 @@
       "display": "stjuno",
       "symbol": "stJUNO",
       "traces": [
-        {
-          "type": "liquid-stake",
-          "counterparty": {
-            "chain_name": "juno",
-            "base_denom": "ujuno"
-          },
-          "provider": "Stride"
-        },
         {
           "type": "ibc",
           "counterparty": {
@@ -6225,7 +5886,8 @@
           "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/stride/images/stjuno.png",
           "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/stride/images/stjuno.svg"
         }
-      ]
+      ],
+      "coingecko_id": "stride-staked-juno"
     },
     {
       "denom_units": [
@@ -6247,14 +5909,6 @@
       "display": "stosmo",
       "symbol": "stOSMO",
       "traces": [
-        {
-          "type": "liquid-stake",
-          "counterparty": {
-            "chain_name": "osmosis",
-            "base_denom": "uosmo"
-          },
-          "provider": "Stride"
-        },
         {
           "type": "ibc",
           "counterparty": {
@@ -6281,7 +5935,8 @@
           "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/stride/images/stosmo.png",
           "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/stride/images/stosmo.svg"
         }
-      ]
+      ],
+      "coingecko_id": "stride-staked-osmo"
     },
     {
       "description": "The native token cw20 for MuseDAO on Juno Chain",
@@ -6379,7 +6034,8 @@
           "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/lambda/images/lambda.png",
           "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/lambda/images/lambda.svg"
         }
-      ]
+      ],
+      "coingecko_id": "lambda"
     },
     {
       "description": "The native over-collateralized stablecoin from the Kujira chain.",
@@ -6428,7 +6084,8 @@
           "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/kujira/images/usk.png",
           "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/kujira/images/usk.svg"
         }
-      ]
+      ],
+      "coingecko_id": "usk"
     },
     {
       "description": "Staking and governance coin for the Unification Blockchain",
@@ -6477,7 +6134,8 @@
           "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/unification/images/fund.svg",
           "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/unification/images/fund.png"
         }
-      ]
+      ],
+      "coingecko_id": "unification"
     },
     {
       "description": "The native staking and governance token of Jackal.",
@@ -6526,7 +6184,8 @@
           "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/jackal/images/jkl.png",
           "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/jackal/images/jkl.svg"
         }
-      ]
+      ],
+      "coingecko_id": "jackal-protocol"
     },
     {
       "description": "The native token cw20 for Alter on Secret Network",
@@ -6731,7 +6390,8 @@
           "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/secretnetwork/images/sienna.png",
           "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/secretnetwork/images/sienna.svg"
         }
-      ]
+      ],
+      "coingecko_id": "sienna"
     },
     {
       "description": "The native token cw20 for SCRT Staking Derivatives on Secret Network",
@@ -6782,7 +6442,8 @@
           "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/secretnetwork/images/stkd-scrt.png",
           "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/secretnetwork/images/stkd-scrt.svg"
         }
-      ]
+      ],
+      "coingecko_id": "stkd-scrt"
     },
     {
       "description": "BeeZee native blockchain",
@@ -6831,7 +6492,8 @@
           "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/beezee/images/bze.png",
           "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/beezee/images/bze.svg"
         }
-      ]
+      ],
+      "coingecko_id": "bzedge"
     },
     {
       "description": "The native token cw20 for Fanfury on Juno Chain",
@@ -6850,18 +6512,10 @@
       ],
       "type_asset": "ics20",
       "base": "ibc/7CE5F388D661D82A0774E47B5129DA51CC7129BD1A70B5FA6BCEBB5B0A2FAEAF",
-      "name": "furya (Juno)",
+      "name": "FURY.legacy",
       "display": "fury",
-      "symbol": "FURY.juno",
+      "symbol": "FURY.legacy",
       "traces": [
-        {
-          "type": "legacy-mintage",
-          "counterparty": {
-            "chain_name": "furya",
-            "base_denom": "ufury"
-          },
-          "provider": "Fanfury"
-        },
         {
           "type": "ibc-cw20",
           "counterparty": {
@@ -6986,7 +6640,8 @@
           "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/comdex/images/cmst.png",
           "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/comdex/images/cmst.svg"
         }
-      ]
+      ],
+      "coingecko_id": "composite"
     },
     {
       "description": "The native EVM, governance and staking token of the Imversed",
@@ -7137,6 +6792,7 @@
           "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/juno/images/phmn.svg"
         }
       ],
+      "coingecko_id": "posthuman",
       "socials": {
         "website": "https://posthuman.digital/",
         "twitter": "https://twitter.com/POSTHUMAN_DVS"
@@ -7241,6 +6897,7 @@
           "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/onomy/images/nom.svg"
         }
       ],
+      "coingecko_id": "onomy-protocol",
       "keywords": [
         "dex",
         "stablecoin",
@@ -7273,14 +6930,6 @@
       "symbol": "stkATOM",
       "traces": [
         {
-          "type": "liquid-stake",
-          "counterparty": {
-            "chain_name": "cosmoshub",
-            "base_denom": "uatom"
-          },
-          "provider": "pSTAKE"
-        },
-        {
           "type": "ibc",
           "counterparty": {
             "chain_name": "persistence",
@@ -7306,7 +6955,8 @@
           "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/persistence/images/stkatom.png",
           "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/persistence/images/stkatom.svg"
         }
-      ]
+      ],
+      "coingecko_id": "stkatom"
     },
     {
       "description": "The native staking and governance token of the Dyson Protocol",
@@ -7322,7 +6972,7 @@
       "type_asset": "ics20",
       "base": "ibc/E27CD305D33F150369AB526AEB6646A76EC3FFB1A6CA58A663B5DE657A89D55D",
       "name": "Dyson Protocol",
-      "display": "ibc/E27CD305D33F150369AB526AEB6646A76EC3FFB1A6CA58A663B5DE657A89D55D",
+      "display": "dys",
       "symbol": "DYS",
       "traces": [
         {
@@ -7500,7 +7150,8 @@
           "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/planq/images/planq.png",
           "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/planq/images/planq.svg"
         }
-      ]
+      ],
+      "coingecko_id": "planq"
     },
     {
       "description": "Fantom's native utility token — FTM — powers the entire Fantom blockchain ecosystem. FTM tokens are used for staking, governance, payments, and fees on the network.",
@@ -7521,27 +7172,8 @@
       "base": "ibc/5E2DFDF1734137302129EA1C1BA21A580F96F778D4F021815EA4F6DB378DA1A4",
       "name": "Fantom",
       "display": "ftm",
-      "symbol": "FTM",
+      "symbol": "WFTM",
       "traces": [
-        {
-          "type": "wrapped",
-          "counterparty": {
-            "chain_name": "fantom",
-            "base_denom": "wei"
-          },
-          "chain": {
-            "contract": "0x21be370D5312f44cB42ce377BC9b8a0cEF1A4C83"
-          },
-          "provider": "Fantom"
-        },
-        {
-          "type": "bridge",
-          "counterparty": {
-            "chain_name": "fantom",
-            "base_denom": "0x21be370D5312f44cB42ce377BC9b8a0cEF1A4C83"
-          },
-          "provider": "Axelar"
-        },
         {
           "type": "ibc",
           "counterparty": {
@@ -7617,7 +7249,8 @@
           "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/canto/images/canto.png",
           "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/canto/images/canto.svg"
         }
-      ]
+      ],
+      "coingecko_id": "canto"
     },
     {
       "description": "Quicksilver Liquid Staked STARS",
@@ -7641,14 +7274,6 @@
       "display": "qstars",
       "symbol": "qSTARS",
       "traces": [
-        {
-          "type": "liquid-stake",
-          "counterparty": {
-            "chain_name": "stargaze",
-            "base_denom": "ustars"
-          },
-          "provider": "Quicksilver"
-        },
         {
           "type": "ibc",
           "counterparty": {
@@ -7745,34 +7370,10 @@
       ],
       "type_asset": "ics20",
       "base": "ibc/231FD77ECCB2DB916D314019DA30FE013202833386B1908A191D16989AD80B5A",
-      "name": "USDC (Ethereum) (Polygon via Axelar)",
+      "name": "USD Coin from Polygon",
       "display": "polygon-usdc",
-      "symbol": "USDC.e.matic.axl",
+      "symbol": "USDC",
       "traces": [
-        {
-          "type": "synthetic",
-          "counterparty": {
-            "chain_name": "forex",
-            "base_denom": "USD"
-          },
-          "provider": "Circle"
-        },
-        {
-          "type": "bridge",
-          "counterparty": {
-            "chain_name": "ethereum",
-            "base_denom": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48"
-          },
-          "provider": "Polygon PoS Bridge"
-        },
-        {
-          "type": "bridge",
-          "counterparty": {
-            "chain_name": "polygon",
-            "base_denom": "0x2791Bca1f2de4661ED88A30C99A7a9449Aa84174"
-          },
-          "provider": "Axelar"
-        },
         {
           "type": "ibc",
           "counterparty": {
@@ -7821,34 +7422,10 @@
       ],
       "type_asset": "ics20",
       "base": "ibc/F17C9CA112815613C5B6771047A093054F837C3020CBA59DFFD9D780A8B2984C",
-      "name": "USDC (Avalanche via Axelar)",
+      "name": "USD Coin from Avalanche",
       "display": "avalanche-usdc",
-      "symbol": "USDC.avax.axl",
+      "symbol": "USDC",
       "traces": [
-        {
-          "type": "synthetic",
-          "counterparty": {
-            "chain_name": "forex",
-            "base_denom": "USD"
-          },
-          "provider": "Circle"
-        },
-        {
-          "type": "additional-mintage",
-          "counterparty": {
-            "chain_name": "ethereum",
-            "base_denom": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48"
-          },
-          "provider": "Circle"
-        },
-        {
-          "type": "bridge",
-          "counterparty": {
-            "chain_name": "avalanche",
-            "base_denom": "0xB97EF9Ef8734C71904D8002F8b6Bc66Dd9c48a6E"
-          },
-          "provider": "Axelar"
-        },
         {
           "type": "ibc",
           "counterparty": {
@@ -7897,18 +7474,10 @@
       ],
       "type_asset": "ics20",
       "base": "ibc/573FCD90FACEE750F55A8864EF7D38265F07E5A9273FA0E8DAFD39951332B580",
-      "name": "Mars Protocol (Mars Hub)",
-      "display": "MARS.old",
-      "symbol": "MARS.mars",
+      "name": "Mars",
+      "display": "mars",
+      "symbol": "MARS.old",
       "traces": [
-        {
-          "type": "legacy-mintage",
-          "counterparty": {
-            "chain_name": "neutron",
-            "base_denom": "factory/neutron1ndu2wvkrxtane8se2tr48gv7nsm46y5gcqjhux/MARS"
-          },
-          "provider": "Mars Hub"
-        },
         {
           "type": "ibc",
           "counterparty": {
@@ -7935,7 +7504,8 @@
           "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/mars/images/mars-token-ibc.png",
           "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/mars/images/mars-token-ibc.svg"
         }
-      ]
+      ],
+      "coingecko_id": "mars-protocol-a7fcbcfb-fd61-4017-92f0-7ee9f9cc6da3"
     },
     {
       "description": "Ciento Exchange Token",
@@ -8007,14 +7577,6 @@
       "symbol": "stLUNA",
       "traces": [
         {
-          "type": "liquid-stake",
-          "counterparty": {
-            "chain_name": "terra2",
-            "base_denom": "uluna"
-          },
-          "provider": "Stride"
-        },
-        {
           "type": "ibc",
           "counterparty": {
             "chain_name": "stride",
@@ -8062,14 +7624,6 @@
       "display": "stevmos",
       "symbol": "stEVMOS",
       "traces": [
-        {
-          "type": "liquid-stake",
-          "counterparty": {
-            "chain_name": "evmos",
-            "base_denom": "aevmos"
-          },
-          "provider": "Stride"
-        },
         {
           "type": "ibc",
           "counterparty": {
@@ -8222,14 +7776,6 @@
       "symbol": "qATOM",
       "traces": [
         {
-          "type": "liquid-stake",
-          "counterparty": {
-            "chain_name": "cosmoshub",
-            "base_denom": "uatom"
-          },
-          "provider": "Quicksilver"
-        },
-        {
           "type": "ibc",
           "counterparty": {
             "chain_name": "quicksilver",
@@ -8328,14 +7874,6 @@
       "display": "qregen",
       "symbol": "qREGEN",
       "traces": [
-        {
-          "type": "liquid-stake",
-          "counterparty": {
-            "chain_name": "regen",
-            "base_denom": "uregen"
-          },
-          "provider": "Quicksilver"
-        },
         {
           "type": "ibc",
           "counterparty": {
@@ -8459,7 +7997,8 @@
           },
           "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/quicksilver/images/qck.png"
         }
-      ]
+      ],
+      "coingecko_id": "quicksilver"
     },
     {
       "description": "The native token of Arkhadian",
@@ -8535,14 +8074,6 @@
       "display": "qosmo",
       "symbol": "qOSMO",
       "traces": [
-        {
-          "type": "liquid-stake",
-          "counterparty": {
-            "chain_name": "osmosis",
-            "base_denom": "uosmo"
-          },
-          "provider": "Quicksilver"
-        },
         {
           "type": "ibc",
           "counterparty": {
@@ -8668,7 +8199,8 @@
           "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/migaloo/images/white-whale.png",
           "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/migaloo/images/white-whale.svg"
         }
-      ]
+      ],
+      "coingecko_id": "white-whale"
     },
     {
       "description": "Evmos Guardians governance token.",
@@ -8917,7 +8449,8 @@
           "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/regen/images/nct.png",
           "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/regen/images/nct.svg"
         }
-      ]
+      ],
+      "coingecko_id": "toucan-protocol-nature-carbon-tonne"
     },
     {
       "description": "Celestims",
@@ -9309,7 +8842,8 @@
           "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/omniflixhub/images/flix.png",
           "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/omniflixhub/images/flix.svg"
         }
-      ]
+      ],
+      "coingecko_id": "omniflix-network"
     },
     {
       "description": "Spacer",
@@ -9458,7 +8992,8 @@
           "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/secretnetwork/images/silk.png",
           "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/secretnetwork/images/silk.svg"
         }
-      ]
+      ],
+      "coingecko_id": "silk-bcec1136-561c-4706-a42c-8b67d0d7f7d2"
     },
     {
       "description": "Mille: the 1000th token on osmosis",
@@ -9575,26 +9110,10 @@
       ],
       "type_asset": "ics20",
       "base": "ibc/18FB5C09D9D2371F659D4846A956FA56225E377EE3C3652A2BF3542BF809159D",
-      "name": "Filecoin (Axelar)",
+      "name": "Wrapped FIL from Filecoin",
       "display": "fil",
-      "symbol": "FIL.axl",
+      "symbol": "axlFIL",
       "traces": [
-        {
-          "type": "wrapped",
-          "counterparty": {
-            "chain_name": "filecoin",
-            "base_denom": "attoFIL"
-          },
-          "provider": "Filecoin"
-        },
-        {
-          "type": "bridge",
-          "counterparty": {
-            "chain_name": "filecoin",
-            "base_denom": "0x60E1773636CF5E4A227d9AC24F20fEca034ee25A"
-          },
-          "provider": "Axelar"
-        },
         {
           "type": "ibc",
           "counterparty": {
@@ -9721,7 +9240,8 @@
           "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/secretnetwork/images/shd.png",
           "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/secretnetwork/images/shd.svg"
         }
-      ]
+      ],
+      "coingecko_id": "shade-protocol"
     },
     {
       "description": "The native token of Bluzelle",
@@ -9774,6 +9294,7 @@
           "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/bluzelle/images/bluzelle.svg"
         }
       ],
+      "coingecko_id": "bluzelle",
       "keywords": [
         "bluzelle",
         "game"
@@ -9796,18 +9317,10 @@
       ],
       "type_asset": "ics20",
       "base": "ibc/10E5E5B06D78FFBB61FD9F89209DEE5FD4446ED0550CBB8E3747DA79E10D9DC6",
-      "name": "Arbitrum (Axelar)",
+      "name": "Arbitrum",
       "display": "arb",
-      "symbol": "ARB.axl",
+      "symbol": "ARB",
       "traces": [
-        {
-          "type": "bridge",
-          "counterparty": {
-            "chain_name": "arbitrum",
-            "base_denom": "0x912CE59144191C1204E64559FE8253a0e49E6548"
-          },
-          "provider": "Axelar"
-        },
         {
           "type": "ibc",
           "counterparty": {
@@ -9952,18 +9465,10 @@
       ],
       "type_asset": "ics20",
       "base": "ibc/E47F4E97C534C95B942729E1B25DBDE111EA791411CFF100515050BEA0AC0C6B",
-      "name": "Pepe (Axelar)",
+      "name": "Pepe",
       "display": "pepe",
-      "symbol": "PEPE.axl",
+      "symbol": "PEPE",
       "traces": [
-        {
-          "type": "bridge",
-          "counterparty": {
-            "chain_name": "ethereum",
-            "base_denom": "0x6982508145454Ce325dDbE47a25d4ec3d2311933"
-          },
-          "provider": "Axelar"
-        },
         {
           "type": "ibc",
           "counterparty": {
@@ -10045,22 +9550,6 @@
       "symbol": "cbETH",
       "traces": [
         {
-          "type": "liquid-stake",
-          "counterparty": {
-            "chain_name": "ethereum",
-            "base_denom": "wei"
-          },
-          "provider": "Coinbase"
-        },
-        {
-          "type": "bridge",
-          "counterparty": {
-            "chain_name": "ethereum",
-            "base_denom": "0xbe9895146f7af43049ca1c1ae358b0541ea49704"
-          },
-          "provider": "Axelar"
-        },
-        {
           "type": "ibc",
           "counterparty": {
             "chain_name": "axelar",
@@ -10108,22 +9597,6 @@
       "display": "reth",
       "symbol": "rETH",
       "traces": [
-        {
-          "type": "liquid-stake",
-          "counterparty": {
-            "chain_name": "ethereum",
-            "base_denom": "wei"
-          },
-          "provider": "Rocket Pool"
-        },
-        {
-          "type": "bridge",
-          "counterparty": {
-            "chain_name": "ethereum",
-            "base_denom": "0xae78736cd615f374d3085123a210448e74fc6393"
-          },
-          "provider": "Axelar"
-        },
         {
           "type": "ibc",
           "counterparty": {
@@ -10173,30 +9646,6 @@
       "symbol": "sfrxETH",
       "traces": [
         {
-          "type": "synthetic",
-          "counterparty": {
-            "chain_name": "ethereum",
-            "base_denom": "wei"
-          },
-          "provider": "Frax"
-        },
-        {
-          "type": "liquid-stake",
-          "counterparty": {
-            "chain_name": "ethereum",
-            "base_denom": "0x5e8422345238f34275888049021821e8e08caa1f"
-          },
-          "provider": "Frax"
-        },
-        {
-          "type": "bridge",
-          "counterparty": {
-            "chain_name": "ethereum",
-            "base_denom": "0xac3e018457b222d93114458476f3e3416abbe38f"
-          },
-          "provider": "Axelar"
-        },
-        {
           "type": "ibc",
           "counterparty": {
             "chain_name": "axelar",
@@ -10239,34 +9688,10 @@
       ],
       "type_asset": "ics20",
       "base": "ibc/B2BD584CD2A0A9CE53D4449667E26160C7D44A9C41AF50F602C201E5B3CCA46C",
-      "name": "Wrapped Lido Staked Ether (Axelar)",
+      "name": "Wrapped Lido Staked Ether",
       "display": "wsteth",
-      "symbol": "wstETH.axl",
+      "symbol": "wstETH",
       "traces": [
-        {
-          "type": "liquid-stake",
-          "counterparty": {
-            "chain_name": "ethereum",
-            "base_denom": "wei"
-          },
-          "provider": "Lido"
-        },
-        {
-          "type": "liquid-stake",
-          "counterparty": {
-            "chain_name": "ethereum",
-            "base_denom": "0xae7ab96520de3a18e5e111b5eaab095312d7fe84"
-          },
-          "provider": "Lido"
-        },
-        {
-          "type": "bridge",
-          "counterparty": {
-            "chain_name": "ethereum",
-            "base_denom": "0x7f39c581f595b53c5cb19bd0b3f8da6c935e2ca0"
-          },
-          "provider": "Axelar"
-        },
         {
           "type": "ibc",
           "counterparty": {
@@ -10343,7 +9768,8 @@
         {
           "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/gitopia/images/gitopia.png"
         }
-      ]
+      ],
+      "coingecko_id": "gitopia"
     },
     {
       "description": "Lion DAO is a community DAO that lives on the Terra blockchain with the mission to reactivate the LUNAtic community and showcase Terra protocols & tooling",
@@ -10392,7 +9818,8 @@
           },
           "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/terra2/images/roar.png"
         }
-      ]
+      ],
+      "coingecko_id": "lion-dao"
     },
     {
       "denom_units": [
@@ -10414,14 +9841,6 @@
       "display": "stumee",
       "symbol": "stUMEE",
       "traces": [
-        {
-          "type": "liquid-stake",
-          "counterparty": {
-            "chain_name": "umee",
-            "base_denom": "uumee"
-          },
-          "provider": "Stride"
-        },
         {
           "type": "ibc",
           "counterparty": {
@@ -10448,7 +9867,8 @@
           "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/stride/images/stumee.png",
           "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/stride/images/stumee.svg"
         }
-      ]
+      ],
+      "coingecko_id": "stride-staked-umee"
     },
     {
       "denom_units": [
@@ -10525,7 +9945,8 @@
           "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/nolus/images/nolus.png",
           "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/nolus/images/nolus.svg"
         }
-      ]
+      ],
+      "coingecko_id": "nolus"
     },
     {
       "description": "Lion Cub DAO is a useless meme community DAO on Terra",
@@ -10675,7 +10096,8 @@
             "circle": true
           }
         }
-      ]
+      ],
+      "coingecko_id": "neutron-3"
     },
     {
       "description": "An innovative DAO dedicated to housing the most vulnerable",
@@ -10748,14 +10170,6 @@
       "symbol": "PICA",
       "traces": [
         {
-          "type": "additional-mintage",
-          "counterparty": {
-            "chain_name": "picasso",
-            "base_denom": "ppica"
-          },
-          "provider": "Picasso"
-        },
-        {
           "type": "ibc",
           "counterparty": {
             "chain_name": "composable",
@@ -10779,7 +10193,8 @@
           },
           "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/composable/images/pica.svg"
         }
-      ]
+      ],
+      "coingecko_id": "picasso"
     },
     {
       "description": "The native fee, governance, staking, and bonding token of the Polkadot platform.",
@@ -10803,27 +10218,6 @@
       "display": "ksm",
       "symbol": "KSM",
       "traces": [
-        {
-          "type": "bridge",
-          "counterparty": {
-            "chain_name": "kusama",
-            "base_denom": "Planck"
-          },
-          "provider": "Kusama Parachain"
-        },
-        {
-          "type": "ibc-bridge",
-          "counterparty": {
-            "chain_name": "picasso",
-            "base_denom": "4",
-            "channel_id": "channel-17"
-          },
-          "chain": {
-            "channel_id": "channel-2",
-            "path": "transfer/channel-2/4"
-          },
-          "provider": "Picasso"
-        },
         {
           "type": "ibc",
           "counterparty": {
@@ -10868,44 +10262,10 @@
       ],
       "type_asset": "ics20",
       "base": "ibc/6B2B19D874851F631FF0AF82C38A20D4B82F438C7A22F41EDA33568345397244",
-      "name": "Polkadot (Picasso)",
+      "name": "DOT",
       "display": "dot",
-      "symbol": "DOT.pica",
+      "symbol": "DOT",
       "traces": [
-        {
-          "type": "bridge",
-          "counterparty": {
-            "chain_name": "polkadot",
-            "base_denom": "Planck"
-          },
-          "provider": "Polkadot Parachain"
-        },
-        {
-          "type": "ibc-bridge",
-          "counterparty": {
-            "chain_name": "composablepolkadot",
-            "base_denom": "79228162514264337593543950342",
-            "channel_id": "channel-15"
-          },
-          "chain": {
-            "channel_id": "channel-15",
-            "path": "transfer/channel-15/79228162514264337593543950342"
-          },
-          "provider": "Picasso"
-        },
-        {
-          "type": "ibc-bridge",
-          "counterparty": {
-            "chain_name": "picasso",
-            "base_denom": "79228162514264337593543950342",
-            "channel_id": "channel-17"
-          },
-          "chain": {
-            "channel_id": "channel-2",
-            "path": "transfer/channel-2/transfer/channel-15/79228162514264337593543950342"
-          },
-          "provider": "Picasso"
-        },
         {
           "type": "ibc",
           "counterparty": {
@@ -11033,7 +10393,8 @@
           "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/archway/images/arch.png",
           "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/archway/images/arch.svg"
         }
-      ]
+      ],
+      "coingecko_id": "archway"
     },
     {
       "description": "The native staking and governance token of Empower.",
@@ -11187,7 +10548,8 @@
           "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/kyve/images/kyve-token.png",
           "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/kyve/images/kyve-token.svg"
         }
-      ]
+      ],
+      "coingecko_id": "kyve-network"
     },
     {
       "description": "Tether gives you the joint benefits of open blockchain technology and traditional currency by converting your cash into a stable digital currency equivalent.",
@@ -11206,26 +10568,10 @@
       ],
       "type_asset": "ics20",
       "base": "ibc/4ABBEF4C8926DDDB320AE5188CFD63267ABBCEFC0583E4AE05D6E5AA2401DDAB",
-      "name": "Tether USD (Kava)",
+      "name": "Tether USD",
       "display": "usdt",
-      "symbol": "USDT.kava",
+      "symbol": "USDT",
       "traces": [
-        {
-          "type": "synthetic",
-          "counterparty": {
-            "chain_name": "forex",
-            "base_denom": "USD"
-          },
-          "provider": "Tether"
-        },
-        {
-          "type": "additional-mintage",
-          "counterparty": {
-            "chain_name": "ethereum",
-            "base_denom": "0xdac17f958d2ee523a2206206994597c13d831ec7"
-          },
-          "provider": "Tether"
-        },
         {
           "type": "ibc",
           "counterparty": {
@@ -11255,7 +10601,8 @@
             "circle": true
           }
         }
-      ]
+      ],
+      "coingecko_id": "tether"
     },
     {
       "description": "ERIS liquid staked OSMO",
@@ -11335,7 +10682,8 @@
           "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/sei/images/sei.png",
           "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/sei/images/sei.svg"
         }
-      ]
+      ],
+      "coingecko_id": "sei-network"
     },
     {
       "description": "Quicksilver Liquid Staked SOMM",
@@ -11359,14 +10707,6 @@
       "display": "qsomm",
       "symbol": "qSOMM",
       "traces": [
-        {
-          "type": "liquid-stake",
-          "counterparty": {
-            "chain_name": "sommelier",
-            "base_denom": "usomm"
-          },
-          "provider": "Quicksilver"
-        },
         {
           "type": "ibc",
           "counterparty": {
@@ -11440,7 +10780,8 @@
           },
           "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/passage/images/pasg.png"
         }
-      ]
+      ],
+      "coingecko_id": "passage"
     },
     {
       "denom_units": [
@@ -11462,14 +10803,6 @@
       "display": "stsomm",
       "symbol": "stSOMM",
       "traces": [
-        {
-          "type": "liquid-stake",
-          "counterparty": {
-            "chain_name": "sommelier",
-            "base_denom": "usomm"
-          },
-          "provider": "Stride"
-        },
         {
           "type": "ibc",
           "counterparty": {
@@ -11496,7 +10829,8 @@
           "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/stride/images/stsomm.png",
           "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/stride/images/stsomm.svg"
         }
-      ]
+      ],
+      "coingecko_id": "stride-staked-sommelier"
     },
     {
       "description": "Solana (SOL) is the native asset of the Solana blockchain.",
@@ -11516,26 +10850,10 @@
       ],
       "type_asset": "ics20",
       "base": "ibc/1E43D59E565D41FB4E54CA639B838FFD5BCFC20003D330A56CB1396231AA1CBA",
-      "name": "Solana (Wormhole)",
+      "name": "Wrapped SOL (Wormhole)",
       "display": "wormhole/8sYgCzLRJC3J7qPn2bNbx6PiGcarhyx8rBhVaNnfvHCA/8",
-      "symbol": "SOL.wh",
+      "symbol": "SOL",
       "traces": [
-        {
-          "type": "wrapped",
-          "counterparty": {
-            "chain_name": "solana",
-            "base_denom": "Lamport"
-          },
-          "provider": "Solana"
-        },
-        {
-          "type": "bridge",
-          "counterparty": {
-            "chain_name": "solana",
-            "base_denom": "So11111111111111111111111111111111111111112"
-          },
-          "provider": "Wormhole"
-        },
         {
           "type": "ibc",
           "counterparty": {
@@ -11587,16 +10905,8 @@
       "base": "ibc/CA3733CB0071F480FAE8EF0D9C3D47A49C6589144620A642BBE0D59A293D110E",
       "name": "Bonk",
       "display": "wormhole/95mnwzvJZJ3fKz77xfGN2nR5to9pZmH8YNvaxgLgw5AR/5",
-      "symbol": "BONK",
+      "symbol": "Bonk",
       "traces": [
-        {
-          "type": "bridge",
-          "counterparty": {
-            "chain_name": "solana",
-            "base_denom": "DezXAZ8z7PnrnRJjz3wXBoRgixCa6xjnB7YaB1pPB263"
-          },
-          "provider": "Wormhole"
-        },
         {
           "type": "ibc",
           "counterparty": {
@@ -11641,26 +10951,10 @@
       ],
       "type_asset": "ics20",
       "base": "ibc/2108F2D81CBE328F371AD0CEF56691B18A86E08C3651504E42487D9EE92DDE9C",
-      "name": "Tether USD (Ethereum via Wormhole)",
+      "name": "Tether USD (Wormhole)",
       "display": "wormhole/8iuAc6DSeLvi2JDUtwJxLytsZT8R19itXebZsNReLLNi/6",
-      "symbol": "USDT.eth.wh",
+      "symbol": "USDT",
       "traces": [
-        {
-          "type": "synthetic",
-          "counterparty": {
-            "chain_name": "forex",
-            "base_denom": "USD"
-          },
-          "provider": "Tether"
-        },
-        {
-          "type": "bridge",
-          "counterparty": {
-            "chain_name": "ethereum",
-            "base_denom": "0xdac17f958d2ee523a2206206994597c13d831ec7"
-          },
-          "provider": "Wormhole"
-        },
         {
           "type": "ibc",
           "counterparty": {
@@ -11712,16 +11006,8 @@
       "base": "ibc/B1C287C2701774522570010EEBCD864BCB7AB714711B3AA218699FDD75E832F5",
       "name": "Sui (Wormhole)",
       "display": "wormhole/46YEtoSN1AcwgGSRoWruoS6bnVh8XpMp5aQTpKohCJYh/8",
-      "symbol": "SUI.wh",
+      "symbol": "SUI",
       "traces": [
-        {
-          "type": "bridge",
-          "counterparty": {
-            "chain_name": "sui",
-            "base_denom": "0x2::sui::SUI"
-          },
-          "provider": "Wormhole"
-        },
         {
           "type": "ibc",
           "counterparty": {
@@ -11768,16 +11054,8 @@
       "base": "ibc/A4D176906C1646949574B48C1928D475F2DF56DE0AC04E1C99B08F90BC21ABDE",
       "name": "Aptos Coin (Wormhole)",
       "display": "wormhole/5wS2fGojbL9RhGEAeQBdkHPUAciYDxjDTMYvdf9aDn2r/8",
-      "symbol": "APT.wh",
+      "symbol": "APT",
       "traces": [
-        {
-          "type": "bridge",
-          "counterparty": {
-            "chain_name": "aptos",
-            "base_denom": "0x1::aptos_coin::AptosCoin"
-          },
-          "provider": "Wormhole"
-        },
         {
           "type": "ibc",
           "counterparty": {
@@ -11857,7 +11135,8 @@
           "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/kujira/images/mnta.png",
           "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/kujira/images/mnta.svg"
         }
-      ]
+      ],
+      "coingecko_id": "mantadao"
     },
     {
       "denom_units": [
@@ -11923,26 +11202,10 @@
       ],
       "type_asset": "ics20",
       "base": "ibc/6B99DB46AA9FF47162148C1726866919E44A6A5E0274B90912FD17E19A337695",
-      "name": "USDC (Ethereum via Wormhole)",
+      "name": "USD Coin (Wormhole)",
       "display": "wormhole/GGh9Ufn1SeDGrhzEkMyRKt5568VbbxZK2yvWNsd6PbXt/6",
-      "symbol": "USDC.eth.wh",
+      "symbol": "USDC",
       "traces": [
-        {
-          "type": "synthetic",
-          "counterparty": {
-            "chain_name": "forex",
-            "base_denom": "USD"
-          },
-          "provider": "Circle"
-        },
-        {
-          "type": "bridge",
-          "counterparty": {
-            "chain_name": "ethereum",
-            "base_denom": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48"
-          },
-          "provider": "Wormhole"
-        },
         {
           "type": "ibc",
           "counterparty": {
@@ -11992,26 +11255,10 @@
       ],
       "type_asset": "ics20",
       "base": "ibc/62F82550D0B96522361C89B0DA1119DE262FBDFB25E5502BC5101B5C0D0DBAAC",
-      "name": "Ethereum (Wormhole)",
+      "name": "Wrapped Ether (Wormhole)",
       "display": "wormhole/5BWqpR48Lubd55szM5i62zK7TFkddckhbT48yy6mNbDp/8",
-      "symbol": "ETH.wh",
+      "symbol": "WETH",
       "traces": [
-        {
-          "type": "wrapped",
-          "counterparty": {
-            "chain_name": "ethereum",
-            "base_denom": "wei"
-          },
-          "provider": "Ethereum"
-        },
-        {
-          "type": "bridge",
-          "counterparty": {
-            "chain_name": "ethereum",
-            "base_denom": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2"
-          },
-          "provider": "Wormhole"
-        },
         {
           "type": "ibc",
           "counterparty": {
@@ -12063,22 +11310,6 @@
       "symbol": "USDC",
       "traces": [
         {
-          "type": "synthetic",
-          "counterparty": {
-            "chain_name": "forex",
-            "base_denom": "USD"
-          },
-          "provider": "Circle"
-        },
-        {
-          "type": "additional-mintage",
-          "counterparty": {
-            "chain_name": "ethereum",
-            "base_denom": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48"
-          },
-          "provider": "Circle"
-        },
-        {
           "type": "ibc",
           "counterparty": {
             "chain_name": "noble",
@@ -12107,7 +11338,8 @@
             "circle": true
           }
         }
-      ]
+      ],
+      "coingecko_id": "usd-coin"
     },
     {
       "description": "Maximize ETH yield through leveraged staking across Aave, Compound and Morpho and liquidity provision of ETH liquid staking tokens on Uniswap V3.",
@@ -12131,22 +11363,6 @@
       "display": "YieldETH",
       "symbol": "YieldETH",
       "traces": [
-        {
-          "type": "liquid-stake",
-          "counterparty": {
-            "chain_name": "ethereum",
-            "base_denom": "wei"
-          },
-          "provider": "Seven Seas & DeFine Logic Labs"
-        },
-        {
-          "type": "bridge",
-          "counterparty": {
-            "chain_name": "ethereum",
-            "base_denom": "0xb5b29320d2Dde5BA5BAFA1EbcD270052070483ec"
-          },
-          "provider": "Axelar"
-        },
         {
           "type": "ibc",
           "counterparty": {
@@ -12222,7 +11438,8 @@
           "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/xpla/images/xpla.png",
           "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/xpla/images/xpla.svg"
         }
-      ]
+      ],
+      "coingecko_id": "xpla"
     },
     {
       "description": "OIN Token ($OIN) is a groundbreaking digital asset developed on the $SEI Blockchain. It transcends being merely a cryptocurrency; $OIN stands as a robust store of value, symbolizing the future of decentralized finance and its potential to reshape the crypto landscape.",
@@ -12370,7 +11587,8 @@
             "circle": true
           }
         }
-      ]
+      ],
+      "coingecko_id": "realio-network"
     },
     {
       "description": "Membrane's CDP-style stablecoin called CDT",
@@ -12476,7 +11694,8 @@
             "circle": false
           }
         }
-      ]
+      ],
+      "coingecko_id": "six-sigma"
     },
     {
       "description": "The native staking and governance token of the StaFi Hub.",
@@ -12523,7 +11742,8 @@
           },
           "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/stafihub/images/fis.svg"
         }
-      ]
+      ],
+      "coingecko_id": "stafi"
     },
     {
       "description": "A liquid staking representation of staked ATOMs",
@@ -12546,14 +11766,6 @@
       "display": "ratom",
       "symbol": "rATOM",
       "traces": [
-        {
-          "type": "liquid-stake",
-          "counterparty": {
-            "chain_name": "cosmoshub",
-            "base_denom": "uatom"
-          },
-          "provider": "StaFiHub"
-        },
         {
           "type": "ibc",
           "counterparty": {
@@ -12727,6 +11939,7 @@
           "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/coreum/images/coreum.svg"
         }
       ],
+      "coingecko_id": "coreum",
       "keywords": [
         "dex",
         "staking",
@@ -12783,7 +11996,8 @@
           "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/celestia/images/celestia.png",
           "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/celestia/images/celestia.svg"
         }
-      ]
+      ],
+      "coingecko_id": "celestia"
     },
     {
       "description": "DYDX is a decentralized trading platform focused on derivatives and perpetual contracts, offering a secure and efficient trading experience without intermediaries.",
@@ -12803,9 +12017,9 @@
       ],
       "type_asset": "ics20",
       "base": "ibc/831F0B1BBB1D08A2B75311892876D71565478C532967545476DF4C2D7492E48C",
-      "name": "dYdX Protocol (dYdX Protocol)",
+      "name": "dYdX",
       "display": "dydx",
-      "symbol": "DYDX.dydx",
+      "symbol": "DYDX",
       "traces": [
         {
           "type": "ibc",
@@ -12838,7 +12052,8 @@
           "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/dydx/images/dydx.png",
           "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/dydx/images/dydx.svg"
         }
-      ]
+      ],
+      "coingecko_id": "dydx-chain"
     },
     {
       "description": "The native staking token of the Function X",
@@ -12887,7 +12102,8 @@
           "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/fxcore/images/fx.png",
           "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/fxcore/images/fx.svg"
         }
-      ]
+      ],
+      "coingecko_id": "fx-coin"
     },
     {
       "description": "Bitcoin. On Cosmos.",
@@ -12910,14 +12126,6 @@
       "display": "nbtc",
       "symbol": "nBTC",
       "traces": [
-        {
-          "type": "bridge",
-          "counterparty": {
-            "chain_name": "bitcoin",
-            "base_denom": "sat"
-          },
-          "provider": "Nomic"
-        },
         {
           "type": "ibc",
           "counterparty": {
@@ -13072,7 +12280,8 @@
           },
           "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/kujira/images/nstk.svg"
         }
-      ]
+      ],
+      "coingecko_id": "unstake-fi"
     },
     {
       "description": "ohhNFT LP token.",
@@ -13144,30 +12353,6 @@
       "display": "wstETH",
       "symbol": "wstETH",
       "traces": [
-        {
-          "type": "liquid-stake",
-          "counterparty": {
-            "chain_name": "ethereum",
-            "base_denom": "wei"
-          },
-          "provider": "Lido"
-        },
-        {
-          "type": "liquid-stake",
-          "counterparty": {
-            "chain_name": "ethereum",
-            "base_denom": "0xae7ab96520de3a18e5e111b5eaab095312d7fe84"
-          },
-          "provider": "Lido"
-        },
-        {
-          "type": "bridge",
-          "counterparty": {
-            "chain_name": "ethereum",
-            "base_denom": "0x7f39c581f595b53c5cb19bd0b3f8da6c935e2ca0"
-          },
-          "provider": "Lido wstETH Cosmos Bridge"
-        },
         {
           "type": "ibc",
           "counterparty": {
@@ -13313,7 +12498,7 @@
       "type_asset": "ics20",
       "base": "ibc/4F3B0EC2FE2D370D10C3671A1B7B06D2A964C721470C305CBB846ED60E6CAA20",
       "name": "Bostrom Hydrogen",
-      "display": "ibc/4F3B0EC2FE2D370D10C3671A1B7B06D2A964C721470C305CBB846ED60E6CAA20",
+      "display": "hydrogen",
       "symbol": "HYDROGEN",
       "traces": [
         {
@@ -13358,7 +12543,7 @@
       "type_asset": "ics20",
       "base": "ibc/BCDB35B7390806F35E716D275E1E017999F8281A81B6F128F087EF34D1DFA761",
       "name": "Bostrom Tocyb",
-      "display": "ibc/BCDB35B7390806F35E716D275E1E017999F8281A81B6F128F087EF34D1DFA761",
+      "display": "tocyb",
       "symbol": "TOCYB",
       "traces": [
         {
@@ -13540,7 +12725,8 @@
           "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/source/images/source.png",
           "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/source/images/source.svg"
         }
-      ]
+      ],
+      "coingecko_id": "source"
     },
     {
       "description": "Pyth is a protocol that allows market participants to publish pricing information on-chain for others to use. The protocol is an interaction between three parties:\n-Publishers submit pricing information to Pyth's oracle program. Pyth has multiple data publishers for every product to improve the accuracy and robustness of the system.\n-Pyth's oracle program combines publishers' data to produce a single aggregate price and confidence interval.\nConsumers read the price information produced by the oracle program.\n\nPyth's oracle program runs simultaneously on both Solana mainnet and Pythnet. Each instance of the program is responsible for its own set of price feeds. Solana Price Feeds are available for use by Solana protocols. In this case, since the oracle program itself runs on Solana, the resulting prices are immediately available to consumers without requiring any additional work. Pythnet Price Feeds are available on 12+ blockchains. The prices constructed on Pythnet are transferred cross-chain to reach consumers on these blockchains.\n\nIn both cases, the critical component of the system is the oracle program that combines the data from each individual publisher. This program maintains a number of different Solana accounts that list the products on Pyth and their current price data. Publishers publish their price and confidence by interacting with the oracle program on every slot. The program stores this information in its accounts. The first price update in a slot additionally triggers price aggregation, which combines the price data from the previous slot into a single aggregate price and confidence interval. This aggregate price is written to the Solana account where it is readable by other on-chain programs and available for transmission to other blockchains.",
@@ -13567,14 +12753,6 @@
       "display": "wormhole/B8ohBnfisop27exk2gtNABJyYjLwQA7ogrp5uNzvZCoy/6",
       "symbol": "PYTH",
       "traces": [
-        {
-          "type": "bridge",
-          "counterparty": {
-            "chain_name": "solana",
-            "base_denom": "HZ1JovNiVvGrGNiiYvEozEVgZ58xaU3RKwX8eACQBCt3"
-          },
-          "provider": "Wormhole"
-        },
         {
           "type": "ibc",
           "counterparty": {
@@ -13625,14 +12803,6 @@
       "display": "stkosmo",
       "symbol": "stkOSMO",
       "traces": [
-        {
-          "type": "liquid-stake",
-          "counterparty": {
-            "chain_name": "osmosis",
-            "base_denom": "uosmo"
-          },
-          "provider": "pSTAKE"
-        },
         {
           "type": "ibc",
           "counterparty": {
@@ -13789,7 +12959,8 @@
           },
           "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/neutron/images/newt.png"
         }
-      ]
+      ],
+      "coingecko_id": "newt"
     },
     {
       "description": "MilkyWay's liquid staked TIA",
@@ -13924,7 +13095,8 @@
           "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/migaloo/images/rac.png",
           "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/migaloo/images/rac.svg"
         }
-      ]
+      ],
+      "coingecko_id": "racoon"
     },
     {
       "description": "GUPPY",
@@ -14020,7 +13192,8 @@
           "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/haqq/images/islm.png",
           "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/haqq/images/islm.svg"
         }
-      ]
+      ],
+      "coingecko_id": "islamic-coin"
     },
     {
       "description": "$AUTISM exists to celebrate autism as a superior biological tech stack for a changing world",
@@ -14068,6 +13241,7 @@
           "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/injective/images/autism.png"
         }
       ],
+      "coingecko_id": "autism",
       "keywords": [
         "osmosis_unlisted"
       ]
@@ -14093,14 +13267,6 @@
       "display": "page",
       "symbol": "PAGE",
       "traces": [
-        {
-          "type": "bridge",
-          "counterparty": {
-            "chain_name": "ethereum",
-            "base_denom": "0x60e683C6514Edd5F758A55b6f393BeBBAfaA8d5e"
-          },
-          "provider": "Gravity Bridge"
-        },
         {
           "type": "ibc",
           "counterparty": {
@@ -14150,15 +13316,6 @@
       "display": "PURSE",
       "symbol": "PURSE",
       "traces": [
-        {
-          "type": "bridge",
-          "counterparty": {
-            "chain_name": "binancesmartchain",
-            "base_denom": "0x29a63F4B209C29B4DC47f06FFA896F32667DAD2C",
-            "contract": "0x84238c00c8313920826D798e3cF6793Ef4F610ad"
-          },
-          "provider": "Function X"
-        },
         {
           "type": "ibc",
           "counterparty": {
@@ -14238,7 +13395,8 @@
             "circle": true
           }
         }
-      ]
+      ],
+      "coingecko_id": "dog-wif-nuchucks"
     },
     {
       "description": "Kleomedes Token",
@@ -14401,7 +13559,8 @@
         {
           "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/nyx/images/nym.png"
         }
-      ]
+      ],
+      "coingecko_id": "nym"
     },
     {
       "description": "has a hat",
@@ -14669,14 +13828,6 @@
       "symbol": "WBTC",
       "traces": [
         {
-          "type": "bridge",
-          "counterparty": {
-            "chain_name": "bitcoin",
-            "base_denom": "sat"
-          },
-          "provider": "BitGo, Kyber, and Ren"
-        },
-        {
           "type": "additional-mintage",
           "counterparty": {
             "chain_name": "ethereum",
@@ -14921,14 +14072,6 @@
       "symbol": "stDYDX",
       "traces": [
         {
-          "type": "liquid-stake",
-          "counterparty": {
-            "chain_name": "dydx",
-            "base_denom": "adydx"
-          },
-          "provider": "Stride"
-        },
-        {
           "type": "ibc",
           "counterparty": {
             "chain_name": "stride",
@@ -14977,14 +14120,6 @@
       "display": "stTIA",
       "symbol": "stTIA",
       "traces": [
-        {
-          "type": "liquid-stake",
-          "counterparty": {
-            "chain_name": "celestia",
-            "base_denom": "utia"
-          },
-          "provider": "Stride"
-        },
         {
           "type": "ibc",
           "counterparty": {
@@ -15035,14 +14170,6 @@
       "symbol": "stSAGA",
       "traces": [
         {
-          "type": "liquid-stake",
-          "counterparty": {
-            "chain_name": "saga",
-            "base_denom": "usaga"
-          },
-          "provider": "Stride"
-        },
-        {
           "type": "ibc",
           "counterparty": {
             "chain_name": "stride",
@@ -15090,14 +14217,6 @@
       "display": "stINJ",
       "symbol": "stINJ",
       "traces": [
-        {
-          "type": "liquid-stake",
-          "counterparty": {
-            "chain_name": "injective",
-            "base_denom": "inj"
-          },
-          "provider": "Stride"
-        },
         {
           "type": "ibc",
           "counterparty": {
@@ -15148,14 +14267,6 @@
       "symbol": "GLTO",
       "traces": [
         {
-          "type": "bridge",
-          "counterparty": {
-            "chain_name": "ethereum",
-            "base_denom": "0xd73175f9eb15eee81745d367ae59309Ca2ceb5e2"
-          },
-          "provider": "Peggy"
-        },
-        {
           "type": "ibc",
           "counterparty": {
             "chain_name": "injective",
@@ -15200,9 +14311,9 @@
       ],
       "type_asset": "ics20",
       "base": "ibc/9A76CDF0CBCEF37923F32518FA15E5DC92B9F56128292BC4D63C4AEA76CBB110",
-      "name": "Dymension Hub (Dymension Hub)",
+      "name": "Dymension",
       "display": "dym",
-      "symbol": "DYM.dym",
+      "symbol": "DYM",
       "traces": [
         {
           "type": "ibc",
@@ -15230,7 +14341,8 @@
           "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/dymension/images/dymension-logo.png",
           "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/dymension/images/dymension-logo.svg"
         }
-      ]
+      ],
+      "coingecko_id": "dymension"
     },
     {
       "description": "Rapture insurance is the first ever P2P insurance platform on $OSMO. Get rewarded to take care of peoples loved ones after the Rapture.",
@@ -15279,18 +14391,10 @@
       ],
       "type_asset": "ics20",
       "base": "ibc/C25A2303FE24B922DAFFDCE377AC5A42E5EF746806D32E2ED4B610DE85C203F7",
-      "name": "Astroport token (Terra)",
+      "name": "Astroport CW20 Token",
       "display": "astro.cw20",
-      "symbol": "ASTRO.terra",
+      "symbol": "ASTRO.cw20",
       "traces": [
-        {
-          "type": "legacy-mintage",
-          "counterparty": {
-            "chain_name": "neutron",
-            "base_denom": "factory/neutron1ffus553eet978k024lmssw0czsxwr97mggyv85lpcsdkft8v9ufsz3sa07/astro"
-          },
-          "provider": "Astroport"
-        },
         {
           "type": "ibc-cw20",
           "counterparty": {
@@ -15325,7 +14429,8 @@
           "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/neutron/images/astro.png",
           "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/neutron/images/astro.svg"
         }
-      ]
+      ],
+      "coingecko_id": "astroport-fi"
     },
     {
       "description": "A clan of 11y bad kids crafting chaos on the Cosmos eco. One bad memecoin to rule them all  $BADKID. Airdropped to Badkids NFT holders and $STARS stakers. It's so bad, your wallet's throwing a tantrum for it.",
@@ -15372,34 +14477,10 @@
       ],
       "type_asset": "ics20",
       "base": "ibc/F08DE332018E8070CC4C68FE06E04E254F527556A614F5F8F9A68AF38D367E45",
-      "name": "USDC (Solana via Wormhole)",
+      "name": "Solana USD Coin (Wormhole)",
       "display": "wormhole/HJk1XMDRNUbRrpKkNZYui7SwWDMjXZAsySzqgyNcQoU3/6",
-      "symbol": "USDC.sol.wh",
+      "symbol": "solana.USDC.wh",
       "traces": [
-        {
-          "type": "synthetic",
-          "counterparty": {
-            "chain_name": "forex",
-            "base_denom": "USD"
-          },
-          "provider": "Circle"
-        },
-        {
-          "type": "additional-mintage",
-          "counterparty": {
-            "chain_name": "ethereum",
-            "base_denom": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48"
-          },
-          "provider": "Circle"
-        },
-        {
-          "type": "bridge",
-          "counterparty": {
-            "chain_name": "solana",
-            "base_denom": "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v"
-          },
-          "provider": "Wormhole"
-        },
         {
           "type": "ibc",
           "counterparty": {
@@ -15481,7 +14562,8 @@
             "dark_mode": true
           }
         }
-      ]
+      ],
+      "coingecko_id": "humans-ai"
     },
     {
       "description": "The token of Teledisko DAO.",
@@ -15501,7 +14583,7 @@
       "type_asset": "ics20",
       "base": "ibc/2BF9656CAB0384A31167DB9B0254F0FB1CB4346A229BD7E5CBDCBB911C3740F7",
       "name": "Teledisko DAO - Legacy",
-      "display": "berlin",
+      "display": "berlin-legacy",
       "symbol": "BERLIN-legacy",
       "traces": [
         {
@@ -15579,7 +14661,8 @@
           "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/scorum/images/scr.png",
           "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/scorum/images/scr.svg"
         }
-      ]
+      ],
+      "coingecko_id": "scorum"
     },
     {
       "description": "The native token of Chain4Energy",
@@ -15626,7 +14709,8 @@
           },
           "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/chain4energy/images/c4e.png"
         }
-      ]
+      ],
+      "coingecko_id": "chain4energy"
     },
     {
       "description": "Bitmos opens doors for BRC20 tokens to thrive alongside established players in the Cosmos Network, revolutionizing decentralized finance (DeFi) for all.",
@@ -15699,30 +14783,6 @@
       "display": "srcx",
       "symbol": "SRCX",
       "traces": [
-        {
-          "type": "bridge",
-          "counterparty": {
-            "chain_name": "binancesmartchain",
-            "base_denom": "0x454b90716a9435e7161a9aea5cf00e0acbe565ae",
-            "contract": "0xC891aBa0b42818fb4c975Bf6461033c62BCE75ff"
-          },
-          "chain": {
-            "contract": "0xC891aBa0b42818fb4c975Bf6461033c62BCE75ff"
-          },
-          "provider": "DeltaSwap.io"
-        },
-        {
-          "type": "ibc",
-          "counterparty": {
-            "chain_name": "planq",
-            "base_denom": "erc20/0x091F9A57A3F58d758b6572E9d41675918EAC7F09",
-            "channel_id": "channel-61"
-          },
-          "chain": {
-            "channel_id": "channel-1",
-            "path": "transfer/channel-1/erc20/0x091F9A57A3F58d758b6572E9d41675918EAC7F09"
-          }
-        },
         {
           "type": "ibc",
           "counterparty": {
@@ -15823,14 +14883,6 @@
       "symbol": "BSKT",
       "traces": [
         {
-          "type": "bridge",
-          "counterparty": {
-            "chain_name": "solana",
-            "base_denom": "6gnCPhXtLnUD76HjQuSYPENLSZdG8RvDB1pTLM5aLSJA"
-          },
-          "provider": "Wormhole"
-        },
-        {
           "type": "ibc",
           "counterparty": {
             "chain_name": "gateway",
@@ -15877,9 +14929,9 @@
       ],
       "type_asset": "ics20",
       "base": "ibc/BB0AFE2AFBD6E883690DAE4B9168EAC2B306BCC9C9292DACBB4152BBB08DB25F",
-      "name": "AIOZ Network (AIOZ Network)",
+      "name": "AIOZ",
       "display": "aioz",
-      "symbol": "AIOZ.aioz",
+      "symbol": "AIOZ",
       "traces": [
         {
           "type": "ibc",
@@ -15907,7 +14959,8 @@
           "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/aioz/images/aioz.png",
           "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/aioz/images/aioz.svg"
         }
-      ]
+      ],
+      "coingecko_id": "aioz-network"
     },
     {
       "description": "Stride's liquid staked DYM",
@@ -15930,14 +14983,6 @@
       "display": "stDYM",
       "symbol": "stDYM",
       "traces": [
-        {
-          "type": "liquid-stake",
-          "counterparty": {
-            "chain_name": "dymension",
-            "base_denom": "adym"
-          },
-          "provider": "Stride"
-        },
         {
           "type": "ibc",
           "counterparty": {
@@ -16011,7 +15056,8 @@
           },
           "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/odin/images/doki_Logo.png"
         }
-      ]
+      ],
+      "coingecko_id": "doki"
     },
     {
       "description": "Sail DAO is a liquidity deployment and management DAO built as a collaboration between the Osmosis and Migaloo Blockchains.",
@@ -16109,18 +15155,10 @@
       ],
       "type_asset": "ics20",
       "base": "ibc/63A7CA0B6838AD8CAD6B5103998FF9B9B6A6F06FBB9638BFF51E63E0142339F3",
-      "name": "Ripple (xrpl via Coreum)",
+      "name": "Ripple",
       "display": "xrp",
-      "symbol": "XRP.xrpl.core",
+      "symbol": "XRP",
       "traces": [
-        {
-          "type": "bridge",
-          "counterparty": {
-            "chain_name": "xrpl",
-            "base_denom": "drop"
-          },
-          "provider": "Coreum"
-        },
         {
           "type": "ibc",
           "counterparty": {
@@ -16248,7 +15286,8 @@
           "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/nibiru/images/nibiru.png",
           "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/nibiru/images/nibiru.svg"
         }
-      ]
+      ],
+      "coingecko_id": "nibiru"
     },
     {
       "description": "BEAST-ERC20 on injective",
@@ -16271,14 +15310,6 @@
       "display": "beast",
       "symbol": "BEAST",
       "traces": [
-        {
-          "type": "bridge",
-          "counterparty": {
-            "chain_name": "ethereum",
-            "base_denom": "0xA4426666addBE8c4985377d36683D17FB40c31Be"
-          },
-          "provider": "Peggy"
-        },
         {
           "type": "ibc",
           "counterparty": {
@@ -16353,6 +15384,7 @@
           "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/conscious/images/cvn.svg"
         }
       ],
+      "coingecko_id": "consciousdao",
       "keywords": [
         "osmosis_unlisted"
       ]
@@ -16534,15 +15566,6 @@
       "symbol": "PUNDIX",
       "traces": [
         {
-          "type": "bridge",
-          "counterparty": {
-            "chain_name": "ethereum",
-            "base_denom": "0x0FD10b9899882a6f2fcb5c371E17e70FdEe00C38",
-            "contract": "0x0FD10b9899882a6f2fcb5c371E17e70FdEe00C38"
-          },
-          "provider": "Function X"
-        },
-        {
           "type": "ibc",
           "counterparty": {
             "chain_name": "fxcore",
@@ -16596,27 +15619,6 @@
       "symbol": "TNKR",
       "traces": [
         {
-          "type": "bridge",
-          "counterparty": {
-            "chain_name": "tinkernet",
-            "base_denom": "Planck"
-          },
-          "provider": "Tinkernet Parachain"
-        },
-        {
-          "type": "ibc-bridge",
-          "counterparty": {
-            "chain_name": "picasso",
-            "base_denom": "2125",
-            "channel_id": "channel-17"
-          },
-          "chain": {
-            "channel_id": "channel-2",
-            "path": "transfer/channel-2/2125"
-          },
-          "provider": "Picasso"
-        },
-        {
           "type": "ibc",
           "counterparty": {
             "chain_name": "composable",
@@ -16663,14 +15665,6 @@
       "display": "w",
       "symbol": "W",
       "traces": [
-        {
-          "type": "bridge",
-          "counterparty": {
-            "chain_name": "solana",
-            "base_denom": "85VBFQZC9TZkfaptBWjvUw7YbZjy52A6mjtPGjstQAmQ"
-          },
-          "provider": "Wormhole"
-        },
         {
           "type": "ibc",
           "counterparty": {
@@ -16752,7 +15746,8 @@
             "circle": true
           }
         }
-      ]
+      ],
+      "coingecko_id": "dhealth"
     },
     {
       "description": "The native token of Furya",
@@ -16802,6 +15797,7 @@
           "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/furya/images/fury.svg"
         }
       ],
+      "coingecko_id": "fanfury",
       "keywords": [
         "gaming",
         "staking"
@@ -16864,7 +15860,8 @@
             "dark_mode": false
           }
         }
-      ]
+      ],
+      "coingecko_id": "saga-2"
     },
     {
       "description": "$ATOM to $1,000 LFG!!",
@@ -16962,6 +15959,7 @@
           "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/shido/images/shido.svg"
         }
       ],
+      "coingecko_id": "shido-2",
       "keywords": [
         "osmosis_unlisted"
       ]
@@ -17063,7 +16061,8 @@
           },
           "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/injective/images/hava.png"
         }
-      ]
+      ],
+      "coingecko_id": "hava-coin"
     },
     {
       "description": "OnE mEmEcOiN tO cOnNeCt oL ImBeCiles - aNd in Da Cosmos BiNd DeM",
@@ -17198,7 +16197,8 @@
           "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/neutron/images/astro.png",
           "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/neutron/images/astro.svg"
         }
-      ]
+      ],
+      "coingecko_id": "astroport-fi"
     },
     {
       "description": "Astroport is a neutral marketplace where anyone, from anywhere in the galaxy, can dock to trade their wares.",
@@ -17222,14 +16222,6 @@
       "display": "xASTRO",
       "symbol": "xASTRO",
       "traces": [
-        {
-          "type": "liquid-stake",
-          "counterparty": {
-            "chain_name": "neutron",
-            "base_denom": "factory/neutron1ffus553eet978k024lmssw0czsxwr97mggyv85lpcsdkft8v9ufsz3sa07/astro"
-          },
-          "provider": "Astroport"
-        },
         {
           "type": "ibc",
           "counterparty": {
@@ -17276,26 +16268,10 @@
       ],
       "type_asset": "ics20",
       "base": "ibc/A5CCD24BA902843B1003A7EEE5F937C632808B9CF4925601241B15C5A0A51A53",
-      "name": "Paxos Gold (Gravity Bridge)",
+      "name": "Paxos Gold",
       "display": "gpaxg",
-      "symbol": "PAXG.grv",
+      "symbol": "PAXG",
       "traces": [
-        {
-          "type": "synthetic",
-          "counterparty": {
-            "chain_name": "comex",
-            "base_denom": "XAU"
-          },
-          "provider": "Paxos"
-        },
-        {
-          "type": "bridge",
-          "counterparty": {
-            "chain_name": "ethereum",
-            "base_denom": "0x45804880De22913dAFE09f4980848ECE6EcbAf78"
-          },
-          "provider": "Gravity Bridge"
-        },
         {
           "type": "ibc",
           "counterparty": {
@@ -17425,23 +16401,10 @@
       ],
       "type_asset": "ics20",
       "base": "ibc/A23E590BA7E0D808706FB5085A449B3B9D6864AE4DDE7DAF936243CEBB2A3D43",
-      "name": "Ethereum (Picasso)",
+      "name": "Ethereum",
       "display": "eth",
-      "symbol": "ETH.pica",
+      "symbol": "ETH",
       "traces": [
-        {
-          "type": "ibc-bridge",
-          "counterparty": {
-            "chain_name": "ethereum",
-            "base_denom": "wei",
-            "channel_id": "channel-2"
-          },
-          "chain": {
-            "channel_id": "channel-52",
-            "path": "transfer/channel-52/wei"
-          },
-          "provider": "Picasso"
-        },
         {
           "type": "ibc",
           "counterparty": {
@@ -17488,31 +16451,10 @@
       ],
       "type_asset": "ics20",
       "base": "ibc/37DFAFDA529FF7D513B0DB23E9728DF9BF73122D38D46824C78BB7F91E6A736B",
-      "name": "Dai Stablecoin (Picasso)",
+      "name": "Dai",
       "display": "dai",
-      "symbol": "DAI.pica",
+      "symbol": "DAI",
       "traces": [
-        {
-          "type": "synthetic",
-          "counterparty": {
-            "chain_name": "forex",
-            "base_denom": "USD"
-          },
-          "provider": "MakerDAO"
-        },
-        {
-          "type": "ibc-bridge",
-          "counterparty": {
-            "chain_name": "ethereum",
-            "base_denom": "0x6b175474e89094c44da98b954eedeac495271d0f",
-            "channel_id": "channel-2"
-          },
-          "chain": {
-            "channel_id": "channel-52",
-            "path": "transfer/channel-52/0x6b175474e89094c44da98b954eedeac495271d0f"
-          },
-          "provider": "Picasso"
-        },
         {
           "type": "ibc",
           "counterparty": {
@@ -17557,23 +16499,10 @@
       ],
       "type_asset": "ics20",
       "base": "ibc/5435437A8C9416B650DDA49C338B63CCFC6465123B715F6BAA9B1B2071E27913",
-      "name": "Frax Share (Picasso)",
+      "name": "Frax Shares",
       "display": "fxs",
-      "symbol": "FXS.pica",
+      "symbol": "FXS",
       "traces": [
-        {
-          "type": "ibc-bridge",
-          "counterparty": {
-            "chain_name": "ethereum",
-            "base_denom": "0x3432b6a60d23ca0dfca7761b7ab56459d9c964d0",
-            "channel_id": "channel-2"
-          },
-          "chain": {
-            "channel_id": "channel-52",
-            "path": "transfer/channel-52/0x3432b6a60d23ca0dfca7761b7ab56459d9c964d0"
-          },
-          "provider": "Picasso"
-        },
         {
           "type": "ibc",
           "counterparty": {
@@ -17620,31 +16549,10 @@
       ],
       "type_asset": "ics20",
       "base": "ibc/9A8CBC029002DC5170E715F93FBF35011FFC9796371F59B1F3C3094AE1B453A9",
-      "name": "Frax (Picasso)",
+      "name": "Frax",
       "display": "frax",
-      "symbol": "FRAX.pica",
+      "symbol": "FRAX",
       "traces": [
-        {
-          "type": "synthetic",
-          "counterparty": {
-            "chain_name": "forex",
-            "base_denom": "USD"
-          },
-          "provider": "Frax Protocol"
-        },
-        {
-          "type": "ibc-bridge",
-          "counterparty": {
-            "chain_name": "ethereum",
-            "base_denom": "0x853d955acef822db058eb8505911ed77f175b99e",
-            "channel_id": "channel-2"
-          },
-          "chain": {
-            "channel_id": "channel-52",
-            "path": "transfer/channel-52/0x853d955acef822db058eb8505911ed77f175b99e"
-          },
-          "provider": "Picasso"
-        },
         {
           "type": "ibc",
           "counterparty": {
@@ -17689,31 +16597,10 @@
       ],
       "type_asset": "ics20",
       "base": "ibc/078AD6F581E8115CDFBD8FFA29D8C71AFE250CE952AFF80040CBC64868D44AD3",
-      "name": "Tether USD (Ethereum via Picasso)",
+      "name": "Tether (Ethereum)",
       "display": "usdt",
-      "symbol": "USDT.eth.pica",
+      "symbol": "USDT",
       "traces": [
-        {
-          "type": "synthetic",
-          "counterparty": {
-            "chain_name": "forex",
-            "base_denom": "USD"
-          },
-          "provider": "Tether"
-        },
-        {
-          "type": "ibc-bridge",
-          "counterparty": {
-            "chain_name": "ethereum",
-            "base_denom": "0xdac17f958d2ee523a2206206994597c13d831ec7",
-            "channel_id": "channel-2"
-          },
-          "chain": {
-            "channel_id": "channel-52",
-            "path": "transfer/channel-52/0xdac17f958d2ee523a2206206994597c13d831ec7"
-          },
-          "provider": "Picasso"
-        },
         {
           "type": "ibc",
           "counterparty": {
@@ -17763,39 +16650,10 @@
       ],
       "type_asset": "ics20",
       "base": "ibc/0EFA07F312E05258A56AE1DD600E39B9151CF7A91C8A94EEBCF4F03ECFE5DD98",
-      "name": "Staked FRAX (Picasso)",
+      "name": "Staked FRAX",
       "display": "sfrax",
-      "symbol": "sFRAX.pica",
+      "symbol": "sFRAX",
       "traces": [
-        {
-          "type": "synthetic",
-          "counterparty": {
-            "chain_name": "forex",
-            "base_denom": "USD"
-          },
-          "provider": "Frax Protocol"
-        },
-        {
-          "type": "liquid-stake",
-          "counterparty": {
-            "chain_name": "ethereum",
-            "base_denom": "0x853d955acef822db058eb8505911ed77f175b99e"
-          },
-          "provider": "Frax"
-        },
-        {
-          "type": "ibc-bridge",
-          "counterparty": {
-            "chain_name": "ethereum",
-            "base_denom": "0xa663b02cf0a4b149d2ad41910cb81e23e1c41c32",
-            "channel_id": "channel-2"
-          },
-          "chain": {
-            "channel_id": "channel-52",
-            "path": "transfer/channel-52/0xa663b02cf0a4b149d2ad41910cb81e23e1c41c32"
-          },
-          "provider": "Picasso"
-        },
         {
           "type": "ibc",
           "counterparty": {
@@ -17842,31 +16700,10 @@
       ],
       "type_asset": "ics20",
       "base": "ibc/688E70EF567E5D4BA1CF4C54BAD758C288BC1A6C8B0B12979F911A2AE95E27EC",
-      "name": "Frax Ether (Picasso)",
+      "name": "Frax Ether",
       "display": "frxeth",
-      "symbol": "frxETH.pica",
+      "symbol": "frxETH",
       "traces": [
-        {
-          "type": "synthetic",
-          "counterparty": {
-            "chain_name": "ethereum",
-            "base_denom": "wei"
-          },
-          "provider": "Frax"
-        },
-        {
-          "type": "ibc-bridge",
-          "counterparty": {
-            "chain_name": "ethereum",
-            "base_denom": "0x5e8422345238f34275888049021821e8e08caa1f",
-            "channel_id": "channel-2"
-          },
-          "chain": {
-            "channel_id": "channel-52",
-            "path": "transfer/channel-52/0x5e8422345238f34275888049021821e8e08caa1f"
-          },
-          "provider": "Picasso"
-        },
         {
           "type": "ibc",
           "counterparty": {
@@ -17913,39 +16750,10 @@
       ],
       "type_asset": "ics20",
       "base": "ibc/F17CCB4F07948CC2D8B72952C2D0A84F2B763962F698774BB121B872AE4611B5",
-      "name": "Staked Frax Ether (Picasso)",
+      "name": "Frax Staked Ether",
       "display": "sfrxeth",
-      "symbol": "sfrxETH.pica",
+      "symbol": "sfrxETH",
       "traces": [
-        {
-          "type": "synthetic",
-          "counterparty": {
-            "chain_name": "ethereum",
-            "base_denom": "wei"
-          },
-          "provider": "Frax"
-        },
-        {
-          "type": "liquid-stake",
-          "counterparty": {
-            "chain_name": "ethereum",
-            "base_denom": "0x5e8422345238f34275888049021821e8e08caa1f"
-          },
-          "provider": "Frax"
-        },
-        {
-          "type": "ibc-bridge",
-          "counterparty": {
-            "chain_name": "ethereum",
-            "base_denom": "0xac3e018457b222d93114458476f3e3416abbe38f",
-            "channel_id": "channel-2"
-          },
-          "chain": {
-            "channel_id": "channel-52",
-            "path": "transfer/channel-52/0xac3e018457b222d93114458476f3e3416abbe38f"
-          },
-          "provider": "Picasso"
-        },
         {
           "type": "ibc",
           "counterparty": {
@@ -18140,18 +16948,6 @@
         {
           "type": "ibc",
           "counterparty": {
-            "chain_name": "nim",
-            "base_denom": "anim",
-            "channel_id": "channel-0"
-          },
-          "chain": {
-            "channel_id": "channel-49",
-            "path": "transfer/channel-49/anim"
-          }
-        },
-        {
-          "type": "ibc",
-          "counterparty": {
             "chain_name": "dymension",
             "base_denom": "ibc/FB53D1684F155CBB86D9CE917807E42B59209EBE3AD3A92E15EF66586C073942",
             "channel_id": "channel-2"
@@ -18176,6 +16972,7 @@
           "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/nim/images/nim.svg"
         }
       ],
+      "coingecko_id": "nim-network",
       "keywords": [
         "gaming",
         "AI",
@@ -18233,7 +17030,8 @@
           "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/seda/images/seda.png",
           "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/seda/images/seda.svg"
         }
-      ]
+      ],
+      "coingecko_id": "seda-2"
     },
     {
       "description": "Cosmos Airdrop Chat",
@@ -18472,14 +17270,6 @@
       "symbol": "qJUNO",
       "traces": [
         {
-          "type": "liquid-stake",
-          "counterparty": {
-            "chain_name": "juno",
-            "base_denom": "ujuno"
-          },
-          "provider": "Quicksilver"
-        },
-        {
           "type": "ibc",
           "counterparty": {
             "chain_name": "quicksilver",
@@ -18529,14 +17319,6 @@
       "display": "qsaga",
       "symbol": "qSAGA",
       "traces": [
-        {
-          "type": "liquid-stake",
-          "counterparty": {
-            "chain_name": "saga",
-            "base_denom": "usaga"
-          },
-          "provider": "Quicksilver"
-        },
         {
           "type": "ibc",
           "counterparty": {
@@ -18588,14 +17370,6 @@
       "symbol": "qDYDX",
       "traces": [
         {
-          "type": "liquid-stake",
-          "counterparty": {
-            "chain_name": "dydx",
-            "base_denom": "adydx"
-          },
-          "provider": "Quicksilver"
-        },
-        {
           "type": "ibc",
           "counterparty": {
             "chain_name": "quicksilver",
@@ -18646,14 +17420,6 @@
       "symbol": "qBLD",
       "traces": [
         {
-          "type": "liquid-stake",
-          "counterparty": {
-            "chain_name": "agoric",
-            "base_denom": "ubld"
-          },
-          "provider": "Quicksilver"
-        },
-        {
           "type": "ibc",
           "counterparty": {
             "chain_name": "quicksilver",
@@ -18699,23 +17465,10 @@
       ],
       "type_asset": "ics20",
       "base": "ibc/5B5BFCC8A9F0D554A4245117F7798E85BE25B6C73DBFA2D6F369BD9DD6CACC6D",
-      "name": "Pepe (Picasso)",
+      "name": "Pepe",
       "display": "pepe",
-      "symbol": "PEPE.pica",
+      "symbol": "PEPE",
       "traces": [
-        {
-          "type": "ibc-bridge",
-          "counterparty": {
-            "chain_name": "ethereum",
-            "base_denom": "0x6982508145454Ce325dDbE47a25d4ec3d2311933",
-            "channel_id": "channel-2"
-          },
-          "chain": {
-            "channel_id": "channel-52",
-            "path": "transfer/channel-52/0x6982508145454ce325ddbe47a25d4ec3d2311933"
-          },
-          "provider": "Picasso"
-        },
         {
           "type": "ibc",
           "counterparty": {
@@ -18765,23 +17518,10 @@
       ],
       "type_asset": "ics20",
       "base": "ibc/080CE38C1E49595F2199E88BE7281F93FAEEF3FE354EECED0640625E8311C9CF",
-      "name": "Curve DAO (Picasso)",
+      "name": "Curve DAO",
       "display": "crv",
-      "symbol": "CRV.pica",
+      "symbol": "CRV",
       "traces": [
-        {
-          "type": "ibc-bridge",
-          "counterparty": {
-            "chain_name": "ethereum",
-            "base_denom": "0xd533a949740bb3306d119cc777fa900ba034cd52",
-            "channel_id": "channel-2"
-          },
-          "chain": {
-            "channel_id": "channel-52",
-            "path": "transfer/channel-52/0xd533a949740bb3306d119cc777fa900ba034cd52"
-          },
-          "provider": "Picasso"
-        },
         {
           "type": "ibc",
           "counterparty": {
@@ -18829,31 +17569,10 @@
       ],
       "type_asset": "ics20",
       "base": "ibc/39AAE0F5F918B731BEF1E02E9BAED33C242805F668B0A941AC509FB569FE51CB",
-      "name": "Renzo Restaked ETH (Picasso)",
+      "name": "Renzo Restaked ETH",
       "display": "ezeth",
-      "symbol": "ezETH.pica",
+      "symbol": "ezETH",
       "traces": [
-        {
-          "type": "liquid-stake",
-          "counterparty": {
-            "chain_name": "ethereum",
-            "base_denom": "wei"
-          },
-          "provider": "Renzo"
-        },
-        {
-          "type": "ibc-bridge",
-          "counterparty": {
-            "chain_name": "ethereum",
-            "base_denom": "0xbf5495efe5db9ce00f80364c8b423567e58d2110",
-            "channel_id": "channel-2"
-          },
-          "chain": {
-            "channel_id": "channel-52",
-            "path": "transfer/channel-52/0xbf5495efe5db9ce00f80364c8b423567e58d2110"
-          },
-          "provider": "Picasso"
-        },
         {
           "type": "ibc",
           "counterparty": {
@@ -18901,31 +17620,10 @@
       ],
       "type_asset": "ics20",
       "base": "ibc/BFFE212A23384C4EB055CF6F95A1F5EC1BE0F9BD286FAA66C3748F0444E67D63",
-      "name": "Ethena USDe (Picasso)",
+      "name": "Ethena USDe",
       "display": "usde",
-      "symbol": "USDe.pica",
+      "symbol": "USDe",
       "traces": [
-        {
-          "type": "synthetic",
-          "counterparty": {
-            "chain_name": "forex",
-            "base_denom": "USD"
-          },
-          "provider": "Ethena"
-        },
-        {
-          "type": "ibc-bridge",
-          "counterparty": {
-            "chain_name": "ethereum",
-            "base_denom": "0x4c9edd5852cd905f086c759e8383e09bff1e68b3",
-            "channel_id": "channel-2"
-          },
-          "chain": {
-            "channel_id": "channel-52",
-            "path": "transfer/channel-52/0x4c9edd5852cd905f086c759e8383e09bff1e68b3"
-          },
-          "provider": "Picasso"
-        },
         {
           "type": "ibc",
           "counterparty": {
@@ -18973,23 +17671,10 @@
       ],
       "type_asset": "ics20",
       "base": "ibc/257FF64F160106F6EE43CEE7C761DA64C1346221895373CC810FFA1BFAC5A7CD",
-      "name": "Ethena (Picasso)",
+      "name": "Ethena",
       "display": "ena",
-      "symbol": "ENA.pica",
+      "symbol": "ENA",
       "traces": [
-        {
-          "type": "ibc-bridge",
-          "counterparty": {
-            "chain_name": "ethereum",
-            "base_denom": "0x57e114b691db790c35207b2e685d4a43181e6061",
-            "channel_id": "channel-2"
-          },
-          "chain": {
-            "channel_id": "channel-52",
-            "path": "transfer/channel-52/0x57e114b691db790c35207b2e685d4a43181e6061"
-          },
-          "provider": "Picasso"
-        },
         {
           "type": "ibc",
           "counterparty": {
@@ -19037,31 +17722,10 @@
       ],
       "type_asset": "ics20",
       "base": "ibc/8D0FFEA4EDB04E3C1738C9599B66AE49683E0540FC4C1214AC84534C200D818B",
-      "name": "ether.fi Staked ETH (Picasso)",
+      "name": "ether.fi Staked ETH",
       "display": "eeth",
-      "symbol": "eETH.pica",
+      "symbol": "eETH",
       "traces": [
-        {
-          "type": "liquid-stake",
-          "counterparty": {
-            "chain_name": "ethereum",
-            "base_denom": "wei"
-          },
-          "provider": "EtherFi"
-        },
-        {
-          "type": "ibc-bridge",
-          "counterparty": {
-            "chain_name": "ethereum",
-            "base_denom": "0x35fa164735182de50811e8e2e824cfb9b6118ac2",
-            "channel_id": "channel-2"
-          },
-          "chain": {
-            "channel_id": "channel-52",
-            "path": "transfer/channel-52/0x35fa164735182de50811e8e2e824cfb9b6118ac2"
-          },
-          "provider": "Picasso"
-        },
         {
           "type": "ibc",
           "counterparty": {
@@ -19109,31 +17773,10 @@
       ],
       "type_asset": "ics20",
       "base": "ibc/D09BB89B2187EF13EF006B44510749B0F02FD0B34F8BB55C70D812A1FF6148C7",
-      "name": "Dinero Staked ETH (Picasso)",
+      "name": "Dinero Staked ETH",
       "display": "pxeth",
-      "symbol": "pxETH.pica",
+      "symbol": "pxETH",
       "traces": [
-        {
-          "type": "liquid-stake",
-          "counterparty": {
-            "chain_name": "ethereum",
-            "base_denom": "wei"
-          },
-          "provider": "Dinero"
-        },
-        {
-          "type": "ibc-bridge",
-          "counterparty": {
-            "chain_name": "ethereum",
-            "base_denom": "0x04c154b66cb340f3ae24111cc767e0184ed00cc6",
-            "channel_id": "channel-2"
-          },
-          "chain": {
-            "channel_id": "channel-52",
-            "path": "transfer/channel-52/0x04c154b66cb340f3ae24111cc767e0184ed00cc6"
-          },
-          "provider": "Picasso"
-        },
         {
           "type": "ibc",
           "counterparty": {
@@ -19181,31 +17824,10 @@
       ],
       "type_asset": "ics20",
       "base": "ibc/63551E7BB24008F0AFC1CB051A423A5104F781F035F8B1A191264B7086A0A0F6",
-      "name": "crvUSD (Picasso)",
+      "name": "crvUSD",
       "display": "crvusd",
-      "symbol": "crvUSD.pica",
+      "symbol": "crvUSD",
       "traces": [
-        {
-          "type": "synthetic",
-          "counterparty": {
-            "chain_name": "forex",
-            "base_denom": "USD"
-          },
-          "provider": "Curve Finance"
-        },
-        {
-          "type": "ibc-bridge",
-          "counterparty": {
-            "chain_name": "ethereum",
-            "base_denom": "0xf939e0a03fb07f59a73314e73794be0e57ac1b4e",
-            "channel_id": "channel-2"
-          },
-          "chain": {
-            "channel_id": "channel-52",
-            "path": "transfer/channel-52/0xf939e0a03fb07f59a73314e73794be0e57ac1b4e"
-          },
-          "provider": "Picasso"
-        },
         {
           "type": "ibc",
           "counterparty": {
@@ -19333,39 +17955,10 @@
       ],
       "type_asset": "ics20",
       "base": "ibc/0233A3F2541FD43DBCA569B27AF886E97F5C03FC0305E4A8A3FAC6AC26249C7A",
-      "name": "Tether USD (Solana via Picasso)",
+      "name": "Tether",
       "display": "usdt",
-      "symbol": "USDT.sol.pica",
+      "symbol": "USDT",
       "traces": [
-        {
-          "type": "synthetic",
-          "counterparty": {
-            "chain_name": "forex",
-            "base_denom": "USD"
-          },
-          "provider": "Tether"
-        },
-        {
-          "type": "additional-mintage",
-          "counterparty": {
-            "chain_name": "ethereum",
-            "base_denom": "0xdac17f958d2ee523a2206206994597c13d831ec7"
-          },
-          "provider": "Tether"
-        },
-        {
-          "type": "ibc-bridge",
-          "counterparty": {
-            "chain_name": "solana",
-            "base_denom": "Es9vMFrzaCERmJfrF4H2FYD4KCoNkY11McCe8BenwNYB",
-            "channel_id": "channel-1"
-          },
-          "chain": {
-            "channel_id": "channel-71",
-            "path": "transfer/channel-71/Es9vMFrzaCERmJfrF4H2FYD4KCoNkY11McCe8BenwNYB"
-          },
-          "provider": "Picasso"
-        },
         {
           "type": "ibc",
           "counterparty": {
@@ -19417,31 +18010,10 @@
       ],
       "type_asset": "ics20",
       "base": "ibc/B83F9E20B4A07FA8846880000BD9D8985D89567A090F5E9390C64E81C39B4607",
-      "name": "Edgevana Staked SOL (Picasso)",
+      "name": "Edgevana Staked SOL",
       "display": "edgesol",
-      "symbol": "edgeSOL.pica",
+      "symbol": "edgeSOL",
       "traces": [
-        {
-          "type": "liquid-stake",
-          "counterparty": {
-            "chain_name": "solana",
-            "base_denom": "Lamport"
-          },
-          "provider": "Edgevana"
-        },
-        {
-          "type": "ibc-bridge",
-          "counterparty": {
-            "chain_name": "solana",
-            "base_denom": "edge86g9cVz87xcpKpy3J77vbp4wYd9idEV562CCntt",
-            "channel_id": "channel-1"
-          },
-          "chain": {
-            "channel_id": "channel-71",
-            "path": "transfer/channel-71/edge86g9cVz87xcpKpy3J77vbp4wYd9idEV562CCntt"
-          },
-          "provider": "Picasso"
-        },
         {
           "type": "ibc",
           "counterparty": {
@@ -19488,31 +18060,10 @@
       ],
       "type_asset": "ics20",
       "base": "ibc/F618D130A2B8203D169811658BD0361F18DC2453085965FA0E5AEB8018DD54EE",
-      "name": "Liquid Staking Token (Picasso)",
+      "name": "Liquid Staking Token",
       "display": "lst",
-      "symbol": "LST.pica",
+      "symbol": "LST",
       "traces": [
-        {
-          "type": "liquid-stake",
-          "counterparty": {
-            "chain_name": "solana",
-            "base_denom": "Lamport"
-          },
-          "provider": "MarginFi"
-        },
-        {
-          "type": "ibc-bridge",
-          "counterparty": {
-            "chain_name": "solana",
-            "base_denom": "LSTxxxnJzKDFSLr4dUkPcmCf5VyryEqzPLz5j4bpxFp",
-            "channel_id": "channel-1"
-          },
-          "chain": {
-            "channel_id": "channel-71",
-            "path": "transfer/channel-71/LSTxxxnJzKDFSLr4dUkPcmCf5VyryEqzPLz5j4bpxFp"
-          },
-          "provider": "Picasso"
-        },
         {
           "type": "ibc",
           "counterparty": {
@@ -19566,31 +18117,10 @@
       ],
       "type_asset": "ics20",
       "base": "ibc/9A83BDF4C8C5FFDDE735533BC8CD4363714A6474AED1C2C492FB003BB77C7982",
-      "name": "Jito Staked SOL (Picasso)",
+      "name": "Jito Staked SOL",
       "display": "jitosol",
-      "symbol": "jitoSOL.pica",
+      "symbol": "jitoSOL",
       "traces": [
-        {
-          "type": "liquid-stake",
-          "counterparty": {
-            "chain_name": "solana",
-            "base_denom": "Lamport"
-          },
-          "provider": "Jito"
-        },
-        {
-          "type": "ibc-bridge",
-          "counterparty": {
-            "chain_name": "solana",
-            "base_denom": "J1toso1uCk3RLmjorhTtrVwY9HJ7X8V9yYac6Y7kGCPn",
-            "channel_id": "channel-1"
-          },
-          "chain": {
-            "channel_id": "channel-71",
-            "path": "transfer/channel-71/J1toso1uCk3RLmjorhTtrVwY9HJ7X8V9yYac6Y7kGCPn"
-          },
-          "provider": "Picasso"
-        },
         {
           "type": "ibc",
           "counterparty": {
@@ -19638,31 +18168,10 @@
       ],
       "type_asset": "ics20",
       "base": "ibc/0F9E9277B61A78CB31014D541ACA5BF6AB06DFC4524C4C836490B131DAAECD78",
-      "name": "Solana (Picasso)",
+      "name": "Wrapped Solana",
       "display": "wsol",
-      "symbol": "SOL.pica",
+      "symbol": "wSOL",
       "traces": [
-        {
-          "type": "wrapped",
-          "counterparty": {
-            "chain_name": "solana",
-            "base_denom": "Lamport"
-          },
-          "provider": "Solana"
-        },
-        {
-          "type": "ibc-bridge",
-          "counterparty": {
-            "chain_name": "solana",
-            "base_denom": "So11111111111111111111111111111111111111112",
-            "channel_id": "channel-1"
-          },
-          "chain": {
-            "channel_id": "channel-71",
-            "path": "transfer/channel-71/So11111111111111111111111111111111111111112"
-          },
-          "provider": "Picasso"
-        },
         {
           "type": "ibc",
           "counterparty": {
@@ -19723,14 +18232,6 @@
         {
           "type": "synthetic",
           "counterparty": {
-            "chain_name": "forex",
-            "base_denom": "USD"
-          },
-          "provider": "Tether"
-        },
-        {
-          "type": "synthetic",
-          "counterparty": {
             "chain_name": "ethereum",
             "base_denom": "0xdac17f958d2ee523a2206206994597c13d831ec7"
           },
@@ -19787,19 +18288,6 @@
       "display": "whine",
       "symbol": "WHINE",
       "traces": [
-        {
-          "type": "ibc-bridge",
-          "counterparty": {
-            "chain_name": "solana",
-            "base_denom": "ATeTQcUkWGs7AZ15mCiFUWCW9EUL7KpDZEHCN1Y8pump",
-            "channel_id": "channel-1"
-          },
-          "chain": {
-            "channel_id": "channel-71",
-            "path": "transfer/channel-71/ATeTQcUkWGs7AZ15mCiFUWCW9EUL7KpDZEHCN1Y8pump"
-          },
-          "provider": "Picasso"
-        },
         {
           "type": "ibc",
           "counterparty": {
@@ -19968,7 +18456,7 @@
       "type_asset": "ics20",
       "base": "ibc/46579C587A0B8CF8B0A1FF6B0EFA2082F11876578E47FC81A9CAAD31F424AF98",
       "name": "Juris Protocol",
-      "display": "rakoff",
+      "display": "juris",
       "symbol": "JURIS",
       "traces": [
         {
@@ -20015,42 +18503,10 @@
       ],
       "type_asset": "ics20",
       "base": "ibc/64E62451C9A5682FF3047429C6E4714A02CDC0C35DE35CAB01E18D1188004CEB",
-      "name": "Ethereum (Arbitrum via Axelar)",
+      "name": "Arbitrum axlETH",
       "display": "arbitrum-weth",
-      "symbol": "ETH.arb.axl",
+      "symbol": "axlETH",
       "traces": [
-        {
-          "type": "wrapped",
-          "counterparty": {
-            "chain_name": "ethereum",
-            "base_denom": "wei"
-          },
-          "provider": "Ethereum"
-        },
-        {
-          "type": "bridge",
-          "counterparty": {
-            "chain_name": "ethereum",
-            "base_denom": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2"
-          },
-          "provider": "Arbitrum Bridge"
-        },
-        {
-          "type": "wrapped",
-          "counterparty": {
-            "chain_name": "arbitrum",
-            "base_denom": "wei"
-          },
-          "provider": "Arbitrum"
-        },
-        {
-          "type": "bridge",
-          "counterparty": {
-            "chain_name": "arbitrum",
-            "base_denom": "0x82aF49447D8a07e3bd95BD0d56f35241523fBab1"
-          },
-          "provider": "Axelar"
-        },
         {
           "type": "ibc",
           "counterparty": {
@@ -20102,34 +18558,10 @@
       ],
       "type_asset": "ics20",
       "base": "ibc/D7D6DEF2A4F7ED0A6F5F0E266C1B2C9726E82F67EBBE49BBB47B3DEC289F8D7B",
-      "name": "Ethereum (Base via Axelar)",
+      "name": "Base axlETH",
       "display": "base-weth",
-      "symbol": "ETH.base.axl",
+      "symbol": "axlETH",
       "traces": [
-        {
-          "type": "bridge",
-          "counterparty": {
-            "chain_name": "ethereum",
-            "base_denom": "wei"
-          },
-          "provider": "Base Bridge"
-        },
-        {
-          "type": "wrapped",
-          "counterparty": {
-            "chain_name": "base",
-            "base_denom": "wei"
-          },
-          "provider": "Base"
-        },
-        {
-          "type": "bridge",
-          "counterparty": {
-            "chain_name": "base",
-            "base_denom": "0x4200000000000000000000000000000000000006"
-          },
-          "provider": "Axelar"
-        },
         {
           "type": "ibc",
           "counterparty": {
@@ -20181,34 +18613,10 @@
       ],
       "type_asset": "ics20",
       "base": "ibc/F9EB60AC212DBF05F4C5ED0FDE03BB9F08309B0EE9899A406AD4B904CF84968E",
-      "name": "Ethereum (Polygon via Axelar)",
+      "name": "Polygon axlETH",
       "display": "polygon-weth",
-      "symbol": "ETH.matic.axl",
+      "symbol": "axlETH",
       "traces": [
-        {
-          "type": "wrapped",
-          "counterparty": {
-            "chain_name": "ethereum",
-            "base_denom": "wei"
-          },
-          "provider": "Ethereum"
-        },
-        {
-          "type": "bridge",
-          "counterparty": {
-            "chain_name": "ethereum",
-            "base_denom": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2"
-          },
-          "provider": "Polygon PoS Bridge"
-        },
-        {
-          "type": "bridge",
-          "counterparty": {
-            "chain_name": "polygon",
-            "base_denom": "0x7ceB23fD6bC0adD59E62ac25578270cFf1b9f619"
-          },
-          "provider": "Axelar"
-        },
         {
           "type": "ibc",
           "counterparty": {
@@ -20265,14 +18673,6 @@
       "symbol": "stISLM",
       "traces": [
         {
-          "type": "liquid-stake",
-          "counterparty": {
-            "chain_name": "haqq",
-            "base_denom": "aISLM"
-          },
-          "provider": "Stride"
-        },
-        {
           "type": "ibc",
           "counterparty": {
             "chain_name": "stride",
@@ -20298,7 +18698,8 @@
           "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/stride/images/stislm.png",
           "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/stride/images/stislm.svg"
         }
-      ]
+      ],
+      "coingecko_id": "stride-staked-islm"
     },
     {
       "description": "The native token of Mande Network.",
@@ -20326,18 +18727,6 @@
         {
           "type": "ibc",
           "counterparty": {
-            "chain_name": "mande",
-            "base_denom": "amand",
-            "channel_id": "channel-0"
-          },
-          "chain": {
-            "channel_id": "channel-51",
-            "path": "transfer/channel-51/amand"
-          }
-        },
-        {
-          "type": "ibc",
-          "counterparty": {
             "chain_name": "dymension",
             "base_denom": "ibc/5A26C8DC8DA66F4DD94326E67F94510188F5F7AFE2DB3933A0C823670E56EABF",
             "channel_id": "channel-2"
@@ -20362,6 +18751,7 @@
           "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/mande/images/mande.svg"
         }
       ],
+      "coingecko_id": "mande-network",
       "keywords": [
         "credibility",
         "identity",
@@ -20421,7 +18811,8 @@
           "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/neutaro/images/neutaro.png",
           "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/neutaro/images/neutaro.svg"
         }
-      ]
+      ],
+      "coingecko_id": "neutaro"
     },
     {
       "description": "Pepe Bruce Jenner",
@@ -20450,14 +18841,6 @@
       "display": "wormhole/AbYYFgqSQEhe7NyXfo6w75GT7fCanVd9wNg4E9Df2puP/6",
       "symbol": "PBJ",
       "traces": [
-        {
-          "type": "bridge",
-          "counterparty": {
-            "chain_name": "solana",
-            "base_denom": "ANu4Wuq86WzRU8tykszQUJ66eQzFNfkwap2HcQ5UaFaU"
-          },
-          "provider": "Wormhole"
-        },
         {
           "type": "ibc",
           "counterparty": {
@@ -20532,7 +18915,8 @@
           "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/noble/images/usdy.png",
           "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/noble/images/usdy.svg"
         }
-      ]
+      ],
+      "coingecko_id": "ondo-us-dollar-yield"
     },
     {
       "description": "Jacob Haertnellez Turtle. Launched by Jake's Personally appointed TURD Cult Leader...\"NotSeanO'Riley.\" TURD is going to lead the shitcoins of Cosmos! Or Rug You. It will be Jake's Fault. ",
@@ -20608,7 +18992,8 @@
           "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/firmachain/images/fct.png",
           "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/firmachain/images/fct.svg"
         }
-      ]
+      ],
+      "coingecko_id": "firmachain"
     },
     {
       "description": "An alloy of ETH asset variants on Osmosis.",
@@ -20752,7 +19137,8 @@
           },
           "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/lava/images/lava.png"
         }
-      ]
+      ],
+      "coingecko_id": "lava-network"
     },
     {
       "description": "The native token of Penumbra.",
@@ -20874,14 +19260,6 @@
         {
           "type": "synthetic",
           "counterparty": {
-            "chain_name": "forex",
-            "base_denom": "USD"
-          },
-          "provider": "Tether"
-        },
-        {
-          "type": "synthetic",
-          "counterparty": {
             "chain_name": "ethereum",
             "base_denom": "0xdac17f958d2ee523a2206206994597c13d831ec7"
           },
@@ -20977,14 +19355,6 @@
       "display": "stBAND",
       "symbol": "stBAND",
       "traces": [
-        {
-          "type": "liquid-stake",
-          "counterparty": {
-            "chain_name": "bandchain",
-            "base_denom": "uband"
-          },
-          "provider": "Stride"
-        },
         {
           "type": "ibc",
           "counterparty": {
@@ -21136,7 +19506,8 @@
           "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/routerchain/images/router.svg",
           "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/routerchain/images/router.png"
         }
-      ]
+      ],
+      "coingecko_id": "router-protocol-2"
     },
     {
       "description": "An alloy of OP asset variants on Osmosis.",
@@ -21198,18 +19569,10 @@
       ],
       "type_asset": "ics20",
       "base": "ibc/14A291DD362798D6805B7ABCB8D09AEEE02176108F89FA09AA43EA2EE096A2A9",
-      "name": "Optimism (Axelar)",
+      "name": "Optimism",
       "display": "op",
-      "symbol": "OP.axl",
+      "symbol": "OP",
       "traces": [
-        {
-          "type": "bridge",
-          "counterparty": {
-            "chain_name": "optimism",
-            "base_denom": "0x4200000000000000000000000000000000000042"
-          },
-          "provider": "Axelar"
-        },
         {
           "type": "ibc",
           "counterparty": {
@@ -21469,31 +19832,10 @@
       ],
       "type_asset": "ics20",
       "base": "ibc/C91210281CEB708DC6E41A47FC9EC298F45712273DD58C682BEBAD00DCB59DC2",
-      "name": "Unicorn (Solana via Picasso)",
+      "name": "Unicorn",
       "display": "unicorn",
-      "symbol": "UWU.sol.pica",
+      "symbol": "UWU",
       "traces": [
-        {
-          "type": "additional-mintage",
-          "counterparty": {
-            "chain_name": "unicorn",
-            "base_denom": "uwunicorn"
-          },
-          "provider": "Unicorn"
-        },
-        {
-          "type": "ibc-bridge",
-          "counterparty": {
-            "chain_name": "solana",
-            "base_denom": "UwU8RVXB69Y6Dcju6cN2Qef6fykkq6UUNpB15rZku6Z",
-            "channel_id": "channel-1"
-          },
-          "chain": {
-            "channel_id": "channel-71",
-            "path": "transfer/channel-71/UwU8RVXB69Y6Dcju6cN2Qef6fykkq6UUNpB15rZku6Z"
-          },
-          "provider": "Picasso"
-        },
         {
           "type": "ibc",
           "counterparty": {
@@ -21541,14 +19883,6 @@
       "display": "DEEN",
       "symbol": "DEEN",
       "traces": [
-        {
-          "type": "synthetic",
-          "counterparty": {
-            "chain_name": "comex",
-            "base_denom": "XAU"
-          },
-          "provider": "Deenar"
-        },
         {
           "type": "ibc",
           "counterparty": {
@@ -21658,26 +19992,10 @@
       ],
       "type_asset": "ics20",
       "base": "ibc/2AD3C64D19ADFBB522CD738B58F421102143F827C1CAFF574A8BF0B81017D53D",
-      "name": "Tether USD (Ethereum) (Injective)",
+      "name": "Tether USDT",
       "display": "usdt",
-      "symbol": "USDT.eth.inj",
+      "symbol": "USDT",
       "traces": [
-        {
-          "type": "synthetic",
-          "counterparty": {
-            "chain_name": "forex",
-            "base_denom": "USD"
-          },
-          "provider": "Tether"
-        },
-        {
-          "type": "bridge",
-          "counterparty": {
-            "chain_name": "ethereum",
-            "base_denom": "0xdac17f958d2ee523a2206206994597c13d831ec7"
-          },
-          "provider": "Peggy"
-        },
         {
           "type": "ibc",
           "counterparty": {
@@ -21896,7 +20214,8 @@
           "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/neutron/images/mars-token.png",
           "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/neutron/images/mars-token.svg"
         }
-      ]
+      ],
+      "coingecko_id": "mars-protocol-a7fcbcfb-fd61-4017-92f0-7ee9f9cc6da3"
     },
     {
       "description": "The native token of TON",
@@ -21915,18 +20234,10 @@
       ],
       "type_asset": "ics20",
       "base": "ibc/905889A7F0B94F1CE1506D9BADF13AE9141E4CBDBCD565E1DFC7AE418B3E3E98",
-      "name": "Toncoin (Oraichain Labs TON Bridge)",
+      "name": "Toncoin",
       "display": "ton",
-      "symbol": "TON.orai",
+      "symbol": "TON",
       "traces": [
-        {
-          "type": "bridge",
-          "counterparty": {
-            "chain_name": "ton",
-            "base_denom": "nanoton"
-          },
-          "provider": "Oraichain Labs TON Bridge"
-        },
         {
           "type": "ibc",
           "counterparty": {
@@ -22026,14 +20337,6 @@
       "display": "display_stBTC",
       "symbol": "stBTC",
       "traces": [
-        {
-          "type": "liquid-stake",
-          "counterparty": {
-            "chain_name": "bitcoin",
-            "base_denom": "sat"
-          },
-          "provider": "Lorenzo"
-        },
         {
           "type": "ibc",
           "counterparty": {
@@ -22141,14 +20444,6 @@
         {
           "type": "bridge",
           "counterparty": {
-            "chain_name": "avail",
-            "base_denom": "avail"
-          },
-          "provider": "Avail Bridge"
-        },
-        {
-          "type": "bridge",
-          "counterparty": {
             "chain_name": "ethereum",
             "base_denom": "0xEeB4d8400AEefafC1B2953e0094134A887C76Bd8"
           },
@@ -22195,22 +20490,6 @@
       "symbol": "EURe",
       "traces": [
         {
-          "type": "synthetic",
-          "counterparty": {
-            "chain_name": "forex",
-            "base_denom": "EUR"
-          },
-          "provider": "Monerium"
-        },
-        {
-          "type": "additional-mintage",
-          "counterparty": {
-            "chain_name": "ethereum",
-            "base_denom": "0x3231Cb76718CDeF2155FC47b5286d82e6eDA273f"
-          },
-          "provider": "Monerium"
-        },
-        {
           "type": "ibc",
           "counterparty": {
             "chain_name": "noble",
@@ -22239,7 +20518,8 @@
             "circle": true
           }
         }
-      ]
+      ],
+      "coingecko_id": "monerium-eur-money"
     },
     {
       "description": "The native staking and governance token of Andromeda",
@@ -22286,7 +20566,8 @@
           },
           "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/andromeda/images/andromeda-logo.png"
         }
-      ]
+      ],
+      "coingecko_id": "andromeda-2"
     },
     {
       "description": "Chain-key Bitcoin bridged via Omnity Network.",
@@ -22310,14 +20591,6 @@
       "display": "ckBTC",
       "symbol": "ckBTC",
       "traces": [
-        {
-          "type": "bridge",
-          "counterparty": {
-            "chain_name": "bitcoin",
-            "base_denom": "sat"
-          },
-          "provider": "Omnity Network"
-        },
         {
           "type": "bridge",
           "counterparty": {
@@ -22703,7 +20976,8 @@
           "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/stratos/images/stratos.png",
           "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/stratos/images/stratos.svg"
         }
-      ]
+      ],
+      "coingecko_id": "stratos"
     },
     {
       "description": "Uniswap UNI on Osmosis via Axelar",
@@ -22722,18 +20996,10 @@
       ],
       "type_asset": "ics20",
       "base": "ibc/AE2719773D6FCDD05AC17B1ED63F672F5F9D84144A61965F348C86C2A83AD161",
-      "name": "Uniswap (Axelar)",
+      "name": "Uniswap",
       "display": "uni",
-      "symbol": "UNI.axl",
+      "symbol": "UNI",
       "traces": [
-        {
-          "type": "bridge",
-          "counterparty": {
-            "chain_name": "ethereum",
-            "base_denom": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984"
-          },
-          "provider": "Axelar"
-        },
         {
           "type": "ibc",
           "counterparty": {
@@ -22914,18 +21180,10 @@
       ],
       "type_asset": "ics20",
       "base": "ibc/B3DFDC2958A2BE482532DA3B6B5729B469BE7475598F7487D98B1B3E085245DE",
-      "name": "Dogecoin (Int3)",
+      "name": "Dogecoin",
       "display": "doge",
-      "symbol": "DOGE.int3",
+      "symbol": "DOGE",
       "traces": [
-        {
-          "type": "bridge",
-          "counterparty": {
-            "chain_name": "dogecoin",
-            "base_denom": "shibe"
-          },
-          "provider": "Int3face"
-        },
         {
           "type": "ibc",
           "counterparty": {
@@ -22971,18 +21229,10 @@
       ],
       "type_asset": "ics20",
       "base": "ibc/2F4258D6E1E01B203D6CA83F2C7E4959615053A21EC2C2FC196F7911CAC832EF",
-      "name": "Bitcoin (Int3)",
+      "name": "Bitcoin",
       "display": "btc",
-      "symbol": "BTC.int3",
+      "symbol": "BTC",
       "traces": [
-        {
-          "type": "bridge",
-          "counterparty": {
-            "chain_name": "bitcoin",
-            "base_denom": "sat"
-          },
-          "provider": "Int3face"
-        },
         {
           "type": "ibc",
           "counterparty": {
@@ -23028,18 +21278,10 @@
       ],
       "type_asset": "ics20",
       "base": "ibc/869E01805EBBDDCAEA588666CD5149728B7DC7D69F30D92F77AD67F77CEB3FDA",
-      "name": "Bitcoin Cash (Int3)",
+      "name": "Bitcoin Cash",
       "display": "bch",
-      "symbol": "BCH.int3",
+      "symbol": "BCH",
       "traces": [
-        {
-          "type": "bridge",
-          "counterparty": {
-            "chain_name": "bitcoincash",
-            "base_denom": "sat"
-          },
-          "provider": "Int3face"
-        },
         {
           "type": "ibc",
           "counterparty": {
@@ -23085,18 +21327,10 @@
       ],
       "type_asset": "ics20",
       "base": "ibc/905326586AE1C86AC8B1CDB20BE957DE5FB23963EDD2C9ADD3E835CC22115A46",
-      "name": "Litecoin (Int3)",
+      "name": "Litecoin",
       "display": "ltc",
-      "symbol": "LTC.int3",
+      "symbol": "LTC",
       "traces": [
-        {
-          "type": "bridge",
-          "counterparty": {
-            "chain_name": "litecoin",
-            "base_denom": "litoshi"
-          },
-          "provider": "Int3face"
-        },
         {
           "type": "ibc",
           "counterparty": {
@@ -23142,34 +21376,10 @@
       ],
       "type_asset": "ics20",
       "base": "ibc/57B63A0795B6BC0AC4EFD0D4DEE9FE71FCC1D0FFA87F6280C9CDEF4F6727A173",
-      "name": "Tether USD (Ethereum) (Arbitrum via Axelar)",
+      "name": "Tether USD (Arbitrum)",
       "display": "usdt",
-      "symbol": "USDT.e.arb.axl",
+      "symbol": "axlUSDT",
       "traces": [
-        {
-          "type": "synthetic",
-          "counterparty": {
-            "chain_name": "forex",
-            "base_denom": "USD"
-          },
-          "provider": "Tether"
-        },
-        {
-          "type": "bridge",
-          "counterparty": {
-            "chain_name": "ethereum",
-            "base_denom": "0xdac17f958d2ee523a2206206994597c13d831ec7"
-          },
-          "provider": "Arbitrum Bridge"
-        },
-        {
-          "type": "bridge",
-          "counterparty": {
-            "chain_name": "arbitrum",
-            "base_denom": "0xFd086bC7CD5C481DCC9C85ebE478A1C0b69FCbb9"
-          },
-          "provider": "Axelar"
-        },
         {
           "type": "ibc",
           "counterparty": {
@@ -23218,34 +21428,10 @@
       ],
       "type_asset": "ics20",
       "base": "ibc/EEA21E12A250B7FBBCBBBD1F7AA78984F5C12D684B32EBEEFC585FF596A7BCDA",
-      "name": "Tether USD (Ethereum) (optimism via Axelar)",
+      "name": "Tether USD (Optimism)",
       "display": "usdt",
-      "symbol": "USDT.e.op.axl",
+      "symbol": "axlUSDT",
       "traces": [
-        {
-          "type": "synthetic",
-          "counterparty": {
-            "chain_name": "forex",
-            "base_denom": "USD"
-          },
-          "provider": "Tether"
-        },
-        {
-          "type": "bridge",
-          "counterparty": {
-            "chain_name": "ethereum",
-            "base_denom": "0xdac17f958d2ee523a2206206994597c13d831ec7"
-          },
-          "provider": "Optimism Bridge"
-        },
-        {
-          "type": "bridge",
-          "counterparty": {
-            "chain_name": "optimism",
-            "base_denom": "0x94b008aA00579c1307B0EF2c499aD98a8ce58e58"
-          },
-          "provider": "Axelar"
-        },
         {
           "type": "ibc",
           "counterparty": {
@@ -23294,34 +21480,10 @@
       ],
       "type_asset": "ics20",
       "base": "ibc/2F6003A92088B989A159C593C551DF7B04FA0A0419CA3ED087E45E0006ECFF6E",
-      "name": "Tether USD (Ethereum) (Polygon via Axelar)",
+      "name": "Tether USD (Polygon)",
       "display": "usdt",
-      "symbol": "USDT.e.matic.axl",
+      "symbol": "axlUSDT",
       "traces": [
-        {
-          "type": "synthetic",
-          "counterparty": {
-            "chain_name": "forex",
-            "base_denom": "USD"
-          },
-          "provider": "Tether"
-        },
-        {
-          "type": "bridge",
-          "counterparty": {
-            "chain_name": "ethereum",
-            "base_denom": "0xdac17f958d2ee523a2206206994597c13d831ec7"
-          },
-          "provider": "Polygon PoS Bridge"
-        },
-        {
-          "type": "bridge",
-          "counterparty": {
-            "chain_name": "polygon",
-            "base_denom": "0xc2132D05D31c914a87C6611C10748AEb04B58e8F"
-          },
-          "provider": "Axelar"
-        },
         {
           "type": "ibc",
           "counterparty": {
@@ -23370,26 +21532,10 @@
       ],
       "type_asset": "ics20",
       "base": "ibc/616C2EA69BC328F245CE449785CB0B526B462C48F19DCF9B3D30699579B4308A",
-      "name": "Coinbase Wrapped BTC (Axelar)",
+      "name": "Coinbase Warpped Bitcoin",
       "display": "cbbtc",
-      "symbol": "cbBTC.axl",
+      "symbol": "axl-cbBTC",
       "traces": [
-        {
-          "type": "synthetic",
-          "counterparty": {
-            "chain_name": "bitcoin",
-            "base_denom": "sat"
-          },
-          "provider": "Coinbase"
-        },
-        {
-          "type": "bridge",
-          "counterparty": {
-            "chain_name": "base",
-            "base_denom": "0xcbB7C0000aB88B473b1f5aFd9ef808440eed33Bf"
-          },
-          "provider": "Axelar"
-        },
         {
           "type": "ibc",
           "counterparty": {
@@ -23438,26 +21584,10 @@
       ],
       "type_asset": "ics20",
       "base": "ibc/22C342A34DD0189AC2B2697EE76C360A9FBA53748ABA76E12C3A9E9F5F1E130F",
-      "name": "Fire Bitcoin (Axelar)",
+      "name": "Fire Bitcoin",
       "display": "fbtc",
-      "symbol": "FBTC.axl",
+      "symbol": "axlFBTC",
       "traces": [
-        {
-          "type": "synthetic",
-          "counterparty": {
-            "chain_name": "bitcoin",
-            "base_denom": "sat"
-          },
-          "provider": "Ignition"
-        },
-        {
-          "type": "bridge",
-          "counterparty": {
-            "chain_name": "mantle",
-            "base_denom": "0xC96dE26018A54D51c097160568752c4E3BD6C364"
-          },
-          "provider": "Axelar"
-        },
         {
           "type": "ibc",
           "counterparty": {
@@ -23506,26 +21636,10 @@
       ],
       "type_asset": "ics20",
       "base": "ibc/4AC81C97BBB5482536F6401328E0E10BCCD98F0F471DCF64319A811E25E53CAB",
-      "name": "Lombard Staked Bitcoin (Ethereum via Axelar)",
+      "name": "Lombard Staked Bitcoin",
       "display": "lbtc",
-      "symbol": "LBTC.eth.axl",
+      "symbol": "axlLBTC",
       "traces": [
-        {
-          "type": "liquid-stake",
-          "counterparty": {
-            "chain_name": "bitcoin",
-            "base_denom": "sat"
-          },
-          "provider": "Lombard"
-        },
-        {
-          "type": "bridge",
-          "counterparty": {
-            "chain_name": "ethereum",
-            "base_denom": "0x8236a87084f8B84306f72007F36F2618A5634494"
-          },
-          "provider": "Axelar"
-        },
         {
           "type": "ibc",
           "counterparty": {
@@ -23580,22 +21694,6 @@
       "display": "rbtc",
       "symbol": "RBTC.rt",
       "traces": [
-        {
-          "type": "synthetic",
-          "counterparty": {
-            "chain_name": "bitcoin",
-            "base_denom": "sat"
-          },
-          "provider": "Rootstock"
-        },
-        {
-          "type": "wrapped",
-          "counterparty": {
-            "chain_name": "rootstock",
-            "base_denom": "sat"
-          },
-          "provider": "Rootstock"
-        },
         {
           "type": "synthetic",
           "counterparty": {
@@ -23824,7 +21922,8 @@
             "circle": true
           }
         }
-      ]
+      ],
+      "coingecko_id": "mantra-dao"
     },
     {
       "description": "The native staking and governance token of AtomOne",
@@ -23875,6 +21974,7 @@
           "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/atomone/images/atomone.svg"
         }
       ],
+      "coingecko_id": "atomone",
       "socials": {
         "website": "https://atom.one",
         "twitter": "https://x.com/_atomone"
@@ -23932,16 +22032,8 @@
       "base": "ibc/21D8071EF5B02A86D945430D859A594CBF28287D38104A264BB9FD3B22BBF5DE",
       "name": "Yum",
       "display": "yum",
-      "symbol": "YUM",
+      "symbol": "YUM.axl",
       "traces": [
-        {
-          "type": "bridge",
-          "counterparty": {
-            "chain_name": "ethereum",
-            "base_denom": "0xcE682c89C63d2850Cb2ca898E44D6c7c30d897a6"
-          },
-          "provider": "Axelar"
-        },
         {
           "type": "ibc",
           "counterparty": {
@@ -24020,6 +22112,7 @@
           "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/omniflixhub/images/ygata.svg"
         }
       ],
+      "coingecko_id": "yield-gata",
       "socials": {
         "website": "https://gatahub.zone",
         "twitter": "https://x.com/GataHubZone"
@@ -24043,17 +22136,9 @@
       "type_asset": "ics20",
       "base": "ibc/3B95D63B520C283BCA86F8CD426D57584039463FD684A5CBA31D2780B86A1995",
       "name": "Dragon Coin (old)",
-      "display": "OLDDGN",
-      "symbol": "DGN.old",
+      "display": "DGN",
+      "symbol": "DGN",
       "traces": [
-        {
-          "type": "legacy-mintage",
-          "counterparty": {
-            "chain_name": "dungeon",
-            "base_denom": "udgn"
-          },
-          "provider": "Dungeon Chain"
-        },
         {
           "type": "ibc",
           "counterparty": {
@@ -24081,7 +22166,8 @@
             "circle": true
           }
         }
-      ]
+      ],
+      "coingecko_id": "dragon-coin-2"
     },
     {
       "description": "Dragon Token is the native staking and governance token of Dungeon Chain, serving as the backbone of the ecosystem. Its primary roles include staking, where users stake Dragon Tokens to secure the network, enhance its functionality, and earn rewards in return; governance, granting token holders voting rights to influence key decisions such as game onboarding, protocol updates, and community-driven initiatives; and ecosystem growth, facilitating transactions, incentivizing developers, and promoting the creation of new interchain games. Dragon Token ensures a decentralized, fair, and community-driven ecosystem, fostering the evolution of blockchain-based gaming. It plays a crucial role in driving the growth of Dungeon Chain by empowering both developers and players to participate actively in the ecosystem's governance and success.",
@@ -24131,7 +22217,8 @@
             "circle": true
           }
         }
-      ]
+      ],
+      "coingecko_id": "dragon-coin-2"
     },
     {
       "description": "Synternet is a blockchain that powers modular, interoperable data infrastructure across all major chains.",
@@ -24231,14 +22318,6 @@
       "symbol": "dATOM",
       "traces": [
         {
-          "type": "liquid-stake",
-          "counterparty": {
-            "chain_name": "cosmoshub",
-            "base_denom": "uatom"
-          },
-          "provider": "Drop Protocol"
-        },
-        {
           "type": "ibc",
           "counterparty": {
             "chain_name": "neutron",
@@ -24262,7 +22341,8 @@
           },
           "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/neutron/images/dATOM.svg"
         }
-      ]
+      ],
+      "coingecko_id": "drop-staked-atom"
     },
     {
       "description": "The Sherpa memecoin",
@@ -24314,27 +22394,6 @@
       "display": "amATOM",
       "symbol": "amATOM",
       "traces": [
-        {
-          "type": "ibc",
-          "counterparty": {
-            "chain_name": "cosmoshub",
-            "base_denom": "uatom",
-            "channel_id": "channel-569"
-          },
-          "chain": {
-            "channel_id": "channel-1",
-            "path": "transfer/channel-1/uatom"
-          }
-        },
-        {
-          "type": "synthetic",
-          "counterparty": {
-            "chain_name": "neutron",
-            "base_denom": "ibc/C4CFF46FD6DE35CA4CF4CE031E643C8FDC9BA4B99AE598E9B0ED98FE3A2319F9",
-            "contract": "neutron16d4a7q3wfkkawj4jwyzz6g97xtmj0crkyn06ev74fu4xsgkwnreswzfpcy"
-          },
-          "provider": "Amulet"
-        },
         {
           "type": "ibc",
           "counterparty": {
@@ -24456,7 +22515,8 @@
           },
           "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/xion/images/burnt-round.png"
         }
-      ]
+      ],
+      "coingecko_id": "xion-2"
     },
     {
       "description": "An alloy of FIL asset variants on Osmosis.",
@@ -24519,18 +22579,10 @@
       ],
       "type_asset": "ics20",
       "base": "ibc/DDE1238DCBC338C0FD0700A72CBD64C017B7A646C4A46789ADFB5D47F1E52E38",
-      "name": "Toncoin (Int3)",
+      "name": "TON",
       "display": "ton",
-      "symbol": "TON.int3",
+      "symbol": "TON",
       "traces": [
-        {
-          "type": "bridge",
-          "counterparty": {
-            "chain_name": "ton",
-            "base_denom": "nanoton"
-          },
-          "provider": "Int3face"
-        },
         {
           "type": "ibc",
           "counterparty": {
@@ -24711,7 +22763,8 @@
           },
           "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/elys/images/elys.png"
         }
-      ]
+      ],
+      "coingecko_id": "elys-network"
     },
     {
       "description": "Aaron Network is an innovative platform for secure and private messaging, integrated into the blockchain ecosystem. We also offer a unique address reputation scoring system, ensuring that every user can interact with others confidently.",
@@ -24831,7 +22884,7 @@
       "type_asset": "ics20",
       "base": "ibc/3D00ACF371FC6B7BC871399B1909DDE18749FA19DE6B7A4F74E1D96BC073B3BC",
       "name": "wirelibertyfence",
-      "display": "wirelibertyfence",
+      "display": "WLF",
       "symbol": "WLF",
       "traces": [
         {
@@ -24993,14 +23046,6 @@
       "symbol": "dTIA",
       "traces": [
         {
-          "type": "liquid-stake",
-          "counterparty": {
-            "chain_name": "celestia",
-            "base_denom": "utia"
-          },
-          "provider": "Drop Protocol"
-        },
-        {
           "type": "ibc",
           "counterparty": {
             "chain_name": "neutron",
@@ -25095,43 +23140,6 @@
       "symbol": "nUSDC",
       "traces": [
         {
-          "type": "synthetic",
-          "counterparty": {
-            "chain_name": "forex",
-            "base_denom": "USD"
-          },
-          "provider": "Circle"
-        },
-        {
-          "type": "additional-mintage",
-          "counterparty": {
-            "chain_name": "ethereum",
-            "base_denom": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48"
-          },
-          "provider": "Circle"
-        },
-        {
-          "type": "ibc",
-          "counterparty": {
-            "chain_name": "noble",
-            "base_denom": "uusdc",
-            "channel_id": "channel-31"
-          },
-          "chain": {
-            "channel_id": "channel-148",
-            "path": "transfer/channel-148/uusdc"
-          }
-        },
-        {
-          "type": "synthetic",
-          "counterparty": {
-            "chain_name": "injective",
-            "base_denom": "ibc/2CBC2EA121AE42563B08028466F37B600F2D7D4282342DE938283CC3FB2BC00E",
-            "contract": "inj1nc7gjkf2mhp34a6gquhurg8qahnw5kxs5u3s4u"
-          },
-          "provider": "Neptune"
-        },
-        {
           "type": "ibc",
           "counterparty": {
             "chain_name": "injective",
@@ -25178,14 +23186,6 @@
       "display": "kUSD",
       "symbol": "kUSD",
       "traces": [
-        {
-          "type": "synthetic",
-          "counterparty": {
-            "chain_name": "forex",
-            "base_denom": "USD"
-          },
-          "provider": "Kopi"
-        },
         {
           "type": "ibc",
           "counterparty": {
@@ -25282,14 +23282,6 @@
       "symbol": "qARCH",
       "traces": [
         {
-          "type": "liquid-stake",
-          "counterparty": {
-            "chain_name": "archway",
-            "base_denom": "aarch"
-          },
-          "provider": "Quicksilver"
-        },
-        {
           "type": "ibc",
           "counterparty": {
             "chain_name": "quicksilver",
@@ -25339,22 +23331,6 @@
       "display": "qpica",
       "symbol": "qPICA",
       "traces": [
-        {
-          "type": "additional-mintage",
-          "counterparty": {
-            "chain_name": "picasso",
-            "base_denom": "ppica"
-          },
-          "provider": "Picasso"
-        },
-        {
-          "type": "liquid-stake",
-          "counterparty": {
-            "chain_name": "composable",
-            "base_denom": "ppica"
-          },
-          "provider": "Quicksilver"
-        },
         {
           "type": "ibc",
           "counterparty": {
@@ -25406,14 +23382,6 @@
       "symbol": "qTIA",
       "traces": [
         {
-          "type": "liquid-stake",
-          "counterparty": {
-            "chain_name": "celestia",
-            "base_denom": "utia"
-          },
-          "provider": "Quicksilver"
-        },
-        {
           "type": "ibc",
           "counterparty": {
             "chain_name": "quicksilver",
@@ -25463,14 +23431,6 @@
       "display": "qflix",
       "symbol": "qFLIX",
       "traces": [
-        {
-          "type": "liquid-stake",
-          "counterparty": {
-            "chain_name": "omniflixhub",
-            "base_denom": "uflix"
-          },
-          "provider": "Quicksilver"
-        },
         {
           "type": "ibc",
           "counterparty": {
@@ -25522,14 +23482,6 @@
       "symbol": "qLUNA",
       "traces": [
         {
-          "type": "liquid-stake",
-          "counterparty": {
-            "chain_name": "terra2",
-            "base_denom": "uluna"
-          },
-          "provider": "Quicksilver"
-        },
-        {
           "type": "ibc",
           "counterparty": {
             "chain_name": "quicksilver",
@@ -25576,17 +23528,9 @@
       "type_asset": "ics20",
       "base": "ibc/3C85C44DCB6BCC4FFB9D295EE79ED412E1FAD5D775C99E6AA51CCEF5CA32409C",
       "name": "Quicksilver Liquid Staked INJ",
-      "display": "qinj",
+      "display": "qINJ",
       "symbol": "qINJ",
       "traces": [
-        {
-          "type": "liquid-stake",
-          "counterparty": {
-            "chain_name": "injective",
-            "base_denom": "inj"
-          },
-          "provider": "Quicksilver"
-        },
         {
           "type": "ibc",
           "counterparty": {
@@ -25767,14 +23711,6 @@
       "display": "sBTC",
       "symbol": "sBTC",
       "traces": [
-        {
-          "type": "bridge",
-          "counterparty": {
-            "chain_name": "bitcoin",
-            "base_denom": "sat"
-          },
-          "provider": "Side Chain"
-        },
         {
           "type": "ibc",
           "counterparty": {
@@ -25994,7 +23930,8 @@
           "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/oraichain/images/sam.png",
           "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/oraichain/images/sam.svg"
         }
-      ]
+      ],
+      "coingecko_id": "sam-2"
     },
     {
       "description": "Staking coin of Emporion",
@@ -26142,7 +24079,8 @@
           "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/pryzm/images/pryzm.png",
           "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/pryzm/images/pryzm.svg"
         }
-      ]
+      ],
+      "coingecko_id": "pryzm"
     },
     {
       "description": "The community token for The Fortunate Few, a multi chain NFT community platform.",
@@ -26360,7 +24298,8 @@
           "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/nillion/images/nil.png",
           "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/nillion/images/nil.svg"
         }
-      ]
+      ],
+      "coingecko_id": "nillion"
     },
     {
       "description": "Commemorative token dedicated to the old Prussian noble family",
@@ -26409,26 +24348,10 @@
       ],
       "type_asset": "ics20",
       "base": "ibc/D19DA6AE5B3CB19A035FCB51DEE5A36392E0D64D51C20D159A155D1581911A39",
-      "name": "Movement (Ethereum via Axelar)",
+      "name": "Movement",
       "display": "move",
-      "symbol": "MOVE.eth.axl",
+      "symbol": "axlMOVE",
       "traces": [
-        {
-          "type": "additional-mintage",
-          "counterparty": {
-            "chain_name": "movement",
-            "base_denom": "0xa"
-          },
-          "provider": "Movement Foundation"
-        },
-        {
-          "type": "bridge",
-          "counterparty": {
-            "chain_name": "ethereum",
-            "base_denom": "0x3073f7aaa4db83f95e9fff17424f71d4751a3073"
-          },
-          "provider": "Axelar"
-        },
         {
           "type": "ibc",
           "counterparty": {
@@ -26595,7 +24518,8 @@
           },
           "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/babylon/images/logo.svg"
         }
-      ]
+      ],
+      "coingecko_id": "babylon"
     },
     {
       "description": "Lombard Staked Bitcoin via Eureka",
@@ -26618,34 +24542,6 @@
       "display": "lbtc",
       "symbol": "LBTC",
       "traces": [
-        {
-          "type": "liquid-stake",
-          "counterparty": {
-            "chain_name": "bitcoin",
-            "base_denom": "sat"
-          },
-          "provider": "Lombard"
-        },
-        {
-          "type": "additional-mintage",
-          "counterparty": {
-            "chain_name": "ethereum",
-            "base_denom": "0x8236a87084f8B84306f72007F36F2618A5634494"
-          },
-          "provider": "Lombard"
-        },
-        {
-          "type": "ibc",
-          "counterparty": {
-            "chain_name": "lombardledger",
-            "base_denom": "uclbtc",
-            "channel_id": "channel-0"
-          },
-          "chain": {
-            "channel_id": "channel-1340",
-            "path": "transfer/channel-1340/uclbtc"
-          }
-        },
         {
           "type": "ibc",
           "counterparty": {
@@ -26675,7 +24571,8 @@
             "circle": true
           }
         }
-      ]
+      ],
+      "coingecko_id": "lombard-staked-btc"
     },
     {
       "description": "SolvBTC via Euerka",
@@ -26696,29 +24593,8 @@
       "base": "ibc/2CC08A10459B40B0251B8CB9C036C98BED1ABBD5F03772E371DCD0FFDA3EC7F3",
       "name": "SolvBTC",
       "display": "solvbtc",
-      "symbol": "solvBTC",
+      "symbol": "SolvBTC",
       "traces": [
-        {
-          "type": "liquid-stake",
-          "counterparty": {
-            "chain_name": "bitcoin",
-            "base_denom": "sat"
-          },
-          "provider": "Solv Protocol"
-        },
-        {
-          "type": "ibc-bridge",
-          "counterparty": {
-            "chain_name": "ethereum",
-            "base_denom": "0x7a56e1c57c7475ccf742a1832b028f0456652f97",
-            "channel_id": "cosmoshub-0"
-          },
-          "chain": {
-            "channel_id": "08-wasm-1369",
-            "path": "transfer/08-wasm-1369/0x7a56e1c57c7475ccf742a1832b028f0456652f97"
-          },
-          "provider": "Eureka"
-        },
         {
           "type": "ibc",
           "counterparty": {
@@ -26914,7 +24790,8 @@
             "circle": true
           }
         }
-      ]
+      ],
+      "coingecko_id": "initia"
     },
     {
       "description": "The native token of MilkyWay",
@@ -27081,14 +24958,6 @@
       "symbol": "aUSD",
       "traces": [
         {
-          "type": "synthetic",
-          "counterparty": {
-            "chain_name": "forex",
-            "base_denom": "USD"
-          },
-          "provider": "Astonic"
-        },
-        {
           "type": "ibc",
           "counterparty": {
             "chain_name": "planq",
@@ -27135,14 +25004,6 @@
       "display": "aeur",
       "symbol": "aEUR",
       "traces": [
-        {
-          "type": "synthetic",
-          "counterparty": {
-            "chain_name": "forex",
-            "base_denom": "EUR"
-          },
-          "provider": "Astonic"
-        },
         {
           "type": "ibc",
           "counterparty": {
@@ -27191,14 +25052,6 @@
       "symbol": "aBRL",
       "traces": [
         {
-          "type": "synthetic",
-          "counterparty": {
-            "chain_name": "forex",
-            "base_denom": "BRL"
-          },
-          "provider": "Astonic"
-        },
-        {
           "type": "ibc",
           "counterparty": {
             "chain_name": "planq",
@@ -27238,31 +25091,10 @@
       ],
       "type_asset": "ics20",
       "base": "ibc/88386AC48152D48B34B082648DF836F975506F0B57DBBFC10A54213B1BF484CB",
-      "name": "Wrapped Bitcoin (Ethereum via Eureka)",
+      "name": "Wrapped Bitcoin",
       "display": "wbtc",
-      "symbol": "WBTC.eth.atom",
+      "symbol": "WBTC",
       "traces": [
-        {
-          "type": "bridge",
-          "counterparty": {
-            "chain_name": "bitcoin",
-            "base_denom": "sat"
-          },
-          "provider": "BitGo, Kyber, and Ren"
-        },
-        {
-          "type": "ibc-bridge",
-          "counterparty": {
-            "chain_name": "ethereum",
-            "base_denom": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
-            "channel_id": "cosmoshub-0"
-          },
-          "chain": {
-            "channel_id": "08-wasm-1369",
-            "path": "transfer/08-wasm-1369/0x2260fac5e5542a773aa44fbcfedf7c193bc2c599"
-          },
-          "provider": "Eureka"
-        },
         {
           "type": "ibc",
           "counterparty": {
@@ -27305,31 +25137,10 @@
       ],
       "type_asset": "ics20",
       "base": "ibc/20850C646CDDDC2270E9BBDB08558B5FEE57B647EC6827F41096AABFD8A0471B",
-      "name": "Ethereum (Eureka)",
+      "name": "Ethereum",
       "display": "eth",
-      "symbol": "ETH.atom",
+      "symbol": "ETH",
       "traces": [
-        {
-          "type": "wrapped",
-          "counterparty": {
-            "chain_name": "ethereum",
-            "base_denom": "wei"
-          },
-          "provider": "Ethereum"
-        },
-        {
-          "type": "ibc-bridge",
-          "counterparty": {
-            "chain_name": "ethereum",
-            "base_denom": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
-            "channel_id": "channel-0"
-          },
-          "chain": {
-            "channel_id": "08-wasm-1369",
-            "path": "transfer/08-wasm-1369/0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2"
-          },
-          "provider": "Eureka"
-        },
         {
           "type": "ibc",
           "counterparty": {
@@ -27372,31 +25183,10 @@
       ],
       "type_asset": "ics20",
       "base": "ibc/7BC2F718C47C0749791F2612A914C8C39D1A4F533A27AF7285D924D4B617DDA6",
-      "name": "Tether USD (Ethereum via Eureka)",
+      "name": "Tether USD",
       "display": "usdt",
-      "symbol": "USDT.eth.atom",
+      "symbol": "USDT",
       "traces": [
-        {
-          "type": "synthetic",
-          "counterparty": {
-            "chain_name": "forex",
-            "base_denom": "USD"
-          },
-          "provider": "Tether"
-        },
-        {
-          "type": "ibc-bridge",
-          "counterparty": {
-            "chain_name": "ethereum",
-            "base_denom": "0xdac17f958d2ee523a2206206994597c13d831ec7",
-            "channel_id": "channel-0"
-          },
-          "chain": {
-            "channel_id": "08-wasm-1369",
-            "path": "transfer/08-wasm-1369/0xdac17f958d2ee523a2206206994597c13d831ec7"
-          },
-          "provider": "Eureka"
-        },
         {
           "type": "ibc",
           "counterparty": {
@@ -27522,7 +25312,8 @@
           "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/beezee/images/vdl.png",
           "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/beezee/images/vdl.svg"
         }
-      ]
+      ],
+      "coingecko_id": "vidulum"
     },
     {
       "description": "Real power moves quietly.",
@@ -27581,14 +25372,6 @@
       "display": "milkBABY",
       "symbol": "milkBABY",
       "traces": [
-        {
-          "type": "liquid-stake",
-          "counterparty": {
-            "chain_name": "babylon",
-            "base_denom": "ubbn"
-          },
-          "provider": "MilkyWay"
-        },
         {
           "type": "ibc",
           "counterparty": {
@@ -27712,18 +25495,10 @@
       ],
       "type_asset": "ics20",
       "base": "ibc/A1465DD6AF456FCD0D998869608DFEEDA4F4C11EC0A12AF92A994A3F8CBEE546",
-      "name": "Solana (Int3)",
+      "name": "Solana",
       "display": "sol",
-      "symbol": "SOL.int3",
+      "symbol": "SOL",
       "traces": [
-        {
-          "type": "bridge",
-          "counterparty": {
-            "chain_name": "solana",
-            "base_denom": "Lamport"
-          },
-          "provider": "Int3face"
-        },
         {
           "type": "ibc",
           "counterparty": {
@@ -27819,18 +25594,10 @@
       ],
       "type_asset": "ics20",
       "base": "ibc/013DE940BE791C79142EAD4DF071E1ED280DFEAB8A9DCB5932A4603A74C25CBB",
-      "name": "Ripple (xrpl via Int3)",
+      "name": "Ripple",
       "display": "xrp",
-      "symbol": "XRP.xrpl.int3",
+      "symbol": "XRP",
       "traces": [
-        {
-          "type": "bridge",
-          "counterparty": {
-            "chain_name": "xrpl",
-            "base_denom": "drop"
-          },
-          "provider": "Int3face"
-        },
         {
           "type": "ibc",
           "counterparty": {
@@ -27931,31 +25698,10 @@
       ],
       "type_asset": "ics20",
       "base": "ibc/954F25C3AA0DCF2917393FB89D778F95815B0568EB093C43BA0B24CBD99CBFFB",
-      "name": "pumpBTC (Eureka)",
+      "name": "pumpBTC",
       "display": "pumpbtc",
-      "symbol": "pumpBTC.atom",
+      "symbol": "pumpBTC",
       "traces": [
-        {
-          "type": "liquid-stake",
-          "counterparty": {
-            "chain_name": "bitcoin",
-            "base_denom": "sat"
-          },
-          "provider": "pumpBTC"
-        },
-        {
-          "type": "ibc-bridge",
-          "counterparty": {
-            "chain_name": "ethereum",
-            "base_denom": "0xf469fbd2abcd6b9de8e169d128226c0fc90a012e",
-            "channel_id": "cosmoshub-0"
-          },
-          "chain": {
-            "channel_id": "08-wasm-1369",
-            "path": "transfer/08-wasm-1369/0xf469fbd2abcd6b9de8e169d128226c0fc90a012e"
-          },
-          "provider": "Eureka"
-        },
         {
           "type": "ibc",
           "counterparty": {
@@ -28000,31 +25746,10 @@
       ],
       "type_asset": "ics20",
       "base": "ibc/6E7CA61C5656D3F3007535F035386AEB8281833743CFCE0F069213331CEBBE1A",
-      "name": "Universal BTC (Eureka)",
+      "name": "UniBTC",
       "display": "unibtc",
-      "symbol": "uniBTC.atom",
+      "symbol": "uniBTC",
       "traces": [
-        {
-          "type": "liquid-stake",
-          "counterparty": {
-            "chain_name": "bitcoin",
-            "base_denom": "sat"
-          },
-          "provider": "Bedrock"
-        },
-        {
-          "type": "ibc-bridge",
-          "counterparty": {
-            "chain_name": "ethereum",
-            "base_denom": "0x004e9c3ef86bc1ca1f0bb5c7662861ee93350568",
-            "channel_id": "cosmoshub-0"
-          },
-          "chain": {
-            "channel_id": "08-wasm-1369",
-            "path": "transfer/08-wasm-1369/0x004e9c3ef86bc1ca1f0bb5c7662861ee93350568"
-          },
-          "provider": "Eureka"
-        },
         {
           "type": "ibc",
           "counterparty": {
@@ -28069,23 +25794,10 @@
       ],
       "type_asset": "ics20",
       "base": "ibc/F15348F47575AAFE2BEFF8369CBE3647AE9DC06909CDBF8C97E48ACF7055E459",
-      "name": "mBTC (Eureka)",
+      "name": "mBTC",
       "display": "mbtc",
-      "symbol": "mBTC.atom",
+      "symbol": "mBTC",
       "traces": [
-        {
-          "type": "ibc-bridge",
-          "counterparty": {
-            "chain_name": "ethereum",
-            "base_denom": "0xbdf245957992bfbc62b07e344128a1eec7b7ee3f",
-            "channel_id": "cosmoshub-0"
-          },
-          "chain": {
-            "channel_id": "08-wasm-1369",
-            "path": "transfer/08-wasm-1369/0xbdf245957992bfbc62b07e344128a1eec7b7ee3f"
-          },
-          "provider": "Eureka"
-        },
         {
           "type": "ibc",
           "counterparty": {
@@ -28125,23 +25837,10 @@
       ],
       "type_asset": "ics20",
       "base": "ibc/67144554C6EE6D0FCF43CBA0DF18D821E2818FD1F320B93AB0349E741A0DC850",
-      "name": "Kinza Babylon Staked BTC (Eureka)",
+      "name": "kBTC",
       "display": "kbtc",
-      "symbol": "kBTC.atom",
+      "symbol": "kBTC",
       "traces": [
-        {
-          "type": "ibc-bridge",
-          "counterparty": {
-            "chain_name": "ethereum",
-            "base_denom": "0x9356f6d95b8e109f4b7ce3e49d672967d3b48383",
-            "channel_id": "cosmoshub-0"
-          },
-          "chain": {
-            "channel_id": "08-wasm-1369",
-            "path": "transfer/08-wasm-1369/0x9356f6d95b8e109f4b7ce3e49d672967d3b48383"
-          },
-          "provider": "Eureka"
-        },
         {
           "type": "ibc",
           "counterparty": {
@@ -28181,23 +25880,10 @@
       ],
       "type_asset": "ics20",
       "base": "ibc/4805A17C742D2325715167EA1167974821888307CC62066D6CFA2BD0F724821D",
-      "name": "ether.fi BTC (Eureka)",
+      "name": "eBTC",
       "display": "ebtc",
-      "symbol": "eBTC.atom",
+      "symbol": "eBTC",
       "traces": [
-        {
-          "type": "ibc-bridge",
-          "counterparty": {
-            "chain_name": "ethereum",
-            "base_denom": "0x657e8c867d8b37dcc18fa4caead9c45eb088c642",
-            "channel_id": "cosmoshub-0"
-          },
-          "chain": {
-            "channel_id": "08-wasm-1369",
-            "path": "transfer/08-wasm-1369/0x657e8c867d8b37dcc18fa4caead9c45eb088c642"
-          },
-          "provider": "Eureka"
-        },
         {
           "type": "ibc",
           "counterparty": {
@@ -28237,31 +25923,10 @@
       ],
       "type_asset": "ics20",
       "base": "ibc/FAE7862FCB5DC95168C415A6EE63DA8C38389EA1EAFF51C82F446C80C879156E",
-      "name": "lorenzo Wrapped Bitcoin (Eureka)",
+      "name": "enzoBTC",
       "display": "enzobtc",
-      "symbol": "enzoBTC.atom",
+      "symbol": "enzoBTC",
       "traces": [
-        {
-          "type": "bridge",
-          "counterparty": {
-            "chain_name": "bitcoin",
-            "base_denom": "sat"
-          },
-          "provider": "Lorenzo Protocol"
-        },
-        {
-          "type": "ibc-bridge",
-          "counterparty": {
-            "chain_name": "ethereum",
-            "base_denom": "0x6a9a65b84843f5fd4ac9a0471c4fc11afffbce4a",
-            "channel_id": "cosmoshub-0"
-          },
-          "chain": {
-            "channel_id": "08-wasm-1369",
-            "path": "transfer/08-wasm-1369/0x6a9a65b84843f5fd4ac9a0471c4fc11afffbce4a"
-          },
-          "provider": "Eureka"
-        },
         {
           "type": "ibc",
           "counterparty": {
@@ -28306,23 +25971,10 @@
       ],
       "type_asset": "ics20",
       "base": "ibc/3FC3D99F9E5003057353AD968A6E3AC12AE50741B41441666BAB3890485C9D00",
-      "name": "Midas BTC Yield Token (Eureka)",
+      "name": "Midas BTC Yield Token",
       "display": "mBTC",
-      "symbol": "mBTC.midas.atom",
+      "symbol": "mBTC.midas",
       "traces": [
-        {
-          "type": "ibc-bridge",
-          "counterparty": {
-            "chain_name": "ethereum",
-            "base_denom": "0x007115416ab6c266329a03b09a8aa39ac2ef7d9d",
-            "channel_id": "channel-0"
-          },
-          "chain": {
-            "channel_id": "08-wasm-1369",
-            "path": "transfer/08-wasm-1369/0x007115416ab6c266329a03b09a8aa39ac2ef7d9d"
-          },
-          "provider": "Eureka"
-        },
         {
           "type": "ibc",
           "counterparty": {
@@ -28365,31 +26017,10 @@
       ],
       "type_asset": "ics20",
       "base": "ibc/0EF5630576C66968EF0787868CF09FD866FAD131BC148D24A148358A85F0EB62",
-      "name": "Paxos Gold (Eureka)",
+      "name": "Pax Gold",
       "display": "paxg",
-      "symbol": "PAXG.atom",
+      "symbol": "PAXG",
       "traces": [
-        {
-          "type": "synthetic",
-          "counterparty": {
-            "chain_name": "comex",
-            "base_denom": "XAU"
-          },
-          "provider": "Paxos"
-        },
-        {
-          "type": "ibc-bridge",
-          "counterparty": {
-            "chain_name": "ethereum",
-            "base_denom": "0x45804880De22913dAFE09f4980848ECE6EcbAf78",
-            "channel_id": "channel-0"
-          },
-          "chain": {
-            "channel_id": "08-wasm-1369",
-            "path": "transfer/08-wasm-1369/0x45804880de22913dafe09f4980848ece6ecbaf78"
-          },
-          "provider": "Eureka"
-        },
         {
           "type": "ibc",
           "counterparty": {
@@ -28592,18 +26223,10 @@
       ],
       "type_asset": "ics20",
       "base": "ibc/46EB46DB30D3BBC6F404A9232C09785F36D40DA05C662A8E295712ECBAFF1609",
-      "name": "Ripple (XRPL EVM)",
+      "name": "Ripple",
       "display": "XRP",
-      "symbol": "XRP.xrplevm",
+      "symbol": "XRP",
       "traces": [
-        {
-          "type": "additional-mintage",
-          "counterparty": {
-            "chain_name": "xrpl",
-            "base_denom": "drop"
-          },
-          "provider": "Ripple"
-        },
         {
           "type": "ibc",
           "counterparty": {
@@ -28630,7 +26253,8 @@
           "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/_non-cosmos/xrpl/images/xrp.png",
           "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/_non-cosmos/xrpl/images/xrp.svg"
         }
-      ]
+      ],
+      "coingecko_id": "ripple"
     },
     {
       "description": "TakeTitan Titans",
@@ -28760,7 +26384,8 @@
           "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/noble/images/USDN.png",
           "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/noble/images/USDN.svg"
         }
-      ]
+      ],
+      "coingecko_id": "noble-dollar-usdn"
     },
     {
       "description": "Formation Of $hit Tokens",
@@ -28830,7 +26455,8 @@
           },
           "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/hippoprotocol/images/logo.svg"
         }
-      ]
+      ],
+      "coingecko_id": "hippo-protocol"
     },
     {
       "description": "Pudgy Penguins (PENGU) coin bridged via Int3face bridge",
@@ -28849,18 +26475,10 @@
       ],
       "type_asset": "ics20",
       "base": "ibc/2C5CB5DB3D86F64FDE6155A3A94D7543A126DA55490309EEDF59A0765873DA1C",
-      "name": "Pudgy Penguins (Int3)",
+      "name": "Pudgy Penguins",
       "display": "pengu",
-      "symbol": "PENGU.int3",
+      "symbol": "PENGU",
       "traces": [
-        {
-          "type": "bridge",
-          "counterparty": {
-            "chain_name": "solana",
-            "base_denom": "2zMMhcVQEXDtdE6vsFS7S7D5oUodfJHE8vd1gnBouauv"
-          },
-          "provider": "Int3face"
-        },
         {
           "type": "ibc",
           "counterparty": {
@@ -28904,18 +26522,10 @@
       ],
       "type_asset": "ics20",
       "base": "ibc/51BFF64A432CBBA08A1ED95609BF0255EC4BBF699BFCDFF267F66CCD664CA350",
-      "name": "Official Trump (Int3)",
+      "name": "Official Trump",
       "display": "trump",
-      "symbol": "TRUMP.int3",
+      "symbol": "TRUMP",
       "traces": [
-        {
-          "type": "bridge",
-          "counterparty": {
-            "chain_name": "solana",
-            "base_denom": "6p6xgHyF7AeE6TZkSmFsko444wqoP15icUSqi2jfGiPN"
-          },
-          "provider": "Int3face"
-        },
         {
           "type": "ibc",
           "counterparty": {
@@ -29173,6 +26783,40 @@
             "base_denom": "2zMMhcVQEXDtdE6vsFS7S7D5oUodfJHE8vd1gnBouauv"
           },
           "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/_non-cosmos/solana/images/pengu.png"
+        }
+      ]
+    },
+    {
+      "denom_units": [
+        {
+          "denom": "ibc/29EA1818A218B35E18FADC287C85A01802C900A5FFC0D7C8FC592D05186AAFD0",
+          "exponent": 0,
+          "aliases": [
+            "factory/neutron1r5qx58l3xx2y8gzjtkqjndjgx69mktmapl45vns0pa73z0zpn7fqgltnll/TAB"
+          ]
+        },
+        {
+          "denom": "TAB",
+          "exponent": 6
+        }
+      ],
+      "type_asset": "ics20",
+      "base": "ibc/29EA1818A218B35E18FADC287C85A01802C900A5FFC0D7C8FC592D05186AAFD0",
+      "name": "TabCoin",
+      "display": "TAB",
+      "symbol": "TAB",
+      "traces": [
+        {
+          "type": "ibc",
+          "counterparty": {
+            "chain_name": "neutron",
+            "base_denom": "factory/neutron1r5qx58l3xx2y8gzjtkqjndjgx69mktmapl45vns0pa73z0zpn7fqgltnll/TAB",
+            "channel_id": "channel-10"
+          },
+          "chain": {
+            "channel_id": "channel-874",
+            "path": "transfer/channel-874/factory/neutron1r5qx58l3xx2y8gzjtkqjndjgx69mktmapl45vns0pa73z0zpn7fqgltnll/TAB"
+          }
         }
       ]
     },

--- a/osmosis/assetlist.json
+++ b/osmosis/assetlist.json
@@ -1490,8 +1490,7 @@
           "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/starname/images/iov.png",
           "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/starname/images/iov.svg"
         }
-      ],
-      "coingecko_id": "starname"
+      ]
     },
     {
       "description": "e-Money NGM staking token. In addition to earning staking rewards the token is bought back and burned based on e-Money stablecoin inflation.",
@@ -4660,8 +4659,7 @@
           "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/odin/images/odin.png",
           "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/odin/images/odin.svg"
         }
-      ],
-      "coingecko_id": "odin-protocol"
+      ]
     },
     {
       "description": "GEO token for ODIN Protocol",
@@ -5787,8 +5785,7 @@
           "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/rebus/images/rebus.png",
           "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/rebus/images/rebus.svg"
         }
-      ],
-      "coingecko_id": "rebus"
+      ]
     },
     {
       "description": "The native token of Teritori",
@@ -6034,8 +6031,7 @@
           "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/lambda/images/lambda.png",
           "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/lambda/images/lambda.svg"
         }
-      ],
-      "coingecko_id": "lambda"
+      ]
     },
     {
       "description": "The native over-collateralized stablecoin from the Kujira chain.",
@@ -6897,7 +6893,6 @@
           "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/onomy/images/nom.svg"
         }
       ],
-      "coingecko_id": "onomy-protocol",
       "keywords": [
         "dex",
         "stablecoin",
@@ -10829,8 +10824,7 @@
           "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/stride/images/stsomm.png",
           "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/stride/images/stsomm.svg"
         }
-      ],
-      "coingecko_id": "stride-staked-sommelier"
+      ]
     },
     {
       "description": "Solana (SOL) is the native asset of the Solana blockchain.",
@@ -11694,8 +11688,7 @@
             "circle": false
           }
         }
-      ],
-      "coingecko_id": "six-sigma"
+      ]
     },
     {
       "description": "The native staking and governance token of the StaFi Hub.",
@@ -14661,8 +14654,7 @@
           "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/scorum/images/scr.png",
           "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/scorum/images/scr.svg"
         }
-      ],
-      "coingecko_id": "scorum"
+      ]
     },
     {
       "description": "The native token of Chain4Energy",
@@ -15384,7 +15376,6 @@
           "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/conscious/images/cvn.svg"
         }
       ],
-      "coingecko_id": "consciousdao",
       "keywords": [
         "osmosis_unlisted"
       ]
@@ -18751,7 +18742,6 @@
           "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/mande/images/mande.svg"
         }
       ],
-      "coingecko_id": "mande-network",
       "keywords": [
         "credibility",
         "identity",


### PR DESCRIPTION
Bulk Update of Osmosis Assetlist
Reduces redundant specification of entire traces history (only the latest is needed).
Name and symbol are set to how they're defined for the the source asset on its counterparty chain (ignoring 'canonicalization')