### PR TITLE
Add catsmile public endpoints for Sunrise mainnet:

### DIFF
--- a/sunrise/chain.json
+++ b/sunrise/chain.json
@@ -151,6 +151,10 @@
       {
         "address": "https://rpc-sunrise.blockval.io/",
         "provider": "Blockval"
+      },
+      {
+        "address": "https://rpc-sunrice-mainnet.catsmile.space",
+        "provider": "catsmile"
       }
     ],
     "rest": [
@@ -217,6 +221,10 @@
       {
         "address": "https://api-sunrise.blockval.io",
         "provider": "Blockval"
+      },
+      {
+        "address": "https://api-sunrice-mainnet.catsmile.space",
+        "provider": "catsmile"
       }
     ],
     "grpc": [
@@ -267,6 +275,10 @@
       {
         "address": "grpc-sunrise.blockval.io:443",
         "provider": "Blockval"
+      },
+      {
+        "address": "grpc-sunrice-mainnet.catsmile.space:443",
+        "provider": "catsmile"
       }
     ]
   },
@@ -341,6 +353,12 @@
       "url": "https://explorer.winnode.xyz/Sunrise-Mainnet",
       "tx_page": "https://explorer.winnode.xyz/Sunrise-Mainnet/tx/${txHash}",
       "account_page": "https://explorer.winnode.xyz/Sunrise-Mainnet/account/${accountAddress}"
+    },
+    {
+      "kind": "catsmile explorer",
+      "url": "https://explorer.catsmile.cloud/sunrice-mainnet",
+      "tx_page": "https://explorer.catsmile.cloud/sunrice-mainnet/tx/${txHash}",
+      "account_page": "https://explorer.catsmile.cloud/sunrice-mainnet/account/${accountAddress}"
     }
   ],
   "images": [


### PR DESCRIPTION
Add Catsmile public endpoints for Sunrise mainnet:
- Added RPC endpoint: https://rpc-sunrice-mainnet.catsmile.space/
- Added API endpoint: https://api-sunrice-mainnet.catsmile.space/
- Added gRPC endpoint: grpc-sunrice-mainnet.catsmile.space:443
- Added explorer: https://explorer.catsmile.cloud/sunrice-mainnet

All endpoints verified live and synced with sunrise-1 chain ID. Maintainer: Catsmile