### PR TITLE
added ibc configuration for qubeticstestnet and osmosistestnet

### DIFF
--- a/testnets/_IBC/osmosistestnet-qubeticstestnet.json
+++ b/testnets/_IBC/osmosistestnet-qubeticstestnet.json
@@ -1,0 +1,33 @@
+{
+  "$schema": "../../ibc_data.schema.json",
+  "chain_1": {
+    "chain_name": "osmosistestnet",
+    "chain_id": "osmo-test-5",
+    "client_id": "07-tendermint-4996",
+    "connection_id": "connection-4359"
+  },
+  "chain_2": {
+    "chain_name": "qubeticstestnet",
+    "chain_id": "qubetics_9029-1",
+    "client_id": "07-tendermint-14",
+    "connection_id": "connection-12"
+  },
+  "channels": [
+    {
+      "chain_1": {
+        "channel_id": "channel-11229",
+        "port_id": "transfer"
+      },
+      "chain_2": {
+        "channel_id": "channel-8",
+        "port_id": "transfer"
+      },
+      "ordering": "unordered",
+      "version": "ics20-1",
+      "tags": {
+        "preferred": true,
+        "status": "ACTIVE"
+      }
+    }
+  ]
+}


### PR DESCRIPTION
Configured IBC support between qubeticstestnet and osmosistestnet by adding chain entries, clients, connections, and channels in the relayer configuration, enabling packet relaying and interoperability between the two testnets.