### PR TITLE
Update Epix chain.json

### DIFF
--- a/epix/chain.json
+++ b/epix/chain.json
@@ -80,7 +80,7 @@
     ],
     "grpc": [
       {
-        "address": "https://grpc.epix.zone:15067",
+        "address": "grpc.epix.zone:15067",
         "provider": "Epix"
       }
     ],


### PR DESCRIPTION
This pull request updates the network configuration for the Epix chain, switching all service endpoints and explorer links to official Epix zone providers. The changes ensure that all API connections and explorer references use the latest and most accurate endpoints.

Network endpoint updates:

* Changed all API endpoints (`rpc`, `rest`, `grpc`, `evm-http-jsonrpc`) in `epix/chain.json` to use Epix zone URLs and updated the provider name to "Epix".

Explorer updates:

* Updated the official L1 explorer at `explorer.epix.zone` and updated the transaction page template.
* Added a new EVM explorer entry for `scan.epix.zone` with its own transaction page template.Updated RPC/Explorer information