### PR TITLE
fix(mirage): update IBC channel after client expiration

### DIFF
--- a/_IBC/mirage-osmosis.json
+++ b/_IBC/mirage-osmosis.json
@@ -3,23 +3,23 @@
   "chain_1": {
     "chain_name": "mirage",
     "chain_id": "mirage-1",
-    "client_id": "07-tendermint-1",
-    "connection_id": "connection-0"
+    "client_id": "07-tendermint-2",
+    "connection_id": "connection-1"
   },
   "chain_2": {
     "chain_name": "osmosis",
     "chain_id": "osmosis-1",
-    "client_id": "07-tendermint-3643",
-    "connection_id": "connection-10990"
+    "client_id": "07-tendermint-3654",
+    "connection_id": "connection-11001"
   },
   "channels": [
     {
       "chain_1": {
-        "channel_id": "channel-0",
+        "channel_id": "channel-1",
         "port_id": "transfer"
       },
       "chain_2": {
-        "channel_id": "channel-108600",
+        "channel_id": "channel-108698",
         "port_id": "transfer"
       },
       "ordering": "unordered",


### PR DESCRIPTION
Previous IBC clients expired due to relayer downtime. Created new channel:
- Mirage: channel-0 -> channel-1
- Osmosis: channel-108600 -> channel-108698

Updated all client/connection IDs to match the new active channel.

Please merge as soon as you can.