### PR TITLE
Update logic for checking for duplicate IBC channels

### DIFF
--- a/.github/workflows/utility/validate_data.mjs
+++ b/.github/workflows/utility/validate_data.mjs
@@ -2098,7 +2098,7 @@ async function validateAll() {
   let errorMsgs = {};
 
   //check all chains
-  //await validate_chains(errorMsgs);
+  await validate_chains(errorMsgs);
 
   //check all IBC channels
   validate_ibc_files(errorMsgs);


### PR DESCRIPTION
Update logic for checking for duplicate IBC channels

Will show this when there is a duplicate found:

```
Some channel IDs for the same chain are not unique!: 1
For chain: osmosis, the channel_id: channel-1 is registered 2 times:
[
  {
    "ibcConnection": "8ball:osmosis",
    "ibcChannel": "0",
    "channelChainNumber": "chain_2"
  },
  {
    "ibcConnection": "akash:osmosis",
    "ibcChannel": "0",
    "channelChainNumber": "chain_2"
  }
]
Some channel IDs for the same chain are not unique!: 1
```