### PR TITLE
Fix Image Reference Detection

### DIFF
--- a/.github/workflows/utility/validate_data.mjs
+++ b/.github/workflows/utility/validate_data.mjs
@@ -22,7 +22,7 @@ const chainRegistryRoot = "../../..";
 
 //--APIs--
 import * as coingecko from './coingecko_data.mjs';
-const API_FETCHING = false;// set to false for local testing, true for GitHub validation
+const API_FETCHING = true;// set to false for local testing, true for GitHub validation
 
 
 const imageURIs = ["png", "svg"];


### PR DESCRIPTION
Validation wasn't detecting when an image was only referenced by logo_URIs (it required `images`, but we don't want to actually require `images`)
To resolve: Fix push logo_URIs to images function