### PR TITLE
Updated RPC and REST endpoints for Injective and Terra2

### DIFF
--- a/injective/chain.json
+++ b/injective/chain.json
@@ -172,8 +172,8 @@
   "apis": {
     "rpc": [
       {
-        "address": "https://6d0ff611-9009-4bd1-a7a7-acec7c70d454.injective-1.mesa-rpc.newmetric.xyz",
-        "provider": "NewMetric"
+        "address": "https://injective-rpc.highstakes.ch",
+        "provider": "High Stakes 🇨🇭"
       },
       {
         "address": "https://rpc.injective.goldenratiostaking.net",
@@ -188,18 +188,6 @@
         "provider": "Lavender.Five Nodes 🐝"
       },
       {
-        "address": "https://rpc-injective-ia.cosmosia.notional.ventures/",
-        "provider": "Notional"
-      },
-      {
-        "address": "https://injective-mainnet-rpc.autostake.com:443",
-        "provider": "AutoStake 🛡️ Slash Protected"
-      },
-      {
-        "address": "https://rpc-injective.whispernode.com:443",
-        "provider": "WhisperNode 🤐"
-      },
-      {
         "address": "https://rpc-injective-01.stakeflow.io",
         "provider": "Stakeflow"
       },
@@ -208,34 +196,14 @@
         "provider": "Allnodes ⚡️ Nodes & Staking"
       },
       {
-        "address": "https://injective-rpc.highstakes.ch",
-        "provider": "High Stakes 🇨🇭"
-      },
-      {
         "address": "https://public.stakewolle.com/cosmos/injective/rpc",
         "provider": "Stakewolle"
-      },
-      {
-        "address": "https://rpc.injective.bronbro.io/",
-        "provider": "Bro_n_Bro"
-      },
-      {
-        "address": "https://injective-rpc.noders.services",
-        "provider": "[NODERS]TEAM"
-      },
-      {
-        "address": "https://rpc-injective.kewrnode.com",
-        "provider": "Kewr Node"
       }
     ],
     "rest": [
       {
-        "address": "https://6d0ff611-9009-4bd1-a7a7-acec7c70d454.injective-1.mesa-rest.newmetric.xyz",
-        "provider": "NewMetric"
-      },
-      {
-        "address": "https://api-injective-ia.cosmosia.notional.ventures/",
-        "provider": "Notional"
+        "address": "https://injective-api.highstakes.ch",
+        "provider": "High Stakes 🇨🇭"
       },
       {
         "address": "https://injective-api.polkachu.com",
@@ -246,44 +214,12 @@
         "provider": "Lavender.Five Nodes 🐝"
       },
       {
-        "address": "https://lcd-injective.whispernode.com:443",
-        "provider": "WhisperNode 🤐"
-      },
-      {
-        "address": "https://api-injective-01.stakeflow.io",
-        "provider": "Stakeflow"
-      },
-      {
-        "address": "https://rest.injective.goldenratiostaking.net",
-        "provider": "Golden Ratio Staking"
-      },
-      {
         "address": "https://injective-rest.publicnode.com",
         "provider": "Allnodes ⚡️ Nodes & Staking"
       },
       {
-        "address": "injective-mainnet-lcd.autostake.com:443",
-        "provider": "AutoStake 🛡️ Slash Protected"
-      },
-      {
-        "address": "https://injective-api.highstakes.ch",
-        "provider": "High Stakes 🇨🇭"
-      },
-      {
         "address": "https://public.stakewolle.com/cosmos/injective/rest",
         "provider": "Stakewolle"
-      },
-      {
-        "address": "https://lcd.injective.bronbro.io/",
-        "provider": "Bro_n_Bro"
-      },
-      {
-        "address": "https://injective-api.noders.services",
-        "provider": "[NODERS]TEAM"
-      },
-      {
-        "address": "https://rest-injective.kewrnode.com",
-        "provider": "Kewr Node"
       }
     ],
     "grpc": [

--- a/terra2/chain.json
+++ b/terra2/chain.json
@@ -152,20 +152,12 @@
         "provider": "stakely"
       },
       {
-        "address": "https://phoenix-rpc.terra.dev:443",
-        "provider": "Terraform Labs"
-      },
-      {
         "address": "https://terra-rpc.publicnode.com:443",
         "provider": "Allnodes ⚡️ Nodes & Staking"
       },
       {
         "address": "https://rpc-terra-01.stakeflow.io",
         "provider": "Stakeflow"
-      },
-      {
-        "address": "https://rpc-archive-terra.r93axnodes.cloud:443",
-        "provider": "r93AX Nodes"
       },
       {
         "address": "https://rpc-terra.cosmos-spaces.cloud",
@@ -176,24 +168,12 @@
         "provider": "High Stakes 🇨🇭"
       },
       {
-        "address": "https://rpc-terra.wildsage.io",
-        "provider": "🧙 WildSage Labs"
-      },
-      {
-        "address": "https://terra.interstellar-lounge.org",
-        "provider": "Interstellar Lounge 🍸"
-      },
-      {
         "address": "https://terra2.tdrsys.com:2053",
         "provider": "TdrSys"
       },
       {
         "address": "https://terra-rpc.cosmosrescue.dev:8443",
         "provider": "cosmosrescue"
-      },
-      {
-        "address": "https://terra-rpc.chainroot.io",
-        "provider": "Chainroot"
       },
       {
         "address": "https://terra-rpc.node39.top",
@@ -206,24 +186,12 @@
     ],
     "rest": [
       {
-        "address": "https://lcd-terra.wildsage.io",
-        "provider": "🧙 WildSage Labs"
-      },
-      {
         "address": "https://phoenix-lcd.terra.dev:443",
         "provider": "Terraform Labs"
       },
       {
-        "address": "https://api-terra.cosmos-spaces.cloud",
-        "provider": "Cosmos Spaces"
-      },
-      {
         "address": "https://terra-rest.publicnode.com",
         "provider": "Allnodes ⚡️ Nodes & Staking"
-      },
-      {
-        "address": "https://api-archive-terra.r93axnodes.cloud:443",
-        "provider": "r93AX Nodes"
       },
       {
         "address": "https://api-terra-01.stakeflow.io",
@@ -232,10 +200,6 @@
       {
         "address": "https://terra-phoenix-api.highstakes.ch",
         "provider": "High Stakes 🇨🇭"
-      },
-      {
-        "address": "https://terra-rest.interstellar-lounge.org",
-        "provider": "Interstellar Lounge 🍸"
       },
       {
         "address": "https://terra2.tdrsys.com",


### PR DESCRIPTION
Some of the endpoints are completely dead. Others have been dead for a while based on https://cosmos.directory so I wanted to remove them to clean up the registry. 