### PR TITLE
chore: add new channel details between chains cosmoshub and sentinel

### DIFF
--- a/_IBC/cosmoshub-sentinel.json
+++ b/_IBC/cosmoshub-sentinel.json
@@ -23,7 +23,7 @@
       "ordering": "unordered",
       "version": "ics20-1",
       "tags": {
-        "preferred": false
+        "preferred": false,
         "status": "ACTIVE"
       }
     },


### PR DESCRIPTION
The Sentinel team has created a new channel between Cosmos Hub and Sentinel for IBC ERC-20 token transfers. Relayers will be running on both channel pairs.