### PR TITLE
Remove AviaOne provider entries from chain.json Andromeda

### DIFF
--- a/andromeda/chain.json
+++ b/andromeda/chain.json
@@ -77,11 +77,6 @@
         "id": "400f3d9e30b69e78a7fb891f60d76fa3c73f0ecc",
         "address": "andromeda.rpc.kjnodes.com:14759",
         "provider": "kjnodes.com 🦄"
-      },
-      {
-        "id": "258f523c96efde50d5fe0a9faeea8a3e83be22ca",
-        "address": "seed.andromeda-1.andromeda.aviaone.com:10280",
-        "provider": "AviaOne 🟢"
       }
     ],
     "persistent_peers": [
@@ -125,10 +120,6 @@
   "apis": {
     "rpc": [
       {
-        "address": "https://rpc.andromeda-1.andromeda.aviaone.com",
-        "provider": "AviaOne 🟢"
-      },
-      {
         "address": "https://andromeda.rpc.kjnodes.com",
         "provider": "kjnodes"
       },
@@ -170,10 +161,6 @@
       }
     ],
     "rest": [
-      {
-        "address": "https://api.andromeda-1.andromeda.aviaone.com",
-        "provider": "AviaOne 🟢"
-      },
       {
         "address": "https://andromeda.api.kjnodes.com",
         "provider": "kjnodes"
@@ -219,10 +206,6 @@
       {
         "address": "andromeda.lavenderfive.com:443",
         "provider": "Lavender.Five Nodes 🐝"
-      },
-      {
-        "address": "https://grpc.andromeda-1.andromeda.aviaone.com:9108",
-        "provider": "AviaOne 🟢"
       },
       {
         "address": "andromeda.grpc.kjnodes.com:443",
@@ -291,11 +274,6 @@
       "kind": "ping.pub",
       "url": "https://ping.pub/andromeda",
       "tx_page": "https://ping.pub/andromeda/tx/${txHash}"
-    },
-    {
-      "kind": "AviaOne Explorer 🟢",
-      "url": "https://mainnet.explorer.aviaone.com/andromeda",
-      "tx_page": "https://mainnet.explorer.aviaone.com/andromeda/tx/${txHash}"
     }
   ],
   "logo_URIs": {


### PR DESCRIPTION
Removed references to AviaOne providers and explorers from the chain configuration.

Sorry for my previous PR, parse error !!!