### PR TITLE
[chain4energy] Add POLCRYPTO.PL endpoints and explorer

### DIFF
--- a/chain4energy/chain.json
+++ b/chain4energy/chain.json
@@ -1,237 +1,222 @@
 {
   "$schema": "../chain.schema.json",
-  "chain_name": "chain4energy",
-  "status": "live",
-  "network_type": "mainnet",
-  "website": "https://c4e.io/",
-  "pretty_name": "C4E",
-  "chain_type": "cosmos",
-  "chain_id": "perun-1",
-  "bech32_prefix": "c4e",
-  "daemon_name": "c4ed",
-  "node_home": "$HOME/.c4e-chain",
-  "key_algos": [
-    "secp256k1"
-  ],
-  "slip44": 118,
-  "fees": {
-    "fee_tokens": [
+  "apis": {
+    "grpc": [
       {
-        "denom": "uc4e",
-        "fixed_min_gas_price": 0,
-        "low_gas_price": 0.01,
-        "average_gas_price": 0.025,
-        "high_gas_price": 0.04
-      }
-    ]
-  },
-  "staking": {
-    "staking_tokens": [
-      {
-        "denom": "uc4e"
-      }
-    ]
-  },
-  "codebase": {
-    "git_repo": "https://github.com/chain4energy/c4e-chain",
-    "recommended_version": "v1.3.1",
-    "compatible_versions": [
-      "v1.3.1"
-    ],
-    "genesis": {
-      "genesis_url": "https://raw.githubusercontent.com/chain4energy/c4e-chains/main/perun-1/genesis.json"
-    }
-  },
-  "logo_URIs": {
-    "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/chain4energy/images/c4e.png"
-  },
-  "peers": {
-    "seeds": [
-      {
-        "id": "8ac87f7f8da5c2a901d64f2c1e86f8b6ee39fef1",
-        "address": "seed-m.c4e.apeironnodes.com:41003",
-        "provider": "Apeiron Nodes"
-      },
-      {
-        "id": "edca3b826d61d1e5e7d3dc173954de1324f2e512",
-        "address": "seed-m.c4e.apeironnodes.com:27003",
-        "provider": "Apeiron Nodes"
-      },
-      {
-        "id": "30e98bbcf5bb29ed4e4ff685fa8fa84fa0ddff51",
-        "address": "tenderseed.ccvalidators.com:26008",
-        "provider": "CryptoCrew"
-      },
-      {
-        "id": "54515079bae4cadae2f9b511cffeb9447d4bc98d",
-        "address": "c4e.seed.bccnodes.com:30656",
-        "provider": "BccNodes"
-      },
-      {
-        "id": "86bd5cb6e762f673f1706e5889e039d5406b4b90",
-        "address": "c4e.seed.node75.org:10156",
-        "provider": "Pro-nodes75"
-      },
-      {
-        "id": "54ca81dd509cc6160de7f4b479a96b341d8e830e",
-        "address": "rpc.c4e.nodexcapital.com:13956",
-        "provider": "NodeX Validator"
-      },
-      {
-        "id": "6da239cb4fe03d957cdb1fdc26af3d083a7f5945",
-        "address": "seed.c4e.hexnodes.co:02656",
-        "provider": "Hexnodes"
-      },
-      {
-        "id": "9aa8a73ea9364aa3cf7806d4dd25b6aed88d8152",
-        "address": "c4e.seed.mzonder.com:11256",
-        "provider": "MZONDER"
-      },
-      {
-        "id": "fbf9a48eca1ba873ad766e2cb72a0562596a248f",
-        "address": "c4e.seed.stavr.tech:17096",
-        "provider": "🔥STAVR🔥"
-      },
-      {
-        "id": "a85a651a3cf1746694560c5b6f76d566c04ca581",
-        "address": "c4e-seed.takeshi.team:10256",
-        "provider": "TAKESHI"
-      },
-      {
-        "id": "ebc272824924ea1a27ea3183dd0b9ba713494f83",
-        "address": "chain4energy-mainnet-seed.autostake.com:27276",
-        "provider": "AutoStake 🛡️ Slash Protected"
-      },
-      {
-        "id": "8cb175d973c3c638a4e5d014c030d8599369419f",
-        "address": "seeds.cros-nest.com:28656",
-        "provider": "Crosnest"
-      },
-      {
-        "id": "5e71b5585d186cc32b9f071610f43042b445c05c",
-        "address": "seeds.c4e.silentvalidator.com:39656",
-        "provider": "silent"
-      },
-      {
-        "id": "6b0ffcce9b59b91ceb8eea5d4599e27707e3604a",
-        "address": "seeds.stakeup.tech:10210",
-        "provider": "StakeUp"
-      },
-      {
-        "id": "6cb7ff21d19f139f4ca5e6e2a336e59d2857aba1",
-        "address": "seeds.anode.team:10256",
-        "provider": "AlxVoy ⚡ ANODE.TEAM"
-      },
-      {
-        "id": "e47f4fa12187234dd205f51cb984c8235c3a3511",
-        "address": "c4e-seeds.validatrium.club:26656",
-        "provider": "Validatrium"
-      },
-      {
-        "id": "3ef7e5e7e163500af9baf53480779448461dac18",
-        "address": "185.245.182.192:46656",
-        "provider": "Meerlabs"
-      },
-      {
-        "id": "0d1a44cc32e927dd062e0fd45d21475f9836e73d",
-        "address": "89.117.58.109:26656",
-        "provider": "medes"
-      },
-      {
-        "id": "d81f51b4a1aae66792fb1717589fa28975f328b0",
-        "address": "164.68.125.243:26656",
-        "provider": "Smt Network"
-      },
-      {
-        "id": "2e08beed75525c2d583e6413fa5f090801965aba",
-        "address": "c4e.doubletop:30655",
-        "provider": "DOUBLETOP"
-      },
-      {
-        "id": "6f181c91dee34ebf2ea5c4f951c51b8c2c897702",
-        "address": "c4e.seed.kalia.network:30656",
-        "provider": "Kalia Network"
-      },
-      {
-        "id": "8739107d0484a4c58c4f980d61f488655597f80c",
-        "address": "seed.c4e.validatus.com:2000",
-        "provider": "Validatus"
-      },
-      {
-        "id": "8542cd7e6bf9d260fef543bc49e59be5a3fa9074",
-        "address": "seed.publicnode.com:26656",
-        "provider": "Allnodes ⚡️ Nodes & Staking"
-      }
-    ],
-    "persistent_peers": [
-      {
-        "id": "00eb92db69a4848f8ac1c84e7b8b2d9b01b95dff",
-        "address": "peer.c4e.mainnet.dteam.tech:30656",
+        "address": "grpc.c4e.mainnet.dteam.tech:30090",
         "provider": "DTEAM"
       },
       {
-        "id": "5b62ff6035d9c8143c0ebf4fe05fa0b22d96bb05",
-        "address": "rpc.c4e.ppnv.space:13656",
-        "provider": "PPNV Service"
+        "address": "c4e.grpc.bccnodes.com:443",
+        "provider": "BccNodes"
       },
       {
-        "id": "a5133743ec9e0edffd83428af65004926352e393",
-        "address": "c4e-peer.nodine.id:13656",
-        "provider": "Nodine.ID"
-      },
-      {
-        "id": "ebc272824924ea1a27ea3183dd0b9ba713494f83",
-        "address": "chain4energy-mainnet-peer.autostake.com:27276",
+        "address": "chain4energy-mainnet-grpc.autostake.com:443",
         "provider": "AutoStake 🛡️ Slash Protected"
       },
       {
-        "id": "e3d0b136495c3f4382ac801fbc89083d32625ff8",
-        "address": "c4e.peer.stavr.tech:17096",
+        "address": "c4e.grpc.bccnodes.com:443",
+        "provider": "BccNodes"
+      },
+      {
+        "address": "grpc-c4e.takeshi.team:443",
+        "provider": "TAKESHI"
+      },
+      {
+        "address": "grpc-c4e.mzonder.com:443",
+        "provider": "MZONDER"
+      },
+      {
+        "address": "http://c4e.grpc.m.stavr.tech:7029",
         "provider": "🔥STAVR🔥"
       },
       {
-        "id": "094cc97f8443ba4302e2db818e64497d03176fad",
-        "address": "rpc.c4e.indonode.net:24656",
-        "provider": "Indonode"
+        "address": "c4e-grpc.stake-town.com:443",
+        "provider": "StakeTown"
       },
       {
-        "id": "89427b98e35b23dacafa8df90df6ae173245439b",
-        "address": "seed-c4e.theamsolutions.info:16656",
+        "address": "grpc.c4e.silentvalidator.com:443",
+        "provider": "silent"
+      },
+      {
+        "address": "http://chain4energy-rpc.stakeangle.com:1317",
+        "provider": "StakeAngle"
+      },
+      {
+        "address": "c4e-grpc.genznodes.dev:52090",
+        "provider": "genznodes"
+      },
+      {
+        "address": "https://grpc-c4e.theamsolutions.info:9391",
         "provider": "AM Solutions"
       },
       {
-        "id": "5be2027950e249c42e20390c94fc1e8f3cd16657",
-        "address": "65.108.70.119:33656",
+        "address": "https://c4e.grpc.m.anode.team",
         "provider": "AlxVoy ⚡ ANODE.TEAM"
       },
       {
-        "id": "1b802d4616c1de3fa687ad0d671b1b9d64754a44",
-        "address": "88.198.49.217:26157",
-        "provider": "Validator.run"
+        "address": "https://c4e-grpc.validatrium.club",
+        "provider": "Validatrium"
       },
       {
-        "id": "3ef7e5e7e163500af9baf53480779448461dac18",
-        "address": "185.245.182.192:46656",
+        "address": "http://185.245.182.192:1318",
         "provider": "Meerlabs"
       },
       {
-        "id": "d81f51b4a1aae66792fb1717589fa28975f328b0",
-        "address": "164.68.125.243:26656",
-        "provider": "Smt Network"
+        "address": "grpc-c4e.stakerun.com:1190",
+        "provider": "StakeRun"
       },
       {
-        "id": "2e08beed75525c2d583e6413fa5f090801965aba",
-        "address": "c4e.doubletop:30655",
+        "address": "https://c4e-grpc.antrixy.org/",
+        "provider": "Antirx Validators"
+      },
+      {
+        "address": "https://c4e.doubletop.tech:443",
         "provider": "DOUBLETOP"
       },
       {
-        "id": "15ea07bf6211f708eb2966b6c66e3aaa45834137",
-        "address": "185.144.99.37:16656",
-        "provider": "CrypTech"
+        "address": "c4e-grpc.kalia.network:3090",
+        "provider": "Kalia Network"
+      },
+      {
+        "address": "https://c4e.grpc.skynodejs.net",
+        "provider": "skynodejs"
+      },
+      {
+        "address": "http://38.242.220.64:19090",
+        "provider": "mahof"
+      },
+      {
+        "address": "http://209.182.239.169:9190",
+        "provider": "SECARD"
+      },
+      {
+        "address": "https://grpc.c4e.validatus.com:443",
+        "provider": "Validatus"
+      },
+      {
+        "address": "https://grpc-c4e.cryptech.com.ua:443",
+        "provider": "Cryptech"
+      },
+      {
+        "address": "http://207.180.208.47:46657",
+        "provider": "NakoTurk"
+      },
+      {
+        "address": "grpc.polcrypto.pl:443",
+        "provider": "POLCRYPTO.PL"
       }
-    ]
-  },
-  "apis": {
+    ],
+    "rest": [
+      {
+        "address": "https://lcd.c4e.io/",
+        "provider": "C4E"
+      },
+      {
+        "address": "https://api.c4e.mainnet.dteam.tech:443",
+        "provider": "DTEAM"
+      },
+      {
+        "address": "https://c4e.lcd.bccnodes.com",
+        "provider": "BccNodes"
+      },
+      {
+        "address": "https://chain4energy-mainnet-lcd.autostake.com:443",
+        "provider": "AutoStake 🛡️ Slash Protected"
+      },
+      {
+        "address": "https://c4e.api.m.stavr.tech",
+        "provider": "🔥STAVR🔥"
+      },
+      {
+        "address": "https://api-c4e.takeshi.team",
+        "provider": "TAKESHI"
+      },
+      {
+        "address": "https://api-c4e.mzonder.com",
+        "provider": "MZONDER"
+      },
+      {
+        "address": "https://rest.cros-nest.com/chain4energy",
+        "provider": "Crosnest"
+      },
+      {
+        "address": "https://api.c4e.indonode.net",
+        "provider": "Indonode"
+      },
+      {
+        "address": "https://c4e-api.stake-town.com",
+        "provider": "StakeTown"
+      },
+      {
+        "address": "https://api.c4e.silentvalidator.com",
+        "provider": "silent"
+      },
+      {
+        "address": "http://api.c4e.stakeup.tech",
+        "provider": "StakeUp"
+      },
+      {
+        "address": "http://chain4energy-rpc.stakeangle.com:1317",
+        "provider": "StakeAngle"
+      },
+      {
+        "address": "https://c4e-api.genznodes.dev",
+        "provider": "genznodes"
+      },
+      {
+        "address": "https://api-c4e.theamsolutions.info",
+        "provider": "AM Solutions"
+      },
+      {
+        "address": "https://c4e.api.m.anode.team",
+        "provider": "AlxVoy ⚡ ANODE.TEAM"
+      },
+      {
+        "address": "http://c4e.api.node75.org:1397",
+        "provider": "Pro-nodes75"
+      },
+      {
+        "address": "http://164.68.125.243:1319",
+        "provider": "Smt Network"
+      },
+      {
+        "address": "https://c4e-rest.antrixy.org/",
+        "provider": "Antrix Validators"
+      },
+      {
+        "address": "https://c4e-api.kalia.network:443",
+        "provider": "Kalia Network"
+      },
+      {
+        "address": "http://38.242.220.64:11317",
+        "provider": "mahof"
+      },
+      {
+        "address": "http://209.182.239.169:1417",
+        "provider": "SECARD"
+      },
+      {
+        "address": "https://api.c4e.validatus.com:443",
+        "provider": "Validatus"
+      },
+      {
+        "address": "https://api-c4e.cryptech.com.ua:443",
+        "provider": "CrypTech"
+      },
+      {
+        "address": "https://lcd-m-c4e.apeironnodes.com",
+        "provider": "Apeiron Nodes"
+      },
+      {
+        "address": "https://chain4energy_mainnet_api.chain.whenmoonwhenlambo.money",
+        "provider": "🚀 WHEN MOON 🌕 WHEN LAMBO 🔥"
+      },
+      {
+        "address": "https://rest.polcrypto.pl",
+        "provider": "POLCRYPTO.PL"
+      }
+    ],
     "rpc": [
       {
         "address": "https://rpc.c4e.io/",
@@ -352,305 +337,338 @@
       {
         "address": "https://chain4energy_mainnet_rpc.chain.whenmoonwhenlambo.money",
         "provider": "🚀 WHEN MOON 🌕 WHEN LAMBO 🔥"
-      }
-    ],
-    "rest": [
-      {
-        "address": "https://lcd.c4e.io/",
-        "provider": "C4E"
       },
       {
-        "address": "https://api.c4e.mainnet.dteam.tech:443",
-        "provider": "DTEAM"
-      },
-      {
-        "address": "https://c4e.lcd.bccnodes.com",
-        "provider": "BccNodes"
-      },
-      {
-        "address": "https://chain4energy-mainnet-lcd.autostake.com:443",
-        "provider": "AutoStake 🛡️ Slash Protected"
-      },
-      {
-        "address": "https://c4e.api.m.stavr.tech",
-        "provider": "🔥STAVR🔥"
-      },
-      {
-        "address": "https://api-c4e.takeshi.team",
-        "provider": "TAKESHI"
-      },
-      {
-        "address": "https://api-c4e.mzonder.com",
-        "provider": "MZONDER"
-      },
-      {
-        "address": "https://rest.cros-nest.com/chain4energy",
-        "provider": "Crosnest"
-      },
-      {
-        "address": "https://api.c4e.indonode.net",
-        "provider": "Indonode"
-      },
-      {
-        "address": "https://c4e-api.stake-town.com",
-        "provider": "StakeTown"
-      },
-      {
-        "address": "https://api.c4e.silentvalidator.com",
-        "provider": "silent"
-      },
-      {
-        "address": "http://api.c4e.stakeup.tech",
-        "provider": "StakeUp"
-      },
-      {
-        "address": "http://chain4energy-rpc.stakeangle.com:1317",
-        "provider": "StakeAngle"
-      },
-      {
-        "address": "https://c4e-api.genznodes.dev",
-        "provider": "genznodes"
-      },
-      {
-        "address": "https://api-c4e.theamsolutions.info",
-        "provider": "AM Solutions"
-      },
-      {
-        "address": "https://c4e.api.m.anode.team",
-        "provider": "AlxVoy ⚡ ANODE.TEAM"
-      },
-      {
-        "address": "http://c4e.api.node75.org:1397",
-        "provider": "Pro-nodes75"
-      },
-      {
-        "address": "http://164.68.125.243:1319",
-        "provider": "Smt Network"
-      },
-      {
-        "address": "https://c4e-rest.antrixy.org/",
-        "provider": "Antrix Validators"
-      },
-      {
-        "address": "https://c4e-api.kalia.network:443",
-        "provider": "Kalia Network"
-      },
-      {
-        "address": "http://38.242.220.64:11317",
-        "provider": "mahof"
-      },
-      {
-        "address": "http://209.182.239.169:1417",
-        "provider": "SECARD"
-      },
-      {
-        "address": "https://api.c4e.validatus.com:443",
-        "provider": "Validatus"
-      },
-      {
-        "address": "https://api-c4e.cryptech.com.ua:443",
-        "provider": "CrypTech"
-      },
-      {
-        "address": "https://lcd-m-c4e.apeironnodes.com",
-        "provider": "Apeiron Nodes"
-      },
-      {
-        "address": "https://chain4energy_mainnet_api.chain.whenmoonwhenlambo.money",
-        "provider": "🚀 WHEN MOON 🌕 WHEN LAMBO 🔥"
-      }
-    ],
-    "grpc": [
-      {
-        "address": "grpc.c4e.mainnet.dteam.tech:30090",
-        "provider": "DTEAM"
-      },
-      {
-        "address": "c4e.grpc.bccnodes.com:443",
-        "provider": "BccNodes"
-      },
-      {
-        "address": "chain4energy-mainnet-grpc.autostake.com:443",
-        "provider": "AutoStake 🛡️ Slash Protected"
-      },
-      {
-        "address": "c4e.grpc.bccnodes.com:443",
-        "provider": "BccNodes"
-      },
-      {
-        "address": "grpc-c4e.takeshi.team:443",
-        "provider": "TAKESHI"
-      },
-      {
-        "address": "grpc-c4e.mzonder.com:443",
-        "provider": "MZONDER"
-      },
-      {
-        "address": "http://c4e.grpc.m.stavr.tech:7029",
-        "provider": "🔥STAVR🔥"
-      },
-      {
-        "address": "c4e-grpc.stake-town.com:443",
-        "provider": "StakeTown"
-      },
-      {
-        "address": "grpc.c4e.silentvalidator.com:443",
-        "provider": "silent"
-      },
-      {
-        "address": "http://chain4energy-rpc.stakeangle.com:1317",
-        "provider": "StakeAngle"
-      },
-      {
-        "address": "c4e-grpc.genznodes.dev:52090",
-        "provider": "genznodes"
-      },
-      {
-        "address": "https://grpc-c4e.theamsolutions.info:9391",
-        "provider": "AM Solutions"
-      },
-      {
-        "address": "https://c4e.grpc.m.anode.team",
-        "provider": "AlxVoy ⚡ ANODE.TEAM"
-      },
-      {
-        "address": "https://c4e-grpc.validatrium.club",
-        "provider": "Validatrium"
-      },
-      {
-        "address": "http://185.245.182.192:1318",
-        "provider": "Meerlabs"
-      },
-      {
-        "address": "grpc-c4e.stakerun.com:1190",
-        "provider": "StakeRun"
-      },
-      {
-        "address": "https://c4e-grpc.antrixy.org/",
-        "provider": "Antirx Validators"
-      },
-      {
-        "address": "https://c4e.doubletop.tech:443",
-        "provider": "DOUBLETOP"
-      },
-      {
-        "address": "c4e-grpc.kalia.network:3090",
-        "provider": "Kalia Network"
-      },
-      {
-        "address": "https://c4e.grpc.skynodejs.net",
-        "provider": "skynodejs"
-      },
-      {
-        "address": "http://38.242.220.64:19090",
-        "provider": "mahof"
-      },
-      {
-        "address": "http://209.182.239.169:9190",
-        "provider": "SECARD"
-      },
-      {
-        "address": "https://grpc.c4e.validatus.com:443",
-        "provider": "Validatus"
-      },
-      {
-        "address": "https://grpc-c4e.cryptech.com.ua:443",
-        "provider": "Cryptech"
-      },
-      {
-        "address": "http://207.180.208.47:46657",
-        "provider": "NakoTurk"
+        "address": "https://rpc.polcrypto.pl",
+        "provider": "POLCRYPTO.PL"
       }
     ]
   },
+  "bech32_prefix": "c4e",
+  "chain_id": "perun-1",
+  "chain_name": "chain4energy",
+  "chain_type": "cosmos",
+  "codebase": {
+    "compatible_versions": [
+      "v1.3.1"
+    ],
+    "genesis": {
+      "genesis_url": "https://raw.githubusercontent.com/chain4energy/c4e-chains/main/perun-1/genesis.json"
+    },
+    "git_repo": "https://github.com/chain4energy/c4e-chain",
+    "recommended_version": "v1.3.1"
+  },
+  "daemon_name": "c4ed",
   "explorers": [
     {
+      "account_page": "https://explorer.chainroot.io/chain4energy/accounts/${accountAddress}",
       "kind": "Chainroot",
-      "url": "https://explorer.chainroot.io/chain4energy",
       "tx_page": "https://explorer.chainroot.io/chain4energy/transactions/${txHash}",
-      "account_page": "https://explorer.chainroot.io/chain4energy/accounts/${accountAddress}"
+      "url": "https://explorer.chainroot.io/chain4energy"
     },
     {
       "kind": "explorer",
-      "url": "https://explorer.apeironnodes.com/chain4energy",
-      "tx_page": "https://explorer.apeironnodes.com/chain4energy/transactions/${txHash}"
+      "tx_page": "https://explorer.apeironnodes.com/chain4energy/transactions/${txHash}",
+      "url": "https://explorer.apeironnodes.com/chain4energy"
     },
     {
       "kind": "DTEAM | Explorer",
-      "url": "https://explorer.mainnet.dteam.tech/chain4energy",
-      "tx_page": "https://explorer.mainnet.dteam.tech/chain4energytransactions/${txHash}"
+      "tx_page": "https://explorer.mainnet.dteam.tech/chain4energytransactions/${txHash}",
+      "url": "https://explorer.mainnet.dteam.tech/chain4energy"
     },
     {
       "kind": "explorer",
-      "url": "https://explorer.ppnv.space/c4e",
-      "tx_page": "https://explorer.ppnv.space/c4e/transactions/${txHash}"
+      "tx_page": "https://explorer.ppnv.space/c4e/transactions/${txHash}",
+      "url": "https://explorer.ppnv.space/c4e"
     },
     {
       "kind": "explorer",
-      "url": "https://explorer.c4e.io/",
-      "tx_page": "https://explorer.c4e.io/transactions/${txHash}"
+      "tx_page": "https://explorer.c4e.io/transactions/${txHash}",
+      "url": "https://explorer.c4e.io/"
     },
     {
       "kind": "NodeStake Explorer",
-      "url": "https://explorer.nodestake.org/chain4energy",
-      "tx_page": "https://explorer.nodestake.org/chain4energy/transactions/${txHash}"
+      "tx_page": "https://explorer.nodestake.org/chain4energy/transactions/${txHash}",
+      "url": "https://explorer.nodestake.org/chain4energy"
     },
     {
       "kind": "𝐥𝐞𝐬𝐧𝐢𝐤 | 𝐔𝐓𝐒𝐀 Explorer",
-      "url": "https://exp.utsa.tech/c4e",
-      "tx_page": "https://exp.utsa.tech/c4e/tx/${txHash}"
+      "tx_page": "https://exp.utsa.tech/c4e/tx/${txHash}",
+      "url": "https://exp.utsa.tech/c4e"
     },
     {
       "kind": "🔥STAVR🔥 Explorer",
-      "url": "https://explorer.stavr.tech/c4e",
-      "tx_page": "https://explorer.stavr.tech/c4e/tx/${txHash}"
+      "tx_page": "https://explorer.stavr.tech/c4e/tx/${txHash}",
+      "url": "https://explorer.stavr.tech/c4e"
     },
     {
       "kind": "BccNodes Explorer",
-      "url": "https://explorer.bccnodes.com/chain4energy",
-      "tx_page": "https://explorer.bccnodes.com/chain4energy/transactions/${txHash}"
+      "tx_page": "https://explorer.bccnodes.com/chain4energy/transactions/${txHash}",
+      "url": "https://explorer.bccnodes.com/chain4energy"
     },
     {
       "kind": "NODEXPLORER",
-      "url": "https://explorer.nodexcapital.com/c4e",
-      "tx_page": "https://explorer.nodexcapital.com/c4e/transactions/${txHash}"
+      "tx_page": "https://explorer.nodexcapital.com/c4e/transactions/${txHash}",
+      "url": "https://explorer.nodexcapital.com/c4e"
     },
     {
+      "account_page": "https://atomscan.com/chain4energy/accounts/${accountAddress}",
       "kind": "atomscan",
-      "url": "https://atomscan.com/chain4energy",
       "tx_page": "https://atomscan.com/chain4energy/transactions/${txHash}",
-      "account_page": "https://atomscan.com/chain4energy/accounts/${accountAddress}"
+      "url": "https://atomscan.com/chain4energy"
     },
     {
       "kind": "AM Solutions Explorer",
-      "url": "https://explorer.theamsolutions.info/c4e-main/staking",
-      "tx_page": "https://explorer.theamsolutions.info/c4e-main/transactions/${txHash}"
+      "tx_page": "https://explorer.theamsolutions.info/c4e-main/transactions/${txHash}",
+      "url": "https://explorer.theamsolutions.info/c4e-main/staking"
     },
     {
       "kind": "AlxVoy ⚡ ANODE.TEAM Explorer",
-      "url": "https://main.anode.team/c4e",
-      "tx_page": "https://main.anode.team/c4e/tx/${txHash}"
+      "tx_page": "https://main.anode.team/c4e/tx/${txHash}",
+      "url": "https://main.anode.team/c4e"
     },
     {
       "kind": "ScanRun",
-      "url": "https://scanrun.io/c4e",
-      "tx_page": "https://scanrun.io/c4e/transactions/${txHash}"
+      "tx_page": "https://scanrun.io/c4e/transactions/${txHash}",
+      "url": "https://scanrun.io/c4e"
     },
     {
       "kind": "Cryptech",
-      "url": "https://explorers.cryptech.com.ua/chain4energy",
-      "tx_page": "https://explorers.cryptech.com.ua/chain4energy/tx/${txHash}"
+      "tx_page": "https://explorers.cryptech.com.ua/chain4energy/tx/${txHash}",
+      "url": "https://explorers.cryptech.com.ua/chain4energy"
     },
     {
+      "account_page": "https://explorer.whenmoonwhenlambo.money/chain4energy/account/${accountAddress}",
       "kind": "🚀 WHEN MOON 🌕 WHEN LAMBO 🔥",
-      "url": "https://explorer.whenmoonwhenlambo.money/chain4energy",
       "tx_page": "https://explorer.whenmoonwhenlambo.money/chain4energy/tx/${txHash}",
-      "account_page": "https://explorer.whenmoonwhenlambo.money/chain4energy/account/${accountAddress}"
+      "url": "https://explorer.whenmoonwhenlambo.money/chain4energy"
+    },
+    {
+      "kind": "pingpub",
+      "provider": "POLCRYPTO.PL",
+      "tx_page": "#/tx?hash=${txHash}",
+      "url": "https://explorer.polcrypto.pl"
     }
   ],
+  "fees": {
+    "fee_tokens": [
+      {
+        "average_gas_price": 0.025,
+        "denom": "uc4e",
+        "fixed_min_gas_price": 0,
+        "high_gas_price": 0.04,
+        "low_gas_price": 0.01
+      }
+    ]
+  },
   "images": [
     {
       "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/chain4energy/images/c4e.png"
     }
-  ]
+  ],
+  "key_algos": [
+    "secp256k1"
+  ],
+  "logo_URIs": {
+    "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/chain4energy/images/c4e.png"
+  },
+  "network_type": "mainnet",
+  "node_home": "$HOME/.c4e-chain",
+  "peers": {
+    "persistent_peers": [
+      {
+        "address": "peer.c4e.mainnet.dteam.tech:30656",
+        "id": "00eb92db69a4848f8ac1c84e7b8b2d9b01b95dff",
+        "provider": "DTEAM"
+      },
+      {
+        "address": "rpc.c4e.ppnv.space:13656",
+        "id": "5b62ff6035d9c8143c0ebf4fe05fa0b22d96bb05",
+        "provider": "PPNV Service"
+      },
+      {
+        "address": "c4e-peer.nodine.id:13656",
+        "id": "a5133743ec9e0edffd83428af65004926352e393",
+        "provider": "Nodine.ID"
+      },
+      {
+        "address": "chain4energy-mainnet-peer.autostake.com:27276",
+        "id": "ebc272824924ea1a27ea3183dd0b9ba713494f83",
+        "provider": "AutoStake 🛡️ Slash Protected"
+      },
+      {
+        "address": "c4e.peer.stavr.tech:17096",
+        "id": "e3d0b136495c3f4382ac801fbc89083d32625ff8",
+        "provider": "🔥STAVR🔥"
+      },
+      {
+        "address": "rpc.c4e.indonode.net:24656",
+        "id": "094cc97f8443ba4302e2db818e64497d03176fad",
+        "provider": "Indonode"
+      },
+      {
+        "address": "seed-c4e.theamsolutions.info:16656",
+        "id": "89427b98e35b23dacafa8df90df6ae173245439b",
+        "provider": "AM Solutions"
+      },
+      {
+        "address": "65.108.70.119:33656",
+        "id": "5be2027950e249c42e20390c94fc1e8f3cd16657",
+        "provider": "AlxVoy ⚡ ANODE.TEAM"
+      },
+      {
+        "address": "88.198.49.217:26157",
+        "id": "1b802d4616c1de3fa687ad0d671b1b9d64754a44",
+        "provider": "Validator.run"
+      },
+      {
+        "address": "185.245.182.192:46656",
+        "id": "3ef7e5e7e163500af9baf53480779448461dac18",
+        "provider": "Meerlabs"
+      },
+      {
+        "address": "164.68.125.243:26656",
+        "id": "d81f51b4a1aae66792fb1717589fa28975f328b0",
+        "provider": "Smt Network"
+      },
+      {
+        "address": "c4e.doubletop:30655",
+        "id": "2e08beed75525c2d583e6413fa5f090801965aba",
+        "provider": "DOUBLETOP"
+      },
+      {
+        "address": "185.144.99.37:16656",
+        "id": "15ea07bf6211f708eb2966b6c66e3aaa45834137",
+        "provider": "CrypTech"
+      }
+    ],
+    "seeds": [
+      {
+        "address": "seed-m.c4e.apeironnodes.com:41003",
+        "id": "8ac87f7f8da5c2a901d64f2c1e86f8b6ee39fef1",
+        "provider": "Apeiron Nodes"
+      },
+      {
+        "address": "seed-m.c4e.apeironnodes.com:27003",
+        "id": "edca3b826d61d1e5e7d3dc173954de1324f2e512",
+        "provider": "Apeiron Nodes"
+      },
+      {
+        "address": "tenderseed.ccvalidators.com:26008",
+        "id": "30e98bbcf5bb29ed4e4ff685fa8fa84fa0ddff51",
+        "provider": "CryptoCrew"
+      },
+      {
+        "address": "c4e.seed.bccnodes.com:30656",
+        "id": "54515079bae4cadae2f9b511cffeb9447d4bc98d",
+        "provider": "BccNodes"
+      },
+      {
+        "address": "c4e.seed.node75.org:10156",
+        "id": "86bd5cb6e762f673f1706e5889e039d5406b4b90",
+        "provider": "Pro-nodes75"
+      },
+      {
+        "address": "rpc.c4e.nodexcapital.com:13956",
+        "id": "54ca81dd509cc6160de7f4b479a96b341d8e830e",
+        "provider": "NodeX Validator"
+      },
+      {
+        "address": "seed.c4e.hexnodes.co:02656",
+        "id": "6da239cb4fe03d957cdb1fdc26af3d083a7f5945",
+        "provider": "Hexnodes"
+      },
+      {
+        "address": "c4e.seed.mzonder.com:11256",
+        "id": "9aa8a73ea9364aa3cf7806d4dd25b6aed88d8152",
+        "provider": "MZONDER"
+      },
+      {
+        "address": "c4e.seed.stavr.tech:17096",
+        "id": "fbf9a48eca1ba873ad766e2cb72a0562596a248f",
+        "provider": "🔥STAVR🔥"
+      },
+      {
+        "address": "c4e-seed.takeshi.team:10256",
+        "id": "a85a651a3cf1746694560c5b6f76d566c04ca581",
+        "provider": "TAKESHI"
+      },
+      {
+        "address": "chain4energy-mainnet-seed.autostake.com:27276",
+        "id": "ebc272824924ea1a27ea3183dd0b9ba713494f83",
+        "provider": "AutoStake 🛡️ Slash Protected"
+      },
+      {
+        "address": "seeds.cros-nest.com:28656",
+        "id": "8cb175d973c3c638a4e5d014c030d8599369419f",
+        "provider": "Crosnest"
+      },
+      {
+        "address": "seeds.c4e.silentvalidator.com:39656",
+        "id": "5e71b5585d186cc32b9f071610f43042b445c05c",
+        "provider": "silent"
+      },
+      {
+        "address": "seeds.stakeup.tech:10210",
+        "id": "6b0ffcce9b59b91ceb8eea5d4599e27707e3604a",
+        "provider": "StakeUp"
+      },
+      {
+        "address": "seeds.anode.team:10256",
+        "id": "6cb7ff21d19f139f4ca5e6e2a336e59d2857aba1",
+        "provider": "AlxVoy ⚡ ANODE.TEAM"
+      },
+      {
+        "address": "c4e-seeds.validatrium.club:26656",
+        "id": "e47f4fa12187234dd205f51cb984c8235c3a3511",
+        "provider": "Validatrium"
+      },
+      {
+        "address": "185.245.182.192:46656",
+        "id": "3ef7e5e7e163500af9baf53480779448461dac18",
+        "provider": "Meerlabs"
+      },
+      {
+        "address": "89.117.58.109:26656",
+        "id": "0d1a44cc32e927dd062e0fd45d21475f9836e73d",
+        "provider": "medes"
+      },
+      {
+        "address": "164.68.125.243:26656",
+        "id": "d81f51b4a1aae66792fb1717589fa28975f328b0",
+        "provider": "Smt Network"
+      },
+      {
+        "address": "c4e.doubletop:30655",
+        "id": "2e08beed75525c2d583e6413fa5f090801965aba",
+        "provider": "DOUBLETOP"
+      },
+      {
+        "address": "c4e.seed.kalia.network:30656",
+        "id": "6f181c91dee34ebf2ea5c4f951c51b8c2c897702",
+        "provider": "Kalia Network"
+      },
+      {
+        "address": "seed.c4e.validatus.com:2000",
+        "id": "8739107d0484a4c58c4f980d61f488655597f80c",
+        "provider": "Validatus"
+      },
+      {
+        "address": "seed.publicnode.com:26656",
+        "id": "8542cd7e6bf9d260fef543bc49e59be5a3fa9074",
+        "provider": "Allnodes ⚡️ Nodes & Staking"
+      }
+    ]
+  },
+  "pretty_name": "C4E",
+  "slip44": 118,
+  "staking": {
+    "staking_tokens": [
+      {
+        "denom": "uc4e"
+      }
+    ]
+  },
+  "status": "live",
+  "website": "https://c4e.io/"
 }


### PR DESCRIPTION
This PR adds new endpoints and an explorer for the Chain4Energy (C4E) mainnet,
operated by **POLCRYPTO.PL** (active validator).

**RPC**
- https://rpc.polcrypto.pl (provider: POLCRYPTO.PL)

**REST (LCD)**
- https://rest.polcrypto.pl (provider: POLCRYPTO.PL)

**gRPC**
- grpc.polcrypto.pl:443 (provider: POLCRYPTO.PL)

**Explorer (PingPub)**
- https://explorer.polcrypto.pl (provider: POLCRYPTO.PL)

All endpoints are publicly available, SSL-enabled, and actively maintained by POLCRYPTO.PL.