### PR TITLE
set version to `agoric-upgrade-22`

### DIFF
--- a/agoric/chain.json
+++ b/agoric/chain.json
@@ -36,15 +36,15 @@
     "genesis": {
       "genesis_url": "https://main.agoric.net/genesis.json"
     },
-    "recommended_version": "agoric-upgrade-21",
+    "recommended_version": "agoric-upgrade-22",
     "compatible_versions": [
-      "agoric-upgrade-21"
+      "agoric-upgrade-22"
     ],
     "consensus": {
       "type": "cometbft",
-      "version": "v0.37.15",
+      "version": "v0.38.17",
       "repo": "https://github.com/agoric-labs/cometbft",
-      "tag": "v0.37.15-alpha.agoric.1"
+      "tag": "v0.38.17-alpha.agoric.1.1"
     },
     "cosmwasm": {
       "enabled": false
@@ -56,19 +56,19 @@
     "sdk": {
       "type": "cosmos",
       "repo": "https://github.com/agoric-labs/cosmos-sdk",
-      "version": "v0.47.17",
-      "tag": "v0.47.17-alpha.agoric.1"
+      "version": "v0.50.14",
+      "tag": "v0.50.14-alpha.agoric.3"
     },
     "ibc": {
       "type": "go",
-      "version": "v7.10.0",
+      "version": "v8.7.0",
       "repo": "https://github.com/agoric-labs/ibc-go",
-      "tag": "v7.10.0-alpha.agoric.2",
+      "tag": "v8.7.0-alpha.agoric.1",
       "ics_enabled": [
         "ics20-1"
       ]
     },
-    "tag": "agoric-upgrade-21"
+    "tag": "agoric-upgrade-22b"
   },
   "logo_URIs": {
     "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/agoric/images/Agoric-logo-color.png",

--- a/agoric/versions.json
+++ b/agoric/versions.json
@@ -290,6 +290,45 @@
         "type": "go",
         "version": "1.22.12"
       }
+    },
+    {
+      "name": "agoric-upgrade-22",
+      "tag": "agoric-upgrade-22b",
+      "proposal": 110,
+      "height": 21690000,
+      "recommended_version": "agoric-upgrade-22",
+      "compatible_versions": [
+        "agoric-upgrade-22"
+      ],
+      "consensus": {
+        "type": "cometbft",
+        "version": "v0.38.17",
+        "repo": "https://github.com/agoric-labs/cometbft",
+        "tag": "v0.38.17-alpha.agoric.1.1"
+      },
+      "cosmwasm": {
+        "enabled": false
+      },
+      "previous_version_name": "agoric-upgrade-21",
+      "sdk": {
+        "type": "cosmos",
+        "repo": "https://github.com/agoric-labs/cosmos-sdk",
+        "version": "v0.50.14",
+        "tag": "v0.50.14-alpha.agoric.3"
+      },
+      "ibc": {
+        "type": "go",
+        "version": "v8.7.0",
+        "repo": "https://github.com/agoric-labs/ibc-go",
+        "tag": "v8.7.0-alpha.agoric.1",
+        "ics_enabled": [
+          "ics20-1"
+        ]
+      },
+      "language": {
+        "type": "go",
+        "version": "1.22.12"
+      }
     }
   ]
 }


### PR DESCRIPTION
https://www.mintscan.io/agoric/proposals/110


Adopts agoric-upgrade-22 upgrade with appropriate tag and version information from a following non-consensus breaking patch.