### PR TITLE
Add Data Nexus archive node to Lumera listing

### DIFF
--- a/lumera/chain.json
+++ b/lumera/chain.json
@@ -143,7 +143,7 @@
         "provider": "LumeraProtocol"
       },
       {
-        "address": "https://grpc.lumera.data.nexus",
+        "address": "https://grpc.lumera.archive.data.nexus",
         "provider": "Data Nexus"
       }
     ]

--- a/lumera/chain.json
+++ b/lumera/chain.json
@@ -113,6 +113,10 @@
       {
         "address": "https://lumera-rpc.stakerhouse.com",
         "provider": "StakerHouse"
+      },
+      {
+        "address": "https://lumera.archive.data.nexus",
+        "provider": "Data Nexus"
       }
     ],
     "rest": [
@@ -127,12 +131,20 @@
       {
         "address": "https://lumera-rest.stakerhouse.com",
         "provider": "StakerHouse"
+      },
+      {
+        "address": "https://rest.lumera.archive.data.nexus",
+        "provider": "Data Nexus"
       }
     ],
     "grpc": [
       {
         "address": "https://grpc.lumera.io:443",
         "provider": "LumeraProtocol"
+      },
+      {
+        "address": "https://grpc.lumera.data.nexus",
+        "provider": "Data Nexus"
       }
     ]
   },

--- a/lumera/chain.json
+++ b/lumera/chain.json
@@ -143,7 +143,7 @@
         "provider": "LumeraProtocol"
       },
       {
-        "address": "https://grpc.lumera.archive.data.nexus",
+        "address": "https://grpc.lumera.archive.data.nexus:443",
         "provider": "Data Nexus"
       }
     ]


### PR DESCRIPTION
This PR adds new archive endpoints to Lumera mainnet, operated by Data Nexus, an active validator on the network.


RPC

https://lumera.archive.data.nexus


REST (LCD)

https://rest.lumera.archive.data.nexus


gRPC

https://grpc.lumera.archive.data.nexus:443
