### PR TITLE
atomone-testnet-1 - upgrade v3.0.1

### DIFF
--- a/testnets/atomonetestnet/chain.json
+++ b/testnets/atomonetestnet/chain.json
@@ -39,15 +39,15 @@
   },
   "codebase": {
     "git_repo": "https://github.com/atomone-hub/atomone",
-    "recommended_version": "v2.0.0-rc2",
-    "compatible_versions": ["v2.0.0-rc2"],
+    "recommended_version": "v3.0.1",
+    "compatible_versions": ["v3.0.1"],
     "binaries": {
-      "linux/amd64": "https://github.com/atomone-hub/atomone/releases/download/v2.0.0-rc2/atomoned-v2.0.0-rc2-linux-amd64",
-      "linux/arm64": "https://github.com/atomone-hub/atomone/releases/download/v2.0.0-rc2/atomoned-v2.0.0-rc2-linux-arm64",
-      "darwin/amd64": "https://github.com/atomone-hub/atomone/releases/download/v2.0.0-rc2/atomoned-v2.0.0-rc2-darwin-amd64",
-      "darwin/arm64": "https://github.com/atomone-hub/atomone/releases/download/v2.0.0-rc2/atomoned-v2.0.0-rc2-darwin-arm64",
-      "windows/amd64": "https://github.com/atomone-hub/atomone/releases/download/v2.0.0-rc2/atomoned-v2.0.0-rc2-windows-amd64.exe",
-      "windows/arm64": "https://github.com/atomone-hub/atomone/releases/download/v2.0.0-rc2/atomoned-v2.0.0-rc2-windows-arm64.exe"
+      "linux/amd64": "https://github.com/atomone-hub/atomone/releases/download/v3.0.1/atomoned-v3.0.1-linux-amd64",
+      "linux/arm64": "https://github.com/atomone-hub/atomone/releases/download/v3.0.1/atomoned-v3.0.1-linux-arm64",
+      "darwin/amd64": "https://github.com/atomone-hub/atomone/releases/download/v3.0.1/atomoned-v3.0.1-darwin-amd64",
+      "darwin/arm64": "https://github.com/atomone-hub/atomone/releases/download/v3.0.1/atomoned-v3.0.1-darwin-arm64",
+      "windows/amd64": "https://github.com/atomone-hub/atomone/releases/download/v3.0.1/atomoned-v3.0.1-windows-amd64.exe",
+      "windows/arm64": "https://github.com/atomone-hub/atomone/releases/download/v3.0.1/atomoned-v3.0.1-windows-arm64.exe"
     },
     "genesis": {
       "genesis_url": "https://atomone.fra1.digitaloceanspaces.com/atomone-testnet-1/genesis.json"

--- a/testnets/atomonetestnet/chain.json
+++ b/testnets/atomonetestnet/chain.json
@@ -20,13 +20,6 @@
         "low_gas_price": 0.225,
         "average_gas_price": 0.3,
         "high_gas_price": 0.5
-      },
-      {
-        "denom": "uatone",
-        "fixed_min_gas_price": 0.025,
-        "low_gas_price": 0.01,
-        "average_gas_price": 0.025,
-        "high_gas_price": 0.05
       }
     ]
   },

--- a/testnets/atomonetestnet/versions.json
+++ b/testnets/atomonetestnet/versions.json
@@ -51,6 +51,31 @@
         "type": "cosmos",
         "version": "v0.47.17"
       }
+    },
+    {
+      "name": "v3.0.1",
+      "tag": "v3.0.1",
+      "recommended_version": "v3.0.1",
+      "compatible_versions": [
+        "v3.0.1"
+      ],
+      "consensus": {
+        "type": "cometbft",
+        "version": "v0.37.15"
+      },
+      "height": 1,
+      "binaries": {
+        "linux/amd64": "https://github.com/atomone-hub/atomone/releases/download/v3.0.1/atomoned-v3.0.1-linux-amd64",
+        "linux/arm64": "https://github.com/atomone-hub/atomone/releases/download/v3.0.1/atomoned-v3.0.1-linux-arm64",
+        "darwin/amd64": "https://github.com/atomone-hub/atomone/releases/download/v3.0.1/atomoned-v3.0.1-darwin-amd64",
+        "darwin/arm64": "https://github.com/atomone-hub/atomone/releases/download/v3.0.1/atomoned-v3.0.1-darwin-arm64",
+        "windows/amd64": "https://github.com/atomone-hub/atomone/releases/download/v3.0.1/atomoned-v3.0.1-windows-amd64.exe",
+        "windows/arm64": "https://github.com/atomone-hub/atomone/releases/download/v3.0.1/atomoned-v3.0.1-windows-arm64.exe"
+      },
+      "sdk": {
+        "type": "cosmos",
+        "version": "v0.47.17"
+      }
     }
   ]
 }


### PR DESCRIPTION
Upgrade informations are specified in https://github.com/atomone-hub/networks/blob/master/atomone-testnet-1/upgrades/v3.0.1.md

Merge only after block https://testnet.explorer.allinbits.services/atomone-testnet-1/block/3240000 passed 