### PR TITLE
fix: update CLW denom casing to uCLW

### DIFF
--- a/stargaze/assetlist.json
+++ b/stargaze/assetlist.json
@@ -1038,7 +1038,7 @@
       "description": "The official token of the Clown Society, originating on Stargaze.",
       "denom_units": [
         {
-          "denom": "factory/stars1khzuhuhv02vaturh9x9lz4jach824x9umcgghl/uclw",
+          "denom": "factory/stars1khzuhuhv02vaturh9x9lz4jach824x9umcgghl/uCLW",
           "exponent": 0
         },
         {
@@ -1046,7 +1046,7 @@
           "exponent": 6
         }
       ],
-      "base": "factory/stars1khzuhuhv02vaturh9x9lz4jach824x9umcgghl/uclw",
+      "base": "factory/stars1khzuhuhv02vaturh9x9lz4jach824x9umcgghl/uCLW",
       "name": "Clown Society",
       "display": "CLW",
       "symbol": "CLW",


### PR DESCRIPTION
The on-chain denom is uppercase (uCLW). Updating metadata to match so it displays correctly on Osmosis and Stargaze.