### PR TITLE
feat(zigchaintestnet): update versions to 2.0.0

### DIFF
--- a/testnets/zigchaintestnet/chain.json
+++ b/testnets/zigchaintestnet/chain.json
@@ -70,21 +70,21 @@
   },
   "codebase": {
     "git_repo": "https://github.com/ZIGChain/zigchain",
-    "recommended_version": "1.2.2",
+    "recommended_version": "2.0.0",
     "compatible_versions": [
-      "1.2.2"
+      "2.0.0"
     ],
     "consensus": {
       "type": "cometbft",
-      "version": "0.38.17"
+      "version": "0.38.19"
     },
     "sdk": {
       "type": "cosmos",
-      "version": "0.50.14"
+      "version": "0.53.4"
     },
     "ibc": {
       "type": "go",
-      "version": "8.4.0"
+      "version": "10.1.0"
     },
     "cosmwasm": {
       "version": "0.55.1",
@@ -94,11 +94,11 @@
       "genesis_url": "https://github.com/ZIGChain/networks/raw/main/zig-test-2/genesis.json"
     },
     "binaries": {
-      "linux/amd64": "https://github.com/ZIGChain/networks/raw/refs/heads/main/zig-test-2/binaries/zigchaind-v1.2.2-linux-amd64.tar.gz",
-      "darwin/amd64": "https://github.com/ZIGChain/networks/raw/refs/heads/main/zig-test-2/binaries/zigchaind-v1.2.2-darwin-amd64.tar.gz",
-      "darwin/arm64": "https://github.com/ZIGChain/networks/raw/refs/heads/main/zig-test-2/binaries/zigchaind-v1.2.2-darwin-amd64.tar.gz"
+      "linux/amd64": "https://github.com/ZIGChain/networks/raw/refs/heads/main/zig-test-2/binaries/zigchaind-v2.0.0-linux-amd64.tar.gz?checksum=sha256:8f2a4a51fa2d73b7bc61c33d30332fb61e76ed0be4a381a37d27aa17115a9040",
+      "darwin/amd64": "https://github.com/ZIGChain/networks/raw/refs/heads/main/zig-test-2/binaries/zigchaind-v2.0.0-darwin-amd64.tar.gz?checksum=sha256:6269882ccb1caf0af7600f2d24f5aeae7710290aba299d0d4ed607c6e63da803",
+      "darwin/arm64": "https://github.com/ZIGChain/networks/raw/refs/heads/main/zig-test-2/binaries/zigchaind-v2.0.0-darwin-arm64.tar.gz?checksum=sha256:07f59514973d67e0d09c27b1be50da78f3b824518f1ee4735c09322ec1bd3789"
     },
-    "tag": "1.2.2"
+    "tag": "v2.0.0"
   },
   "peers": {
     "seeds": [

--- a/testnets/zigchaintestnet/versions.json
+++ b/testnets/zigchaintestnet/versions.json
@@ -164,7 +164,7 @@
         "darwin/amd64": "https://github.com/ZIGChain/networks/raw/refs/heads/main/zig-test-2/binaries/zigchaind-v2.0.0-darwin-amd64.tar.gz?checksum=sha256:6269882ccb1caf0af7600f2d24f5aeae7710290aba299d0d4ed607c6e63da803",
         "darwin/arm64": "https://github.com/ZIGChain/networks/raw/refs/heads/main/zig-test-2/binaries/zigchaind-v2.0.0-darwin-arm64.tar.gz?checksum=sha256:07f59514973d67e0d09c27b1be50da78f3b824518f1ee4735c09322ec1bd3789"
       },
-      "previous_version_name": "v1.2.2",
+      "previous_version_name": "1.2.2",
       "next_version_name": ""
     }
   ]


### PR DESCRIPTION
This pull request adds a new version entry for the ZIGChain testnet in the `versions.json` file.