### PR TITLE
Add Pocket Network RPC/REST endpoints for 12 Cosmos chains

### DIFF
--- a/.github/workflows/tests/apis.py
+++ b/.github/workflows/tests/apis.py
@@ -52,6 +52,7 @@ whitelist = {
         # "Lava",
         # "Golden Ratio Staking",
         # "Stargaze Foundation",
+        # "Pocket Network",
     ]
 } if use_whitelist else {'chains': [], 'providers': []}
 

--- a/akash/chain.json
+++ b/akash/chain.json
@@ -268,6 +268,10 @@
       {
         "address": "https://akash.rpc.arcturian.tech/",
         "provider": "Arcturian Tech"
+      },
+      {
+        "address": "https://akash.api.pocket.network",
+        "provider": "Pocket Network"
       }
     ],
     "rest": [
@@ -310,6 +314,10 @@
       {
         "address": "https://akash.api.arcturian.tech",
         "provider": "Arcturian Tech"
+      },
+      {
+        "address": "https://akash.api.pocket.network",
+        "provider": "Pocket Network"
       }
     ],
     "grpc": [

--- a/atomone/chain.json
+++ b/atomone/chain.json
@@ -288,6 +288,10 @@
       {
         "address": "https://atomone-rpc.nyan-cat.net",
         "provider": "NyanCat"
+      },
+      {
+        "address": "https://atomone.api.pocket.network",
+        "provider": "Pocket Network"
       }
     ],
     "rest": [
@@ -406,6 +410,10 @@
       {
         "address": "https://atomone-api.nyan-cat.net",
         "provider": "NyanCat"
+      },
+      {
+        "address": "https://atomone.api.pocket.network",
+        "provider": "Pocket Network"
       }
     ],
     "grpc": [

--- a/cheqd/chain.json
+++ b/cheqd/chain.json
@@ -179,6 +179,10 @@
       {
         "address": "https://cheqd-rpc.publicnode.com:443",
         "provider": "Allnodes ⚡️ Nodes & Staking"
+      },
+      {
+        "address": "https://cheqd.api.pocket.network",
+        "provider": "Pocket Network"
       }
     ],
     "rest": [
@@ -229,6 +233,10 @@
       {
         "address": "https://cheqd-rest.publicnode.com",
         "provider": "Allnodes ⚡️ Nodes & Staking"
+      },
+      {
+        "address": "https://cheqd.api.pocket.network",
+        "provider": "Pocket Network"
       }
     ],
     "grpc": [

--- a/chihuahua/chain.json
+++ b/chihuahua/chain.json
@@ -177,6 +177,10 @@
       {
         "address": "https://chihuahua-rpc.chainroot.io",
         "provider": "Chainroot"
+      },
+      {
+        "address": "https://chihuahua.api.pocket.network",
+        "provider": "Pocket Network"
       }
     ],
     "rest": [
@@ -227,6 +231,10 @@
       {
         "address": "https://chihuahua-api.chainroot.io",
         "provider": "Chainroot"
+      },
+      {
+        "address": "https://chihuahua.api.pocket.network",
+        "provider": "Pocket Network"
       }
     ],
     "grpc": [

--- a/jackal/chain.json
+++ b/jackal/chain.json
@@ -199,6 +199,10 @@
       {
         "address": "https://jackal-rpc.noders.services",
         "provider": "[NODERS]TEAM"
+      },
+      {
+        "address": "https://jackal.api.pocket.network",
+        "provider": "Pocket Network"
       }
     ],
     "rest": [
@@ -269,6 +273,10 @@
       {
         "address": "https://jackal-api.noders.services",
         "provider": "[NODERS]TEAM"
+      },
+      {
+        "address": "https://jackal.api.pocket.network",
+        "provider": "Pocket Network"
       }
     ],
     "grpc": [

--- a/juno/chain.json
+++ b/juno/chain.json
@@ -225,6 +225,10 @@
       {
         "address": "https://juno-rpc.chainroot.io",
         "provider": "Chainroot"
+      },
+      {
+        "address": "https://juno.api.pocket.network",
+        "provider": "Pocket Network"
       }
     ],
     "rest": [
@@ -275,6 +279,10 @@
       {
         "address": "https://juno-api.chainroot.io",
         "provider": "Chainroot"
+      },
+      {
+        "address": "https://juno.api.pocket.network",
+        "provider": "Pocket Network"
       }
     ],
     "grpc": [

--- a/kava/chain.json
+++ b/kava/chain.json
@@ -128,6 +128,10 @@
       {
         "address": "https://rpc.kava.nodestake.org",
         "provider": "NodeStake"
+      },
+      {
+        "address": "https://kava.api.pocket.network",
+        "provider": "Pocket Network"
       }
     ],
     "rest": [
@@ -162,6 +166,10 @@
       {
         "address": "https://api.kava.nodestake.org",
         "provider": "NodeStake"
+      },
+      {
+        "address": "https://kava.api.pocket.network",
+        "provider": "Pocket Network"
       }
     ],
     "grpc": [

--- a/osmosis/chain.json
+++ b/osmosis/chain.json
@@ -769,6 +769,10 @@
       {
         "address": "https://rpc.osmosis.citizenweb3.com/",
         "provider": "Citizen Web3"
+      },
+      {
+        "address": "https://osmosis.api.pocket.network",
+        "provider": "Pocket Network"
       }
     ],
     "rest": [
@@ -831,6 +835,10 @@
       {
         "address": "https://api.osmosis.citizenweb3.com/",
         "provider": "Citizen Web3"
+      },
+      {
+        "address": "https://osmosis.api.pocket.network",
+        "provider": "Pocket Network"
       }
     ],
     "grpc": [

--- a/persistence/chain.json
+++ b/persistence/chain.json
@@ -240,6 +240,10 @@
       {
         "address": "https://persistence-rpc.stake-town.com",
         "provider": "StakeTown"
+      },
+      {
+        "address": "https://persistence.api.pocket.network",
+        "provider": "Pocket Network"
       }
     ],
     "rest": [
@@ -326,6 +330,10 @@
       {
         "address": "https://persistence-api.stake-town.com",
         "provider": "StakeTown"
+      },
+      {
+        "address": "https://persistence.api.pocket.network",
+        "provider": "Pocket Network"
       }
     ],
     "grpc": [

--- a/sei/chain.json
+++ b/sei/chain.json
@@ -151,6 +151,10 @@
       {
         "address": "https://sei.drpc.org",
         "provider": "dRPC - All chains in one place"
+      },
+      {
+        "address": "https://sei.api.pocket.network",
+        "provider": "Pocket Network"
       }
     ],
     "rest": [
@@ -181,6 +185,10 @@
       {
         "address": "https://sei-rest.publicnode.com",
         "provider": "Allnodes ⚡️ Nodes & Staking"
+      },
+      {
+        "address": "https://sei.api.pocket.network",
+        "provider": "Pocket Network"
       }
     ],
     "grpc": [

--- a/shentu/chain.json
+++ b/shentu/chain.json
@@ -177,6 +177,10 @@
       {
         "address": "https://rpc-shentu.onenov.xyz",
         "provider": "OneNov"
+      },
+      {
+        "address": "https://shentu.api.pocket.network",
+        "provider": "Pocket Network"
       }
     ],
     "rest": [
@@ -231,6 +235,10 @@
       {
         "address": "https://api-shentu.onenov.xyz",
         "provider": "OneNov"
+      },
+      {
+        "address": "https://shentu.api.pocket.network",
+        "provider": "Pocket Network"
       }
     ],
     "grpc": [

--- a/stargaze/chain.json
+++ b/stargaze/chain.json
@@ -210,6 +210,10 @@
       {
         "address": "https://stargaze-rpc.chainroot.io",
         "provider": "Chainroot"
+      },
+      {
+        "address": "https://stargaze.api.pocket.network",
+        "provider": "Pocket Network"
       }
     ],
     "rest": [
@@ -292,6 +296,10 @@
       {
         "address": "https://stargaze-api.chainroot.io",
         "provider": "Chainroot"
+      },
+      {
+        "address": "https://stargaze.api.pocket.network",
+        "provider": "Pocket Network"
       }
     ],
     "grpc": [


### PR DESCRIPTION
This PR adds Pocket Network's public RPC and REST endpoints for 12 Cosmos SDK chains to the chain registry.

### Chains Updated
- ✅ Osmosis (osmosis-1)
- ✅ Akash (akashnet-2)
- ✅ Juno (juno-1)
- ✅ Kava (kava_2222-10)
- ✅ Persistence (core-1)
- ✅ Stargaze (stargaze-1)
- ✅ Shentu (shentu-2.2)
- ✅ AtomOne (atomone-1)
- ✅ Cheqd (cheqd-mainnet-1)
- ✅ Chihuahua (chihuahua-1)
- ✅ Jackal (jackal-1)
- ✅ Sei (pacific-1)

### Endpoint Details
All endpoints follow the pattern: `https://[chain].api.pocket.network`

**Provider:** Pocket Network  
**Type:** Public RPC infrastructure provider

### Testing
All endpoints have been verified to return HTTP 200 on the required paths:
- ✅ REST: `/cosmos/base/tendermint/v1beta1/syncing`
- ✅ RPC: `/status`

### CI Whitelist
Pocket Network has been added to the CI whitelist in `.github/workflows/tests/apis.py` to enable daily endpoint testing at 00:00 UTC.

### About Pocket Network
Pocket Network is a decentralized RPC infrastructure protocol that provides reliable, low-latency access to blockchain data through a distributed network of node operators.

Website: https://pocket.network  
Docs: https://docs.pocket.network  
Public Portal: https://api.pocket.network