### PR TITLE
Update `ibc` agoricdevnet-neutrontestnet

### DIFF
--- a/testnets/_IBC/agoricdevnet-neutrontestnet.json
+++ b/testnets/_IBC/agoricdevnet-neutrontestnet.json
@@ -3,23 +3,23 @@
   "chain_1": {
     "chain_name": "agoricdevnet",
     "chain_id": "agoricdev-25",
-    "client_id": "07-tendermint-128",
-    "connection_id": "connection-82"
+    "client_id": "07-tendermint-9",
+    "connection_id": "connection-9"
   },
   "chain_2": {
     "chain_name": "neutrontestnet",
     "chain_id": "pion-1",
-    "client_id": "07-tendermint-553",
-    "connection_id": "connection-474"
+    "client_id": "07-tendermint-602",
+    "connection_id": "connection-558"
   },
   "channels": [
     {
       "chain_1": {
-        "channel_id": "channel-62",
+        "channel_id": "channel-7",
         "port_id": "transfer"
       },
       "chain_2": {
-        "channel_id": "channel-1578",
+        "channel_id": "channel-1748",
         "port_id": "transfer"
       },
       "ordering": "unordered",


### PR DESCRIPTION
Previous path was pointing to `agoricdev-23` which was a previous testnet, updated to reflect the correct path with `agoricdev-25`