### PR TITLE
chore(KYVE): update gas prices and binary versions

### DIFF
--- a/kyve/chain.json
+++ b/kyve/chain.json
@@ -18,10 +18,10 @@
     "fee_tokens": [
       {
         "denom": "ukyve",
-        "fixed_min_gas_price": 2,
-        "low_gas_price": 2,
-        "average_gas_price": 3,
-        "high_gas_price": 6
+        "fixed_min_gas_price": 62.5,
+        "low_gas_price": 62.5,
+        "average_gas_price": 80,
+        "high_gas_price": 125
       }
     ]
   },
@@ -34,9 +34,9 @@
   },
   "codebase": {
     "git_repo": "https://github.com/KYVENetwork/chain",
-    "recommended_version": "v2.1.0",
+    "recommended_version": "v2.2.0",
     "compatible_versions": [
-      "v2.1.0"
+      "v2.2.0"
     ],
     "consensus": {
       "type": "cometbft",
@@ -44,22 +44,22 @@
       "tag": "v0.38.17"
     },
     "binaries": {
-      "linux/amd64": "https://github.com/KYVENetwork/chain/releases/download/v2.1.0/kyved_mainnet_linux_amd64.tar.gz",
-      "linux/arm64": "https://github.com/KYVENetwork/chain/releases/download/v2.1.0/kyved_mainnet_linux_arm64.tar.gz",
-      "darwin/amd64": "https://github.com/KYVENetwork/chain/releases/download/v2.1.0/kyved_mainnet_darwin_amd64.tar.gz",
-      "darwin/arm64": "https://github.com/KYVENetwork/chain/releases/download/v2.1.0/kyved_mainnet_darwin_arm64.tar.gz"
+      "linux/amd64": "https://github.com/KYVENetwork/chain/releases/download/v2.2.0/kyved_mainnet_linux_amd64.tar.gz",
+      "linux/arm64": "https://github.com/KYVENetwork/chain/releases/download/v2.2.0/kyved_mainnet_linux_arm64.tar.gz",
+      "darwin/amd64": "https://github.com/KYVENetwork/chain/releases/download/v2.2.0/kyved_mainnet_darwin_amd64.tar.gz",
+      "darwin/arm64": "https://github.com/KYVENetwork/chain/releases/download/v2.2.0/kyved_mainnet_darwin_arm64.tar.gz"
     },
     "genesis": {
       "genesis_url": "https://raw.githubusercontent.com/KYVENetwork/networks/main/kyve-1/genesis.json"
     },
     "sdk": {
       "type": "cosmos",
-      "version": "v0.50.12",
-      "tag": "v0.50.12-kyve-rc1"
+      "version": "v0.50.14",
+      "tag": "v0.50.14-kyve-rc1"
     },
     "ibc": {
       "type": "go",
-      "version": "v8.3.1"
+      "version": "v8.7.0"
     }
   },
   "logo_URIs": {

--- a/testnets/kyvedevnet/chain.json
+++ b/testnets/kyvedevnet/chain.json
@@ -17,21 +17,24 @@
     "fee_tokens": [
       {
         "denom": "tkyve",
-        "fixed_min_gas_price": 0
+        "fixed_min_gas_price": 62.5,
+        "low_gas_price": 62.5,
+        "average_gas_price": 80,
+        "high_gas_price": 125
       }
     ]
   },
   "codebase": {
     "git_repo": "https://github.com/KYVENetwork/chain",
-    "recommended_version": "v1.5.0",
+    "recommended_version": "v2.2.0",
     "compatible_versions": [
-      "v1.5.0"
+      "v2.2.0"
     ],
     "binaries": {
-      "darwin/amd64": "https://files.kyve.network/korellia-2/v1.5.0-rc0/kyved_kaon_darwin_amd64?checksum=sha256:5f0c2e02eced4af81d15fbb46ba1f5bca45b662096b8bee3e90a20ef3cb1f54c",
-      "darwin/arm64": "https://files.kyve.network/korellia-2/v1.5.0-rc0/kyved_kaon_darwin_arm64?checksum=sha256:9c3667945a3f559d6a48f03fb61ea4045f410f1207bb9c1705a1043253877bf3",
-      "linux/amd64": "https://files.kyve.network/korellia-2/v1.5.0-rc0/kyved_kaon_linux_amd64?checksum=sha256:f165f4ca6c3831ac0d789fa5b5d6a98c0a9084b767bd048d12cca3691a861e23",
-      "linux/arm64": "https://files.kyve.network/korellia-2/v1.5.0-rc0/kyved_kaon_linux_arm64?checksum=sha256:fbd042016cd6973b301184af39df3020c69b0b35ce08d4286e974bb008ebbff0"
+      "linux/amd64": "https://github.com/KYVENetwork/chain/releases/download/v2.2.0/kyved_kaon_linux_amd64",
+      "linux/arm64": "https://github.com/KYVENetwork/chain/releases/download/v2.2.0/kyved_kaon_linux_arm64",
+      "darwin/amd64": "https://github.com/KYVENetwork/chain/releases/download/v2.2.0/kyved_kaon_darwin_amd64",
+      "darwin/arm64": "https://github.com/KYVENetwork/chain/releases/download/v2.2.0/kyved_kaon_darwin_arm64"
     },
     "genesis": {
       "genesis_url": "https://files.kyve.network/korellia-2/genesis.json"

--- a/testnets/kyvetestnet/chain.json
+++ b/testnets/kyvetestnet/chain.json
@@ -33,16 +33,15 @@
   },
   "codebase": {
     "git_repo": "https://github.com/KYVENetwork/chain",
-    "recommended_version": "v1.5.0",
+    "recommended_version": "v2.2.0",
     "compatible_versions": [
-      "v1.0.0-rc0",
-      "v1.5.0"
+      "v2.2.0"
     ],
     "binaries": {
-      "linux/amd64": "https://github.com/KYVENetwork/chain/releases/download/v1.5.0/kyved_kaon_linux_amd64",
-      "linux/arm64": "https://github.com/KYVENetwork/chain/releases/download/v1.5.0/kyved_kaon_linux_arm64",
-      "darwin/amd64": "https://github.com/KYVENetwork/chain/releases/download/v1.5.0/kyved_kaon_darwin_amd64",
-      "darwin/arm64": "https://github.com/KYVENetwork/chain/releases/download/v1.5.0/kyved_kaon_darwin_arm64"
+      "linux/amd64": "https://github.com/KYVENetwork/chain/releases/download/v2.2.0/kyved_kaon_linux_amd64",
+      "linux/arm64": "https://github.com/KYVENetwork/chain/releases/download/v2.2.0/kyved_kaon_linux_arm64",
+      "darwin/amd64": "https://github.com/KYVENetwork/chain/releases/download/v2.2.0/kyved_kaon_darwin_amd64",
+      "darwin/arm64": "https://github.com/KYVENetwork/chain/releases/download/v2.2.0/kyved_kaon_darwin_arm64"
     },
     "genesis": {
       "genesis_url": "https://raw.githubusercontent.com/KYVENetwork/networks/main/kaon-1/genesis.json"


### PR DESCRIPTION
In a recent governance proposal, KYVE gas prices have changed:

Korellia: https://explorer.kyve.network/korellia/gov/466
Mainnet: https://explorer.kyve.network/kyve/gov/59

Drive-by:
Update binary download links. Korellia (devnet) uses the same binaries as Kaon (testnet)