### PR TITLE
Osmosis v31

### DIFF
--- a/osmosis/chain.json
+++ b/osmosis/chain.json
@@ -527,9 +527,9 @@
       "name": "v3",
       "genesis_url": "https://github.com/osmosis-labs/networks/raw/main/osmosis-1/genesis.json"
     },
-    "recommended_version": "30.0.0",
+    "recommended_version": "31.0.0",
     "compatible_versions": [
-      "30.0.0"
+      "31.0.0"
     ],
     "consensus": {
       "type": "cometbft",
@@ -563,10 +563,10 @@
       "version": "1.23.4"
     },
     "binaries": {
-      "linux/amd64": "https://github.com/osmosis-labs/osmosis/releases/download/v30.0.0/osmosisd-30.0.0-linux-amd64?checksum=b469237ba50239988601ec5f0b88197a507b68ca1e1cf97a7e993bd731d7a5fc",
-      "linux/arm64": "https://github.com/osmosis-labs/osmosis/releases/download/v30.0.0/osmosisd-30.0.0-linux-arm64?checksum=ef79c48f86301fd9e7ac78ad6d5c5291c98d24f77f46460960a487cf60ee526f"
+      "linux/amd64": "https://github.com/osmosis-labs/osmosis/releases/download/v31.0.0/osmosisd-31.0.0-linux-amd64?checksum=d435408b845e79a2594594a315d9d22797fdbb7871a5936df68f51f0df557957",
+      "linux/arm64": "https://github.com/osmosis-labs/osmosis/releases/download/v31.0.0/osmosisd-31.0.0-linux-arm64?checksum=b5c44e74c4dc484f8492d10a24fcd3f75a43dccaa40ab083662741beeeaa20cc"
     },
-    "tag": "v30.0.0"
+    "tag": "v31.0.0"
   },
   "images": [
     {

--- a/osmosis/versions.json
+++ b/osmosis/versions.json
@@ -860,6 +860,53 @@
         "linux/arm64": "https://github.com/osmosis-labs/osmosis/releases/download/v30.0.0/osmosisd-30.0.0-linux-arm64?checksum=ef79c48f86301fd9e7ac78ad6d5c5291c98d24f77f46460960a487cf60ee526f"
       },
       "previous_version_name": "v29",
+      "next_version_name": "v31"
+    },
+    {
+      "name": "v31",
+      "tag": "v31.0.0",
+      "height": 47626000,
+      "proposal": 990,
+      "recommended_version": "31.0.0",
+      "compatible_versions": [
+        "31.0.0"
+      ],
+      "consensus": {
+        "type": "cometbft",
+        "version": "0.38.17",
+        "repo": "https://github.com/osmosis-labs/cometbft",
+        "tag": "v0.38.17-v28-osmo-1"
+      },
+      "cosmwasm": {
+        "version": "0.53.3",
+        "repo": "https://github.com/CosmWasm/wasmd",
+        "tag": "v0.53.3",
+        "enabled": true
+      },
+      "sdk": {
+        "type": "cosmos",
+        "version": "0.50.14",
+        "repo": "https://github.com/osmosis-labs/cosmos-sdk",
+        "tag": "v0.50.14-v30-osmo"
+      },
+      "ibc": {
+        "type": "go",
+        "version": "8.7.0",
+        "repo": "https://github.com/cosmos/ibc-go",
+        "tag": "v8.7.0",
+        "ics_enabled": [
+          "ics20-1"
+        ]
+      },
+      "language": {
+        "type": "go",
+        "version": "1.23.4"
+      },
+      "binaries": {
+        "linux/amd64": "https://github.com/osmosis-labs/osmosis/releases/download/v31.0.0/osmosisd-31.0.0-linux-amd64?checksum=d435408b845e79a2594594a315d9d22797fdbb7871a5936df68f51f0df557957",
+        "linux/arm64": "https://github.com/osmosis-labs/osmosis/releases/download/v31.0.0/osmosisd-31.0.0-linux-arm64?checksum=b5c44e74c4dc484f8492d10a24fcd3f75a43dccaa40ab083662741beeeaa20cc"
+      },
+      "previous_version_name": "v30",
       "next_version_name": ""
     }
   ]


### PR DESCRIPTION
Osmosis software upgrade v31 released:

Proposal: https://www.mintscan.io/osmosis/proposals/990

Release: https://github.com/osmosis-labs/osmosis/releases/tag/v31.0.0

Binaries: https://raw.githubusercontent.com/osmosis-labs/osmosis/main/networks/osmosis-1/upgrades/v31/mainnet/v31_binaries.json