### PR TITLE
Remove dead Arkeo WHENMOONWHENLAMBO RPC/REST endpoints

### DIFF
--- a/arkeo/chain.json
+++ b/arkeo/chain.json
@@ -112,10 +112,6 @@
         "provider": "Roomit"
       },
       {
-        "address": "https://arkeo_mainnet_rpc.chain.whenmoonwhenlambo.money",
-        "provider": "🚀 WHEN MOON 🌕 WHEN LAMBO 🔥"
-      },
-      {
         "address": "https://rpc.arkeo.nodestake.org",
         "provider": "NodeStake"
       }
@@ -132,10 +128,6 @@
       {
         "address": "https://api.arkeo.roomit.xyz",
         "provider": "Roomit"
-      },
-      {
-        "address": "https://arkeo_mainnet_api.chain.whenmoonwhenlambo.money",
-        "provider": "🚀 WHEN MOON 🌕 WHEN LAMBO 🔥"
       },
       {
         "address": "https://api.arkeo.nodestake.org",
@@ -171,12 +163,6 @@
       "url": "https://explorer.tendermint.roomit.xyz/arkeo-mainnet",
       "tx_page": "https://explorer.tendermint.roomit.xyz/arkeo-mainnet/transactions/${txHash}",
       "account_page": "https://explorer.tendermint.roomit.xyz/arkeo-mainnet/account/${accountAddress}"
-    },
-    {
-      "kind": "🚀 WHEN MOON 🌕 WHEN LAMBO 🔥",
-      "url": "https://explorer.whenmoonwhenlambo.money/arkeo",
-      "tx_page": "https://explorer.whenmoonwhenlambo.money/arkeo/tx/${txHash}",
-      "account_page": "https://explorer.whenmoonwhenlambo.money/arkeo/account/${accountAddress}"
     },
     {
       "kind": "NodeStake",


### PR DESCRIPTION
This PR removes Arkeo RPC and REST endpoints operated by the WHENMOONWHENLAMBO validator, which are no longer reachable.

These dead endpoints cause downstream failures in wallets and UIs that consume the Cosmos chain-registry (e.g. Osmosis Portfolio transfers failing due to 404/CORS errors).

The official Arkeo seed endpoints remain unchanged:
- https://rpc-seed.arkeo.network
- https://rest-seed.arkeo.network

This is a maintenance cleanup to ensure reliable endpoint auto-discovery.

No functional changes to Arkeo itself; this PR only removes unreachable infrastructure.