### PR TITLE
Add Mandragora's Bitway seed, peer, RPC, API and gRPC

### DIFF
--- a/bitway/chain.json
+++ b/bitway/chain.json
@@ -185,7 +185,7 @@
       {
         "address": "https://bitway.rpc.mandragora.io",
         "provider": "Mandragora"
-      
+      }
     ],
     "rest": [
       {


### PR DESCRIPTION
We have also changed the compatible version from `v2.0.0` to `v2.0.1` as there has been an upgrade recently. For further reference: https://mainnet.itrocket.net/bitway/gov/4