### PR TITLE
Add allEPIX to Osmosis

### DIFF
--- a/osmosis/assetlist.json
+++ b/osmosis/assetlist.json
@@ -27969,7 +27969,7 @@
       "extended_description": "Multiple EPIX variants on Osmosis comprise the liquidity backing of a tokenized transmuter pool to create an alloy of EPIX.",
       "denom_units": [
         {
-          "denom": "factory/osmo1zem8r6dv6u38f6qpg546zy30946av8h5srgug0s4gcyy6cfecf3seac083/alloyed/allDYDX",
+          "denom": "factory/osmo130tfawc7katf7jwzt2rjdranhqju929rjra3xwsrfsd85hedh3tsssy9j7/alloyed/allEPIX",
           "exponent": 0
         },
         {


### PR DESCRIPTION
Add an alloyed wrapper for EPIX to allow supercharged pool functionality for the asset.