### PR TITLE
Remove '.atom' suffix from asset display and symbol

### DIFF
--- a/terra2/assetlist.json
+++ b/terra2/assetlist.json
@@ -1755,17 +1755,13 @@
         {
           "denom": "paxg",
           "exponent": 18
-        },
-        {
-          "denom": "paxg.atom",
-          "exponent": 18
         }
       ],
       "type_asset": "ics20",
       "base": "ibc/0EF5630576C66968EF0787868CF09FD866FAD131BC148D24A148358A85F0EB62",
       "name": "Eureka Bridged PAX Gold (Terra)",
-      "display": "paxg.atom",
-      "symbol": "PAXG.ATOM",
+      "display": "paxg",
+      "symbol": "PAXG",
       "traces": [
         {
           "type": "ibc-bridge",
@@ -1823,17 +1819,13 @@
         {
           "denom": "xaut",
           "exponent": 6
-        },
-        {
-          "denom": "xaut.atom",
-          "exponent": 6
         }
       ],
       "type_asset": "ics20",
       "base": "ibc/F20FE45BF7122CF10559EDEA032E37956D3314774EA6D8D1D46B87D138290C45",
       "name": "Eureka Bridged Tether Gold (Terra)",
-      "display": "xaut.atom",
-      "symbol": "XAUt.ATOM",
+      "display": "xaut",
+      "symbol": "XAUt",
       "traces": [
         {
           "type": "ibc-bridge",


### PR DESCRIPTION
Remove ".atom" suffix of PAXG and XAUt