### PR TITLE
update(arkeo): refresh Osmosis IBC path with new client and connection IDs

### DIFF
--- a/_IBC/arkeo-osmosis.json
+++ b/_IBC/arkeo-osmosis.json
@@ -1,32 +1,32 @@
 {
-    "$schema": "../ibc_data.schema.json",
-    "chain_1": {
-      "chain_name": "arkeo",
-      "client_id": "07-tendermint-1",
-      "connection_id": "connection-2"
-    },
-    "chain_2": {
-      "chain_name": "osmosis",
-      "client_id": "07-tendermint-3489",
-      "connection_id": "connection-10730"
-    },
-    "channels": [
-      {
-        "chain_1": {
-          "channel_id": "channel-1",
-          "port_id": "transfer"
-        },
-        "chain_2": {
-          "channel_id": "channel-103074",
-          "port_id": "transfer"
-        },
-        "ordering": "unordered",
-        "version": "ics20-1",
-        "tags": {
-          "status": "live",
-          "preferred": true,
-          "dex": "osmosis"
-        }
+  "$schema": "../../ibc_data.schema.json",
+  "chain-1": {
+    "chain-name": "arkeo",
+    "client-id": "07-tendermint-12",
+    "connection-id": "connection-13"
+  },
+  "chain-2": {
+    "chain-name": "osmosis",
+    "client-id": "07-tendermint-3604",
+    "connection-id": "connection-10951"
+  },
+  "channels": [
+    {
+      "chain-1": {
+        "channel-id": "channel-9",
+        "port-id": "transfer"
+      },
+      "chain-2": {
+        "channel-id": "channel-107016",
+        "port-id": "transfer"
+      },
+      "ordering": "unordered",
+      "version": "ics20-1",
+      "tags": {
+        "status": "live",
+        "preferred": true,
+        "dex": "osmosis"
       }
-    ]
-  }
+    }
+  ]
+}


### PR DESCRIPTION
- Updated Osmosis IBC link for Arkeo to use new clients and connections
  - src_client_id: 07-tendermint-12
  - dst_client_id: 07-tendermint-3604
  - src_connection_id: connection-13
  - dst_connection_id: connection-10951
  - src_channel_id: channel-9
  - dst_channel_id: channel-107016

This change replaces the expired IBC client with the new valid one, restoring the transfer channel between Arkeo and Osmosis.