### PR TITLE
Change bech32 prefix from bitway to bc

### DIFF
--- a/bitway/chain.json
+++ b/bitway/chain.json
@@ -7,7 +7,7 @@
   "pretty_name": "Bitway",
   "chain_type": "cosmos",
   "chain_id": "bitway-1",
-  "bech32_prefix": "bitway",
+  "bech32_prefix": "bc",
   "daemon_name": "bitwayd",
   "node_home": "$HOME/.bitway",
   "key_algos": [


### PR DESCRIPTION
Our chain supports both Bitway and BC addresses. We aim to enable cross-chain operations for BC addresses via skip, as the latter is our chain's primary address format.