### PR TITLE
Add Kudora Mainnet

### DIFF
--- a/kudora/assetlist.json
+++ b/kudora/assetlist.json
@@ -1,0 +1,25 @@
+{
+  "$schema": "../assetlist.schema.json",
+  "chain_name": "kudora",
+  "assets": [
+    {
+      "description": "Kudora Native Token",
+      "denom_units": [
+        {
+          "denom": "kud",
+          "exponent": 0
+        },
+        {
+          "denom": "Kudo",
+          "exponent": 18
+        }
+      ],
+      "base": "kud",
+      "name": "Kudo",
+      "display": "Kudo",
+      "symbol": "KUD",
+      "keywords": ["kudora"],
+      "type_asset": "evm-base"
+    }
+  ]
+}

--- a/kudora/chain.json
+++ b/kudora/chain.json
@@ -1,0 +1,71 @@
+{
+  "$schema": "../chain.schema.json",
+  "chain_name": "kudora",
+  "status": "live",
+  "network_type": "mainnet",
+  "website": "https://kudora.org/",
+  "pretty_name": "Kudora",
+  "chain_type": "cosmos",
+  "chain_id": "kudora_12000-1",
+  "bech32_prefix": "kudo",
+  "daemon_name": "kudorad",
+  "node_home": "$HOME/.kudora",
+  "key_algos": ["ethsecp256k1"],
+  "extra_codecs": ["ethermint"],
+  "slip44": 60,
+  "fees": {
+    "fee_tokens": [
+      {
+        "denom": "kud",
+        "average_gas_price": 0.0000000005
+      }
+    ]
+  },
+  "staking": {
+    "staking_tokens": [
+      {
+        "denom": "kud"
+      }
+    ]
+  },
+  "codebase": {
+    "git_repo": "https://github.com/Kudora-Labs/kudora",
+    "recommended_version": "v1.0.0",
+    "compatible_versions": ["v1.0.0"],
+    "consensus": {
+      "type": "cometbft",
+      "version": "0.38.17"
+    },
+    "binaries": {
+      "linux/amd64": "https://github.com/Kudora-Labs/kudora/releases/download/v1.0.0/kudorad_Linux_x86_64.tar.gz"
+    },
+    "genesis": {
+      "genesis_url": "https://raw.githubusercontent.com/Kudora-Labs/kud-network-mainnet/main/genesis.json"
+    },
+    "sdk": {
+      "type": "cosmos",
+      "version": "0.50.13",
+      "repo": "https://github.com/strangelove-ventures/cosmos-sdk"
+    },
+    "ibc": {
+      "type": "go",
+      "version": "8.7.0",
+      "repo": "https://github.com/cosmos/ibc-go",
+      "ics_enabled": ["ics20-1"]
+    },
+    "language": {
+      "type": "go",
+      "version": "1.23.7"
+    }
+  },
+  "apis": {
+    "evm-http-jsonrpc": [
+      { "address": "https://evm.kudora.org/", "provider": "Kudora Org" }
+    ],
+    "grpc": [{ "address": "grpc.kudora.org:443", "provider": "Kudora Org" }],
+    "rest": [
+      { "address": "https://api.kudora.org/", "provider": "Kudora Org" }
+    ],
+    "rpc": [{ "address": "https://rpc.kudora.org/", "provider": "Kudora Org" }]
+  }
+}

--- a/kudora/versions.json
+++ b/kudora/versions.json
@@ -1,0 +1,37 @@
+{
+  "$schema": "../versions.schema.json",
+  "chain_name": "kudora",
+  "versions": [
+    {
+      "name": "v1",
+      "tag": "v1.0.0",
+      "height": 0,
+      "recommended_version": "v1.0.0",
+      "compatible_versions": ["v1.0.0"],
+      "binaries": {
+        "linux/amd64": "https://github.com/Kudora-Labs/kudora/releases/download/v1.0.0/kudorad_Linux_x86_64.tar.gz"
+      },
+      "consensus": {
+        "type": "cometbft",
+        "version": "0.38.17",
+        "repo": "https://github.com/cometbft/cometbft",
+        "tag": "v0.38.17"
+      },
+      "sdk": {
+        "type": "cosmos",
+        "version": "0.50.13",
+        "repo": "https://github.com/strangelove-ventures/cosmos-sdk"
+      },
+      "ibc": {
+        "type": "go",
+        "version": "8.7.0",
+        "repo": "https://github.com/cosmos/ibc-go",
+        "ics_enabled": ["ics20-1"]
+      },
+      "language": {
+        "type": "go",
+        "version": "1.23.7"
+      }
+    }
+  ]
+}


### PR DESCRIPTION
Add Kudora Mainnet (chainId kudora_12000-1), an Cosmos SDK/Ethermint L1, native currency Kudo (KUD, 18 decimals). Explorer (PingPub) and logo assets will follow in a small subsequent PR. Thanks to the repo contributors for the excellent work and for reviewing this change. Maintainer: Kudora Labs: https://github.com/Kudora-Labs