### PR TITLE
Update dYdX - version v9.1

### DIFF
--- a/dydx/chain.json
+++ b/dydx/chain.json
@@ -41,19 +41,19 @@
   },
   "codebase": {
     "git_repo": "https://github.com/dydxprotocol/v4-chain/",
-    "recommended_version": "protocol/v9.0.0",
+    "recommended_version": "protocol/v9.1.0",
     "compatible_versions": [
-      "protocol/v9.0.0"
+      "protocol/v9.1.0"
     ],
     "binaries": {
-      "linux/amd64": "https://github.com/dydxprotocol/v4-chain/releases/download/protocol%2Fv9.0.0/dydxprotocold-v9.0.0-linux-amd64.tar.gz",
-      "linux/arm64": "https://github.com/dydxprotocol/v4-chain/releases/download/protocol%2Fv9.0.0/dydxprotocold-v9.0.0-linux-arm64.tar.gz"
+      "linux/amd64": "https://github.com/dydxprotocol/v4-chain/releases/download/protocol%2Fv9.1.0/dydxprotocold-v9.1.0-linux-amd64.tar.gz",
+      "linux/arm64": "https://github.com/dydxprotocol/v4-chain/releases/download/protocol%2Fv9.1.0/dydxprotocold-v9.1.0-linux-arm64.tar.gz"
     },
     "consensus": {
       "type": "cometbft",
       "version": "v0.38.15",
       "repo": "https://github.com/dydxprotocol/cometbft",
-      "tag": "v0.38.6-0.20250807031327-f63a6917efaf"
+      "tag": "v0.38.6-0.20250917222732-ee7f1a0892c4"
     },
     "genesis": {
       "genesis_url": "https://raw.githubusercontent.com/dydxopsdao/networks/main/dydx-mainnet-1/genesis.json"
@@ -61,8 +61,8 @@
     "sdk": {
       "type": "cosmos",
       "repo": "https://github.com/dydxprotocol/cosmos-sdk",
-      "version": "v0.50.11",
-      "tag": "v0.50.6-0.20250807152116-6f31ad979963"
+      "version": "v0.50.6",
+      "tag": "v0.50.6-0.20250918154803-8e8ecbb19aa4"
     },
     "ibc": {
       "type": "go",

--- a/dydx/versions.json
+++ b/dydx/versions.json
@@ -396,6 +396,36 @@
         "type": "go",
         "version": "v8.0.0"
       },
+      "next_version_name": "v9.1"
+    },
+    {
+      "name": "v9.1",
+      "proposal": 283,
+      "height": 56530000,
+      "recommended_version": "protocol/v9.1.0",
+      "compatible_versions": [
+        "protocol/v9.1.0"
+      ],
+      "binaries": {
+        "linux/amd64": "https://github.com/dydxprotocol/v4-chain/releases/download/protocol%2Fv9.1.0/dydxprotocold-v9.1.0-linux-amd64.tar.gz",
+        "linux/arm64": "https://github.com/dydxprotocol/v4-chain/releases/download/protocol%2Fv9.1.0/dydxprotocold-v9.1.0-linux-arm64.tar.gz"
+      },
+      "consensus": {
+        "type": "cometbft",
+        "version": "v0.38.15",
+        "repo": "https://github.com/dydxprotocol/cometbft",
+        "tag": "v0.38.6-0.20250917222732-ee7f1a0892c4"
+      },
+      "sdk": {
+        "type": "cosmos",
+        "repo": "https://github.com/dydxprotocol/cosmos-sdk",
+        "version": "v0.50.11",
+        "tag": "v0.50.6-0.20250918154803-8e8ecbb19aa4"
+      },
+      "ibc": {
+        "type": "go",
+        "version": "v8.0.0"
+      },
       "next_version_name": ""
     }
   ]


### PR DESCRIPTION
```bash
dydxprotocold version --long

build_deps:
- cloud.google.com/go@v0.115.1
- cloud.google.com/go/auth@v0.9.4
- cloud.google.com/go/auth/oauth2adapt@v0.2.4
- cloud.google.com/go/compute/metadata@v0.5.1
- cloud.google.com/go/iam@v1.2.0
- cloud.google.com/go/storage@v1.43.0
- cosmossdk.io/api@v0.7.6
- cosmossdk.io/client/v2@v2.0.0-beta.4 => github.com/cosmos/cosmos-sdk/client/v2@v2.0.0-beta.1.0.20240219091002-18ea4c520045
- cosmossdk.io/collections@v0.4.0
- cosmossdk.io/core@v0.12.0 => cosmossdk.io/core@v0.11.0
- cosmossdk.io/depinject@v1.1.0
- cosmossdk.io/errors@v1.0.1
- cosmossdk.io/log@v1.4.1
- cosmossdk.io/math@v1.4.0
- cosmossdk.io/store@v1.1.1 => github.com/dydxprotocol/cosmos-sdk/store@v1.0.3-0.20240326192503-dd116391188d
- cosmossdk.io/tools/confix@v0.1.1
- cosmossdk.io/x/evidence@v0.1.0 => cosmossdk.io/x/evidence@v0.1.0
- cosmossdk.io/x/feegrant@v0.1.0
- cosmossdk.io/x/tx@v0.13.7
- cosmossdk.io/x/upgrade@v0.1.4 => cosmossdk.io/x/upgrade@v0.1.1
- filippo.io/edwards25519@v1.1.0
- github.com/99designs/go-keychain@v0.0.0-20191008050251-8e49817e8af4
- github.com/99designs/keyring@v1.2.2 => github.com/cosmos/keyring@v1.2.0
- github.com/DataDog/datadog-go@v4.8.2+incompatible
- github.com/DataDog/datadog-go/v5@v5.0.2
- github.com/DataDog/gostackparse@v0.5.0
- github.com/DataDog/zstd@v1.5.5
- github.com/GeertJohan/go.rice@v1.0.3
- github.com/IBM/sarama@v1.40.1
- github.com/Shopify/sarama@v1.37.2
- github.com/andres-erbsen/clock@v0.0.0-20160526145045-9e14626cd129
- github.com/avast/retry-go@v3.0.0+incompatible
- github.com/aws/aws-sdk-go@v1.44.224
- github.com/beorn7/perks@v1.0.1
- github.com/bgentry/go-netrc@v0.0.0-20140422174119-9fd32a8b3d3d
- github.com/bgentry/speakeasy@v0.1.1-0.20220910012023-760eaf8b6816
- github.com/bits-and-blooms/bitset@v1.14.2
- github.com/blendle/zapdriver@v1.3.1
- github.com/btcsuite/btcd/btcec/v2@v2.3.4 => github.com/btcsuite/btcd/btcec/v2@v2.3.2
- github.com/buger/jsonparser@v1.1.1
- github.com/burdiyan/kafkautil@v0.0.0-20190131162249-eaf83ed22d5b
- github.com/cenkalti/backoff/v4@v4.2.1
- github.com/cespare/xxhash/v2@v2.3.0
- github.com/chzyer/readline@v1.5.1
- github.com/cockroachdb/apd/v2@v2.0.2
- github.com/cockroachdb/errors@v1.11.3
- github.com/cockroachdb/fifo@v0.0.0-20240606204812-0bbfbd93a7ce
- github.com/cockroachdb/logtags@v0.0.0-20230118201751-21c54148d20b
- github.com/cockroachdb/pebble@v1.1.2
- github.com/cockroachdb/redact@v1.1.5
- github.com/cockroachdb/tokenbucket@v0.0.0-20230807174530-cc333fc44b06
- github.com/coinbase/rosetta-sdk-go/types@v1.0.0
- github.com/cometbft/cometbft@v0.38.15 => github.com/dydxprotocol/cometbft@v0.38.6-0.20250917222732-ee7f1a0892c4
- github.com/cometbft/cometbft-db@v0.15.0 => github.com/cometbft/cometbft-db@v0.12.0
- github.com/consensys/bavard@v0.1.13
- github.com/consensys/gnark-crypto@v0.12.1
- github.com/cosmos/btcutil@v1.0.5
- github.com/cosmos/cosmos-db@v1.1.0
- github.com/cosmos/cosmos-proto@v1.0.0-beta.5
- github.com/cosmos/cosmos-sdk@v0.50.11 => github.com/dydxprotocol/cosmos-sdk@v0.50.6-0.20250918154803-8e8ecbb19aa4
- github.com/cosmos/go-bip39@v1.0.0
- github.com/cosmos/gogogateway@v1.2.0
- github.com/cosmos/gogoproto@v1.7.0
- github.com/cosmos/iavl@v1.2.2 => github.com/dydxprotocol/iavl@v1.1.1-0.20240509161911-1c8b8e787e85
- github.com/cosmos/ibc-go/modules/capability@v1.0.1
- github.com/cosmos/ibc-go/v8@v8.5.1 => github.com/dydxprotocol/ibc-go/v8@v8.0.0-rc.0.0.20250312180215-8733b3edf43a
- github.com/cosmos/ics23/go@v0.11.0
- github.com/cosmos/interchain-security/v5@v5.2.0
- github.com/cosmos/rosetta@v0.50.3
- github.com/cosmos/rosetta-sdk-go@v0.10.0
- github.com/crate-crypto/go-ipa@v0.0.0-20240223125850-b1e8a79f509c
- github.com/crate-crypto/go-kzg-4844@v1.0.0
- github.com/creachadair/atomicfile@v0.3.1
- github.com/creachadair/tomledit@v0.0.24
- github.com/daaku/go.zipexe@v1.0.2
- github.com/davecgh/go-spew@v1.1.2-0.20180830191138-d8f796af33cc
- github.com/deckarep/golang-set/v2@v2.6.0
- github.com/decred/dcrd/dcrec/secp256k1/v4@v4.3.0
- github.com/desertbit/timer@v0.0.0-20180107155436-c41aec40b27f
- github.com/dvsekhvalnov/jose2go@v1.6.0
- github.com/dydxprotocol/slinky@v1.3.2
- github.com/eapache/go-resiliency@v1.3.0
- github.com/eapache/go-xerial-snappy@v0.0.0-20230111030713-bf00bc1b83b6
- github.com/eapache/queue@v1.1.0
- github.com/emicklei/dot@v1.6.2
- github.com/ethereum/go-ethereum@v1.14.11
- github.com/ethereum/go-verkle@v0.1.1-0.20240829091221-dffa7562dbe9
- github.com/fatih/color@v1.18.0
- github.com/felixge/httpsnoop@v1.0.4
- github.com/fsnotify/fsnotify@v1.7.0
- github.com/gabriel-vasile/mimetype@v1.4.2
- github.com/gagliardetto/binary@v0.8.0
- github.com/gagliardetto/solana-go@v1.11.0
- github.com/gagliardetto/treeout@v0.1.4
- github.com/getsentry/sentry-go@v0.27.0
- github.com/go-kit/kit@v0.13.0
- github.com/go-kit/log@v0.2.1
- github.com/go-logfmt/logfmt@v0.6.0
- github.com/go-logr/logr@v1.4.2
- github.com/go-logr/stdr@v1.2.2
- github.com/go-playground/locales@v0.14.1
- github.com/go-playground/universal-translator@v0.18.1
- github.com/go-playground/validator/v10@v10.14.0
- github.com/go-stack/stack@v1.8.1
- github.com/gogo/googleapis@v1.4.1
- github.com/gogo/protobuf@v1.3.2
- github.com/golang/groupcache@v0.0.0-20210331224755-41bb18bfe9da
- github.com/golang/mock@v1.6.0
- github.com/golang/protobuf@v1.5.4
- github.com/golang/snappy@v0.0.5-0.20220116011046-fa5810519dcb
- github.com/google/btree@v1.1.3
- github.com/google/go-cmp@v0.6.0
- github.com/google/orderedcode@v0.0.1
- github.com/google/pprof@v0.0.0-20240827171923-fa2c70bbbfe5 => github.com/google/pprof@v0.0.0-20230228050547-1710fef4ab10
- github.com/google/s2a-go@v0.1.8
- github.com/google/uuid@v1.6.0
- github.com/googleapis/enterprise-certificate-proxy@v0.3.4
- github.com/googleapis/gax-go/v2@v2.13.0
- github.com/gorilla/handlers@v1.5.2
- github.com/gorilla/mux@v1.8.1
- github.com/gorilla/rpc@v1.2.0
- github.com/gorilla/websocket@v1.5.3
- github.com/grpc-ecosystem/go-grpc-middleware@v1.4.0
- github.com/grpc-ecosystem/grpc-gateway@v1.16.0
- github.com/hashicorp/errwrap@v1.1.0
- github.com/hashicorp/go-cleanhttp@v0.5.2
- github.com/hashicorp/go-getter@v1.7.5
- github.com/hashicorp/go-hclog@v1.5.0
- github.com/hashicorp/go-immutable-radix@v1.3.1
- github.com/hashicorp/go-metrics@v0.5.3
- github.com/hashicorp/go-multierror@v1.1.1
- github.com/hashicorp/go-plugin@v1.6.0
- github.com/hashicorp/go-safetemp@v1.0.0
- github.com/hashicorp/go-uuid@v1.0.3
- github.com/hashicorp/go-version@v1.7.0
- github.com/hashicorp/golang-lru@v1.0.2
- github.com/hashicorp/hcl@v1.0.0
- github.com/hashicorp/yamux@v0.1.1
- github.com/hdevalence/ed25519consensus@v0.1.0
- github.com/holiman/uint256@v1.3.1
- github.com/huandu/skiplist@v1.2.0
- github.com/iancoleman/strcase@v0.3.0
- github.com/improbable-eng/grpc-web@v0.15.0
- github.com/jcmturner/aescts/v2@v2.0.0
- github.com/jcmturner/dnsutils/v2@v2.0.0
- github.com/jcmturner/gofork@v1.7.6
- github.com/jcmturner/gokrb5/v8@v8.4.3
- github.com/jcmturner/rpc/v2@v2.0.3
- github.com/jmespath/go-jmespath@v0.4.0
- github.com/json-iterator/go@v1.1.12
- github.com/klauspost/compress@v1.17.11
- github.com/kr/pretty@v0.3.1
- github.com/kr/text@v0.2.0
- github.com/leodido/go-urn@v1.2.4
- github.com/lib/pq@v1.10.9
- github.com/libp2p/go-buffer-pool@v0.1.0
- github.com/logrusorgru/aurora@v2.0.3+incompatible
- github.com/lovoo/goka@v1.1.9
- github.com/magiconair/properties@v1.8.7
- github.com/manifoldco/promptui@v0.9.0
- github.com/mattn/go-colorable@v0.1.13
- github.com/mattn/go-isatty@v0.0.20
- github.com/minio/highwayhash@v1.0.3
- github.com/mitchellh/go-homedir@v1.1.0
- github.com/mitchellh/go-testing-interface@v1.14.1
- github.com/mitchellh/mapstructure@v1.5.0
- github.com/mmcloughlin/addchain@v0.4.0
- github.com/modern-go/concurrent@v0.0.0-20180306012644-bacd9c7ef1dd
- github.com/modern-go/reflect2@v1.0.2
- github.com/mostynb/zstdpool-freelist@v0.0.0-20201229113212-927304c0c3b1
- github.com/mr-tron/base58@v1.2.0
- github.com/mtibben/percent@v0.2.1
- github.com/oasisprotocol/curve25519-voi@v0.0.0-20230904125328-1f23a7beb09a
- github.com/oklog/run@v1.1.0
- github.com/pelletier/go-toml@v1.9.5
- github.com/pelletier/go-toml/v2@v2.2.3
- github.com/pierrec/lz4/v4@v4.1.17
- github.com/pkg/errors@v0.9.1
- github.com/pmezard/go-difflib@v1.0.1-0.20181226105442-5d4384ee4fb2
- github.com/prometheus/client_golang@v1.20.5 => github.com/prometheus/client_golang@v1.18.0
- github.com/prometheus/client_model@v0.6.1
- github.com/prometheus/common@v0.60.1 => github.com/prometheus/common@v0.47.0
- github.com/prometheus/procfs@v0.15.1
- github.com/rakyll/statik@v0.1.7
- github.com/rcrowley/go-metrics@v0.0.0-20201227073835-cf1acfcdf475
- github.com/richardartoul/molecule@v1.0.1-0.20221107223329-32cfee06a052
- github.com/rogpeppe/go-internal@v1.13.1
- github.com/rs/cors@v1.11.1
- github.com/rs/zerolog@v1.33.0
- github.com/sagikazarmark/slog-shim@v0.1.0
- github.com/shirou/gopsutil@v3.21.4-0.20210419000835-c7a38de76ee5+incompatible
- github.com/shopspring/decimal@v1.3.1
- github.com/spaolacci/murmur3@v1.1.0
- github.com/spf13/afero@v1.11.0
- github.com/spf13/cast@v1.7.0
- github.com/spf13/cobra@v1.8.1
- github.com/spf13/pflag@v1.0.5
- github.com/spf13/viper@v1.19.0
- github.com/streamingfast/logging@v0.0.0-20230608130331-f22c91403091
- github.com/stretchr/testify@v1.10.0
- github.com/subosito/gotenv@v1.6.0
- github.com/syndtr/goleveldb@v1.0.1-0.20220721030215-126854af5e6d => github.com/syndtr/goleveldb@v1.0.1-0.20210819022825-2ae1ddf74ef7
- github.com/tendermint/go-amino@v0.16.0
- github.com/tidwall/btree@v1.7.0
- github.com/tklauser/go-sysconf@v0.3.12
- github.com/ulikunitz/xz@v0.5.11
- github.com/zyedidia/generic@v1.0.0
- go.mongodb.org/mongo-driver@v1.11.0
- go.opencensus.io@v0.24.0
- go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc@v0.54.0
- go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp@v0.54.0
- go.opentelemetry.io/otel@v1.29.0
- go.opentelemetry.io/otel/metric@v1.29.0
- go.opentelemetry.io/otel/trace@v1.29.0
- go.uber.org/multierr@v1.11.0
- go.uber.org/ratelimit@v0.2.0
- go.uber.org/zap@v1.27.0
- golang.org/x/crypto@v0.31.0
- golang.org/x/exp@v0.0.0-20240909161429-701f63a606c0
- golang.org/x/net@v0.32.0
- golang.org/x/oauth2@v0.23.0
- golang.org/x/sync@v0.10.0
- golang.org/x/sys@v0.28.0
- golang.org/x/term@v0.27.0
- golang.org/x/text@v0.21.0
- golang.org/x/time@v0.6.0
- google.golang.org/api@v0.198.0
- google.golang.org/genproto@v0.0.0-20240903143218-8af14fe29dc1
- google.golang.org/genproto/googleapis/api@v0.0.0-20240903143218-8af14fe29dc1
- google.golang.org/genproto/googleapis/rpc@v0.0.0-20240930140551-af27646dc61f
- google.golang.org/grpc@v1.68.1
- google.golang.org/protobuf@v1.35.2
- gopkg.in/DataDog/dd-trace-go.v1@v1.48.0
- gopkg.in/ini.v1@v1.67.0
- gopkg.in/typ.v4@v4.1.0
- gopkg.in/yaml.v2@v2.4.0
- gopkg.in/yaml.v3@v3.0.1
- gotest.tools/v3@v3.5.1
- nhooyr.io/websocket@v1.8.10
- pgregory.net/rapid@v1.1.0
- rsc.io/tmplfunc@v0.0.3
- sigs.k8s.io/yaml@v1.4.0
build_tags: netgo
commit: 0e878fad62cd54512ac6d87a25743ecedfbc297c
cosmos_sdk_version: v0.50.6-0.20250918154803-8e8ecbb19aa4
go: go version go1.25.1 darwin/arm64
name: dydxprotocol
server_name: dydxprotocold
version: 9.1.0

```