### PR TITLE
osmosis: remove offline and unsynced endpoints

### DIFF
--- a/osmosis/chain.json
+++ b/osmosis/chain.json
@@ -697,28 +697,8 @@
   "apis": {
     "rpc": [
       {
-      "address": "http://79.173.83.234:26657",
-      "provider": "Gonz_chains"
-      },
-      {
         "address": "https://rpc.osmosis.zone/",
         "provider": "Osmosis Foundation"
-      },
-      {
-        "address": "https://rpc-osmosis.blockapsis.com",
-        "provider": "chainapsis"
-      },
-      {
-        "address": "https://osmosis-rpc.onivalidator.com",
-        "provider": "Oni Validator ⛩️"
-      },
-      {
-        "address": "https://osmosis-rpc.quickapi.com:443",
-        "provider": "Chainlayer"
-      },
-      {
-        "address": "https://rpc-osmosis.whispernode.com:443",
-        "provider": "WhisperNode 🤐"
       },
       {
         "address": "https://rpc.lavenderfive.com:443/osmosis",
@@ -729,36 +709,12 @@
         "provider": "ecostake"
       },
       {
-        "address": "https://rpc-osmosis.cosmos-spaces.cloud",
-        "provider": "Cosmos Spaces"
-      },
-      {
         "address": "https://osmosis-rpc.polkachu.com",
         "provider": "Polkachu"
       },
       {
-        "address": "https://rpc-osmosis-ia.cosmosia.notional.ventures",
-        "provider": "Notional"
-      },
-      {
         "address": "https://osmosis.rpc.stakin-nodes.com",
         "provider": "Stakin"
-      },
-      {
-        "address": "https://osmosis-mainnet-rpc.autostake.com:443",
-        "provider": "AutoStake 🛡️ Slash Protected"
-      },
-      {
-        "address": "https://osmosis.api.onfinality.io/public",
-        "provider": "OnFinality"
-      },
-      {
-        "address": "https://rpc-osmosis-01.stakeflow.io",
-        "provider": "Stakeflow"
-      },
-      {
-        "address": "https://osmosis-rpc.w3coins.io",
-        "provider": "w3coins"
       },
       {
         "address": "https://osmosis-rpc.publicnode.com:443",
@@ -777,24 +733,8 @@
         "provider": "StakeTown"
       },
       {
-        "address": "https://osmosis-mainnet.rpc.l0vd.com:443",
-        "provider": "L0vd.com ❤️"
-      },
-      {
-        "address": "https://osmosis-rpc.reece.sh",
-        "provider": "Reecepbcups"
-      },
-      {
         "address": "https://rpc.osmosis.validatus.com",
         "provider": "Validatus"
-      },
-      {
-        "address": "https://rpc.osmosis.bronbro.io:443",
-        "provider": "Bro_n_Bro"
-      },
-      {
-        "address": "https://osmosis.interstellar-lounge.org",
-        "provider": "Interstellar Lounge 🍸"
       },
       {
         "address": "https://public.stakewolle.com/cosmos/osmosis/rpc",
@@ -805,10 +745,6 @@
         "provider": "Crosnest"
       },
       {
-        "address": "https://rpc-osmo.kewrnode.com",
-        "provider": "Kewr Node"
-      },
-      {
         "address": "https://rpc.osmosis.goldenratiostaking.net",
         "provider": "Golden Ratio Staking"
       },
@@ -817,31 +753,11 @@
         "provider": "[NODERS]TEAM"
       },
       {
-        "address": "https://osmosis.drpc.org",
-        "provider": "dRPC"
-      },
-      {
-        "address": "https://osmosis-rpc.chainroot.io",
-        "provider": "Chainroot"
-      },
-      {
-        "address": "https://osmosis.rpc.quasarstaking.ai:443",
-        "provider": "Quasar"
-      },
-      {
-        "address": "https://osmosis-mainnet-tendermint.reliableninjas.com",
-        "provider": "Reliable Ninjas"
-      },
-      {
         "address": "https://osmosis-rpc.highstakes.ch",
         "provider": "High Stakes 🇨🇭"
       }
     ],
     "rest": [
-      {
-      "address": "http://79.173.83.234:1317", 
-      "provider": "Gonz_chains"
-      },
       {
         "address": "https://lcd.osmosis.zone/",
         "provider": "Osmosis Foundation"
@@ -849,14 +765,6 @@
       {
         "address": "https://rest.osmosis.goldenratiostaking.net",
         "provider": "Golden Ratio Staking"
-      },
-      {
-        "address": "https://osmosis-lcd.quickapi.com:443",
-        "provider": "Chainlayer"
-      },
-      {
-        "address": "https://lcd-osmosis.blockapsis.com",
-        "provider": "chainapsis"
       },
       {
         "address": "https://rest.lavenderfive.com:443/osmosis",
@@ -867,36 +775,12 @@
         "provider": "ecostake"
       },
       {
-        "address": "https://api-osmosis-ia.cosmosia.notional.ventures",
-        "provider": "Notional"
-      },
-      {
-        "address": "https://api-osmosis.cosmos-spaces.cloud",
-        "provider": "Cosmos Spaces"
-      },
-      {
         "address": "https://osmosis-api.polkachu.com",
         "provider": "Polkachu"
       },
       {
         "address": "https://osmosis.rest.stakin-nodes.com",
         "provider": "Stakin"
-      },
-      {
-        "address": "https://osmosis-mainnet-lcd.autostake.com:443",
-        "provider": "AutoStake 🛡️ Slash Protected"
-      },
-      {
-        "address": "https://api-osmosis-01.stakeflow.io",
-        "provider": "Stakeflow"
-      },
-      {
-        "address": "https://osmosis-api.w3coins.io",
-        "provider": "w3coins"
-      },
-      {
-        "address": "https://lcd-osmosis.whispernode.com:443",
-        "provider": "WhisperNode 🤐"
       },
       {
         "address": "https://osmosis-rest.publicnode.com",
@@ -911,20 +795,8 @@
         "provider": "StakeTown"
       },
       {
-        "address": "https://osmosis-api.reece.sh",
-        "provider": "Reecepbcups"
-      },
-      {
         "address": "https://api.osmosis.validatus.com:443",
         "provider": "Validatus"
-      },
-      {
-        "address": "https://lcd.osmosis.bronbro.io:443",
-        "provider": "Bro_n_Bro"
-      },
-      {
-        "address": "https://osmosis-rest.interstellar-lounge.org",
-        "provider": "Interstellar Lounge 🍸"
       },
       {
         "address": "https://public.stakewolle.com/cosmos/osmosis/rest",
@@ -935,24 +807,8 @@
         "provider": "Crosnest"
       },
       {
-        "address": "https://rest-osmo.kewrnode.com",
-        "provider": "Kewr Node"
-      },
-      {
         "address": "https://osmosis-api.noders.services",
         "provider": "[NODERS]TEAM"
-      },
-      {
-        "address": "https://osmosis-api.chainroot.io",
-        "provider": "Chainroot"
-      },
-      {
-        "address": "https://osmosis.api.quasarstaking.ai:443",
-        "provider": "Quasar"
-      },
-      {
-        "address": "https://osmosis-mainnet-cosmos.reliableninjas.com",
-        "provider": "Reliable Ninjas"
       },
       {
         "address": "https://osmosis-api.highstakes.ch",
@@ -965,10 +821,6 @@
         "provider": "Lavender.Five Nodes 🐝"
       },
       {
-        "address": "grpc-osmosis-ia.cosmosia.notional.ventures:443",
-        "provider": "Notional"
-      },
-      {
         "address": "osmosis.grpc.stakin-nodes.com:443",
         "provider": "Stakin"
       },
@@ -977,24 +829,8 @@
         "provider": "AutoStake 🛡️ Slash Protected"
       },
       {
-        "address": "grpc-osmosis.cosmos-spaces.cloud:1130",
-        "provider": "Cosmos Spaces"
-      },
-      {
         "address": "grpc-osmosis-01.stakeflow.io:6754",
         "provider": "Stakeflow"
-      },
-      {
-        "address": "services.staketab.com:9010",
-        "provider": "Staketab"
-      },
-      {
-        "address": "osmosis-grpc.w3coins.io:12590",
-        "provider": "w3coins"
-      },
-      {
-        "address": "grpc-osmosis.mms.team:443",
-        "provider": "MMS"
       },
       {
         "address": "osmosis-grpc.publicnode.com:443",
@@ -1005,18 +841,6 @@
         "provider": "StakeTown"
       },
       {
-        "address": "https://grpc-osmosis.nodeist.net",
-        "provider": "Nodeist"
-      },
-      {
-        "address": "osmosis-mainnet.grpc.l0vd.com:80",
-        "provider": "L0vd.com ❤️"
-      },
-      {
-        "address": "grpc-osmosis.whispernode.com:443",
-        "provider": "WhisperNode 🤐"
-      },
-      {
         "address": "grpc.osmosis.validatus.com:443",
         "provider": "Validatus"
       },
@@ -1025,16 +849,8 @@
         "provider": "Bro_n_Bro"
       },
       {
-        "address": "osmosis-grpc.noders.services:10090",
-        "provider": "[NODERS]TEAM"
-      },
-      {
         "address": "osmosis-grpc.chainroot.io:443",
         "provider": "Chainroot"
-      },
-      {
-        "address": "osmosis.grpc.quasarstaking.ai:443",
-        "provider": "Quasar"
       }
     ]
   },


### PR DESCRIPTION
Removed non-functional RPC, REST, and gRPC endpoints based on automated testing results.

Testing performed using https://github.com/jasbanza/cosmos-node-status-report

Changes:

- RPC endpoints: removed 20 offline/unsynced nodes, kept 15 working nodes

- REST endpoints: removed 16 offline/unsynced nodes, kept 14 working nodes

- gRPC endpoints: removed 10 offline nodes, kept 9 working/reachable nodes

Note: Crosnest endpoints retained despite being 20-21 blocks behind (acceptable lag)