### PR TITLE
Update Umee explorers: Remove non-functional ping.pub, prioritize Chainroot

### DIFF
--- a/umee/chain.json
+++ b/umee/chain.json
@@ -370,9 +370,10 @@
   },
   "explorers": [
     {
-      "kind": "ping.pub",
-      "url": "https://ping.pub/umee",
-      "tx_page": "https://ping.pub/umee/tx/${txHash}"
+      "kind": "Chainroot",
+      "url": "https://explorer.chainroot.io/ux",
+      "tx_page": "https://explorer.chainroot.io/ux/transactions/${txHash}",
+      "account_page": "https://explorer.chainroot.io/ux/accounts/${accountAddress}"
     },
     {
       "kind": "🔥STAVR🔥 Explorer",
@@ -424,12 +425,6 @@
       "url": "https://explorer.whenmoonwhenlambo.money/umee",
       "tx_page": "https://explorer.whenmoonwhenlambo.money/umee/tx/${txHash}",
       "account_page": "https://explorer.whenmoonwhenlambo.money/umee/account/${accountAddress}"
-    },
-    {
-      "kind": "Chainroot",
-      "url": "https://explorer.chainroot.io/ux",
-      "tx_page": "https://explorer.chainroot.io/ux/transactions/${txHash}",
-      "account_page": "https://explorer.chainroot.io/ux/accounts/${accountAddress}"
     },
     {
       "kind": "Valopers",


### PR DESCRIPTION
## Description
This PR updates the Umee (UX) chain explorers list to improve user experience.

## Changes
- Removed ping.pub explorer entry (currently non-functional for Umee)
- Moved Chainroot explorer to the first position as the primary explorer

## Rationale
- ping.pub is currently not working for the Umee chain
- Chainroot provides a reliable and functional explorer for UX at https://explorer.chainroot.io/ux
- By placing Chainroot first, it becomes the default explorer for applications that use the first entry

## Testing
Verified that Chainroot explorer is functional at https://explorer.chainroot.io/ux