### PR TITLE
Add Infrasingularity RPC endpoint for Sunrise

### DIFF
--- a/sunrise/chain.json
+++ b/sunrise/chain.json
@@ -89,7 +89,7 @@
         "provider": "Sunrise Team"
       },
       {
-        "address": "https://rpc-sunrise.infrasingularity.com"
+        "address": "https://rpc-sunrise.infrasingularity.com",
         "provider": "Infrasingularity"
       },
       {

--- a/sunrise/chain.json
+++ b/sunrise/chain.json
@@ -89,6 +89,10 @@
         "provider": "Sunrise Team"
       },
       {
+        "address": "https://rpc-sunrise.infrasingularity.com"
+        "provider": "Infrasingularity"
+      },
+      {
         "address": "https://sunrise-mainnet-rpc.mekonglabs.tech",
         "provider": "MekongLabs"
       },


### PR DESCRIPTION
This PR adds the Infrasingularity RPC endpoint for the Sunrise network to the chain-registry.

- The RPC endpoint URL: https://rpc-sunrise.infrasingularity.com
- Transaction indexing is enabled on this node (tx_index = "on" in configuration).
- CORS (Cross-Origin Resource Sharing) headers are properly configured to allow access.
- This submission complies fully with the Sunrise core team requirements for additional delegation incentives.
- The endpoint is production-grade, reliable, and ready to serve the community.