### PR TITLE
Remove Chainroot explorer entries from all chains 

### DIFF
--- a/aaronetwork/chain.json
+++ b/aaronetwork/chain.json
@@ -98,12 +98,6 @@
   },
   "explorers": [
     {
-      "kind": "Chainroot",
-      "url": "https://explorer.chainroot.io/aaronetwork",
-      "tx_page": "https://explorer.chainroot.io/aaronetwork/transactions/${txHash}",
-      "account_page": "https://explorer.chainroot.io/aaronetwork/accounts/${accountAddress}"
-    },
-    {
       "kind": "Ping.pub",
       "url": "https://ping.pub/Aaron%20Network",
       "tx_page": "https://ping.pub/Aaron%20Network/tx/${txHash}",

--- a/agoric/chain.json
+++ b/agoric/chain.json
@@ -269,12 +269,6 @@
   },
   "explorers": [
     {
-      "kind": "Chainroot",
-      "url": "https://explorer.chainroot.io/agoric",
-      "tx_page": "https://explorer.chainroot.io/agoric/transactions/${txHash}",
-      "account_page": "https://explorer.chainroot.io/agoric/accounts/${accountAddress}"
-    },
-    {
       "kind": "explorers.guru",
       "url": "https://agoric.explorers.guru",
       "tx_page": "https://agoric.explorers.guru/transaction/${txHash}",

--- a/akash/chain.json
+++ b/akash/chain.json
@@ -333,12 +333,6 @@
   },
   "explorers": [
     {
-      "kind": "Chainroot",
-      "url": "https://explorer.chainroot.io/akash",
-      "tx_page": "https://explorer.chainroot.io/akash/transactions/${txHash}",
-      "account_page": "https://explorer.chainroot.io/akash/accounts/${accountAddress}"
-    },
-    {
       "kind": "ezstaking",
       "url": "https://ezstaking.app/akash",
       "tx_page": "https://ezstaking.app/akash/txs/${txHash}",

--- a/althea/chain.json
+++ b/althea/chain.json
@@ -132,12 +132,6 @@
   },
   "explorers": [
     {
-      "kind": "Chainroot",
-      "url": "https://explorer.chainroot.io/althea",
-      "tx_page": "https://explorer.chainroot.io/althea/transactions/${txHash}",
-      "account_page": "https://explorer.chainroot.io/althea/accounts/${accountAddress}"
-    },
-    {
       "kind": "staking-explorer.com",
       "url": "https://staking-explorer.com/explorer/althea",
       "tx_page": "https://staking-explorer.com/transaction.php?chain=althea&tx=${txHash}",

--- a/andromeda/chain.json
+++ b/andromeda/chain.json
@@ -247,12 +247,6 @@
   },
   "explorers": [
     {
-      "kind": "Chainroot",
-      "url": "https://explorer.chainroot.io/andromeda",
-      "tx_page": "https://explorer.chainroot.io/andromeda/transactions/${txHash}",
-      "account_page": "https://explorer.chainroot.io/andromeda/accounts/${accountAddress}"
-    },
-    {
       "kind": "🔥STAVR🔥 Explorer",
       "url": "https://explorer.stavr.tech/Andromeda-Mainnet",
       "tx_page": "https://explorer.stavr.tech/Andromeda-Mainnet/tx/${txHash}",

--- a/archway/chain.json
+++ b/archway/chain.json
@@ -500,12 +500,6 @@
       "url": "https://mainnet.whispernode.com/archway",
       "tx_page": "https://mainnet.whispernode.com/archway/tx/${txHash}",
       "account_page": "https://mainnet.whispernode.com/archway/account/${accountAddress}"
-    },
-    {
-      "kind": "Chainroot",
-      "url": "https://explorer.chainroot.io/archway",
-      "tx_page": "https://explorer.chainroot.io/archway/transactions/${txHash}",
-      "account_page": "https://explorer.chainroot.io/archway/accounts/${accountAddress}"
     }
   ],
   "images": [

--- a/assetmantle/chain.json
+++ b/assetmantle/chain.json
@@ -186,12 +186,6 @@
   },
   "explorers": [
     {
-      "kind": "Chainroot",
-      "url": "https://explorer.chainroot.io/assetmantle",
-      "tx_page": "https://explorer.chainroot.io/assetmantle/transactions/${txHash}",
-      "account_page": "https://explorer.chainroot.io/assetmantle/accounts/${accountAddress}"
-    },
-    {
       "kind": "ezstaking",
       "url": "https://ezstaking.app/assetmantle",
       "tx_page": "https://ezstaking.app/assetmantle/txs/${txHash}",

--- a/atomone/chain.json
+++ b/atomone/chain.json
@@ -601,12 +601,6 @@
       "account_page": "https://explorer.bonynode.online/atomone/account/${accountAddress}"
     },
     {
-      "kind": "Chainroot",
-      "url": "https://explorer.chainroot.io/atomone",
-      "tx_page": "https://explorer.chainroot.io/atomone/transactions/${txHash}",
-      "account_page": "https://explorer.chainroot.io/atomone/accounts/${accountAddress}"
-    },
-    {
       "kind": "Ruangnode Explorer",
       "url": "https://explorer.ruangnode.com/dashboard/atomone",
       "tx_page": "https://explorer.ruangnode.com/dashboard/atomone/tx/${txHash}",

--- a/aura/chain.json
+++ b/aura/chain.json
@@ -332,12 +332,6 @@
   },
   "explorers": [
     {
-      "kind": "Chainroot",
-      "url": "https://explorer.chainroot.io/aura",
-      "tx_page": "https://explorer.chainroot.io/aura/transactions/${txHash}",
-      "account_page": "https://explorer.chainroot.io/aura/accounts/${accountAddress}"
-    },
-    {
       "kind": "aurascan",
       "url": "https://aurascan.io",
       "tx_page": "https://aurascan.io/tx/${txHash}",

--- a/axelar/chain.json
+++ b/axelar/chain.json
@@ -360,12 +360,6 @@
   },
   "explorers": [
     {
-      "kind": "Chainroot",
-      "url": "https://explorer.chainroot.io/axelar",
-      "tx_page": "https://explorer.chainroot.io/axelar/transactions/${txHash}",
-      "account_page": "https://explorer.chainroot.io/axelar/accounts/${accountAddress}"
-    },
-    {
       "kind": "axelarscan",
       "url": "https://axelarscan.io",
       "tx_page": "https://axelarscan.io/tx/${txHash}"

--- a/babylon/chain.json
+++ b/babylon/chain.json
@@ -258,12 +258,6 @@
   },
   "explorers": [
     {
-      "kind": "Chainroot",
-      "url": "https://explorer.chainroot.io/babylon",
-      "tx_page": "https://explorer.chainroot.io/babylon/transactions/${txHash}",
-      "account_page": "https://explorer.chainroot.io/babylon/accounts/${accountAddress}"
-    },
-    {
       "kind": "mintscan",
       "url": "https://www.mintscan.io/babylon",
       "tx_page": "https://www.mintscan.io/babylon/transactions/${txHash}",

--- a/bandchain/chain.json
+++ b/bandchain/chain.json
@@ -306,12 +306,6 @@
   },
   "explorers": [
     {
-      "kind": "Chainroot",
-      "url": "https://explorer.chainroot.io/band",
-      "tx_page": "https://explorer.chainroot.io/band/transactions/${txHash}",
-      "account_page": "https://explorer.chainroot.io/band/accounts/${accountAddress}"
-    },
-    {
       "kind": "cosmoscan",
       "url": "https://cosmoscan.io",
       "tx_page": "https://cosmoscan.io/tx/${txHash}"

--- a/beezee/chain.json
+++ b/beezee/chain.json
@@ -146,12 +146,6 @@
   },
   "explorers": [
     {
-      "kind": "Chainroot",
-      "url": "https://explorer.chainroot.io/beezee",
-      "tx_page": "https://explorer.chainroot.io/beezee/transactions/${txHash}",
-      "account_page": "https://explorer.chainroot.io/beezee/accounts/${accountAddress}"
-    },
-    {
       "kind": "ping.pub",
       "url": "https://ping.pub/beezee",
       "tx_page": "https://ping.pub/beezee/tx/${txHash}",

--- a/bitcanna/chain.json
+++ b/bitcanna/chain.json
@@ -478,12 +478,6 @@
   },
   "explorers": [
     {
-      "kind": "Chainroot",
-      "url": "https://explorer.chainroot.io/bitcanna",
-      "tx_page": "https://explorer.chainroot.io/bitcanna/transactions/${txHash}",
-      "account_page": "https://explorer.chainroot.io/bitcanna/accounts/${accountAddress}"
-    },
-    {
       "kind": "EZStaking Tools",
       "url": "https://app.ezstaking.io/bitcanna",
       "tx_page": "https://ezstaking.tools/bitcanna/txs/${txHash}",

--- a/bitsong/chain.json
+++ b/bitsong/chain.json
@@ -214,12 +214,6 @@
   },
   "explorers": [
     {
-      "kind": "Chainroot",
-      "url": "https://explorer.chainroot.io/bitsong",
-      "tx_page": "https://explorer.chainroot.io/bitsong/transactions/${txHash}",
-      "account_page": "https://explorer.chainroot.io/bitsong/accounts/${accountAddress}"
-    },
-    {
       "kind": "ezstaking",
       "url": "https://ezstaking.app/bitsong",
       "tx_page": "https://ezstaking.app/bitsong/txs/${txHash}",

--- a/bostrom/chain.json
+++ b/bostrom/chain.json
@@ -105,12 +105,6 @@
   },
   "explorers": [
     {
-      "kind": "Chainroot",
-      "url": "https://explorer.chainroot.io/bostrom",
-      "tx_page": "https://explorer.chainroot.io/bostrom/transactions/${txHash}",
-      "account_page": "https://explorer.chainroot.io/bostrom/accounts/${accountAddress}"
-    },
-    {
       "kind": "cyb",
       "url": "https://cyb.ai/",
       "tx_page": "https://cyb.ai/network/bostrom/tx/${txHash}"

--- a/carbon/chain.json
+++ b/carbon/chain.json
@@ -410,12 +410,6 @@
   },
   "explorers": [
     {
-      "kind": "Chainroot",
-      "url": "https://explorer.chainroot.io/carbon",
-      "tx_page": "https://explorer.chainroot.io/carbon/transactions/${txHash}",
-      "account_page": "https://explorer.chainroot.io/carbon/accounts/${accountAddress}"
-    },
-    {
       "kind": "carbonscan",
       "url": "https://scan.carbon.network",
       "tx_page": "https://scan.carbon.network/transaction/${txHash}?net=main"

--- a/celestia/chain.json
+++ b/celestia/chain.json
@@ -529,12 +529,6 @@
   },
   "explorers": [
     {
-      "kind": "Chainroot",
-      "url": "https://explorer.chainroot.io/celestia",
-      "tx_page": "https://explorer.chainroot.io/celestia/transactions/${txHash}",
-      "account_page": "https://explorer.chainroot.io/celestia/accounts/${accountAddress}"
-    },
-    {
       "kind": "Nodes.Guru",
       "url": "https://celestia.explorers.guru/",
       "tx_page": "https://celestia.explorers.guru/transaction/${txHash}",

--- a/chain4energy/chain.json
+++ b/chain4energy/chain.json
@@ -605,12 +605,6 @@
   },
   "explorers": [
     {
-      "kind": "Chainroot",
-      "url": "https://explorer.chainroot.io/chain4energy",
-      "tx_page": "https://explorer.chainroot.io/chain4energy/transactions/${txHash}",
-      "account_page": "https://explorer.chainroot.io/chain4energy/accounts/${accountAddress}"
-    },
-    {
       "kind": "explorer",
       "url": "https://explorer.apeironnodes.com/chain4energy",
       "tx_page": "https://explorer.apeironnodes.com/chain4energy/transactions/${txHash}"

--- a/cheqd/chain.json
+++ b/cheqd/chain.json
@@ -280,12 +280,6 @@
   },
   "explorers": [
     {
-      "kind": "Chainroot",
-      "url": "https://explorer.chainroot.io/cheqd",
-      "tx_page": "https://explorer.chainroot.io/cheqd/transactions/${txHash}",
-      "account_page": "https://explorer.chainroot.io/cheqd/accounts/${accountAddress}"
-    },
-    {
       "kind": "bigdipper",
       "url": "https://explorer.cheqd.io",
       "tx_page": "https://explorer.cheqd.io/transactions/${txHash}",

--- a/chihuahua/chain.json
+++ b/chihuahua/chain.json
@@ -282,12 +282,6 @@
   },
   "explorers": [
     {
-      "kind": "Chainroot",
-      "url": "https://explorer.chainroot.io/chihuahua",
-      "tx_page": "https://explorer.chainroot.io/chihuahua/transactions/${txHash}",
-      "account_page": "https://explorer.chainroot.io/chihuahua/accounts/${accountAddress}"
-    },
-    {
       "kind": "ping.pub",
       "url": "https://ping.pub/chihuahua",
       "tx_page": "https://ping.pub/chihuahua/tx/${txHash}"
@@ -326,12 +320,6 @@
       "url": "https://explorer.nodeshub.online/chihuahua/",
       "tx_page": "https://explorer.nodeshub.online/chihuahua/tx/${txHash}",
       "account_page": "https://explorer.nodeshub.online/chihuahua/accounts/${accountAddress}"
-    },
-    {
-      "kind": "Chainroot",
-      "url": "https://explorer.chainroot.io/chihuahua",
-      "tx_page": "https://explorer.chainroot.io/chihuahua/transactions/${txHash}",
-      "account_page": "https://explorer.chainroot.io/chihuahua/accounts/${accountAddress}"
     }
   ],
   "images": [

--- a/comdex/chain.json
+++ b/comdex/chain.json
@@ -368,12 +368,6 @@
       "url": "https://mainnet.whispernode.com/comdex",
       "tx_page": "https://mainnet.whispernode.com/comdex/tx/${txHash}",
       "account_page": "https://mainnet.whispernode.com/comdex/account/${accountAddress}"
-    },
-    {
-      "kind": "Chainroot",
-      "url": "https://explorer.chainroot.io/comdex",
-      "tx_page": "https://explorer.chainroot.io/comdex/transactions/${txHash}",
-      "account_page": "https://explorer.chainroot.io/comdex/accounts/${accountAddress}"
     }
   ],
   "images": [

--- a/coreum/chain.json
+++ b/coreum/chain.json
@@ -237,12 +237,6 @@
   },
   "explorers": [
     {
-      "kind": "Chainroot",
-      "url": "https://explorer.chainroot.io/coreum",
-      "tx_page": "https://explorer.chainroot.io/coreum/transactions/${txHash}",
-      "account_page": "https://explorer.chainroot.io/coreum/accounts/${accountAddress}"
-    },
-    {
       "kind": "Coreum",
       "url": "https://explorer.coreum.com/coreum",
       "tx_page": "https://explorer.coreum.com/coreum/transactions/${txHash}",
@@ -289,12 +283,6 @@
       "url": "https://ezstaking.app/coreum",
       "tx_page": "https://ezstaking.app/coreum/txs/${txHash}",
       "account_page": "https://ezstaking.app/coreum/account/${accountAddress}"
-    },
-    {
-      "kind": "Chainroot",
-      "url": "https://explorer.chainroot.io/coreum",
-      "tx_page": "https://explorer.chainroot.io/coreum/transactions/${txHash}",
-      "account_page": "https://explorer.chainroot.io/coreum/accounts/${accountAddress}"
     }
   ],
   "keywords": [

--- a/cosmoshub/chain.json
+++ b/cosmoshub/chain.json
@@ -611,12 +611,6 @@
   },
   "explorers": [
     {
-      "kind": "Chainroot",
-      "url": "https://explorer.chainroot.io/cosmos",
-      "tx_page": "https://explorer.chainroot.io/cosmos/transactions/${txHash}",
-      "account_page": "https://explorer.chainroot.io/cosmos/accounts/${accountAddress}"
-    },
-    {
       "kind": "mintscan",
       "url": "https://www.mintscan.io/cosmos",
       "tx_page": "https://www.mintscan.io/cosmos/transactions/${txHash}",

--- a/decentr/chain.json
+++ b/decentr/chain.json
@@ -213,12 +213,6 @@
   },
   "explorers": [
     {
-      "kind": "Chainroot",
-      "url": "https://explorer.chainroot.io/decentr",
-      "tx_page": "https://explorer.chainroot.io/decentr/transactions/${txHash}",
-      "account_page": "https://explorer.chainroot.io/decentr/accounts/${accountAddress}"
-    },
-    {
       "kind": "decentr.net",
       "url": "https://explorer.decentr.net",
       "tx_page": "https://explorer.decentr.net/transactions/${txHash}?networkId=mainnet"

--- a/dhealth/chain.json
+++ b/dhealth/chain.json
@@ -127,12 +127,6 @@
   },
   "explorers": [
     {
-      "kind": "Chainroot",
-      "url": "https://explorer.chainroot.io/dhealth",
-      "tx_page": "https://explorer.chainroot.io/dhealth/transactions/${txHash}",
-      "account_page": "https://explorer.chainroot.io/dhealth/accounts/${accountAddress}"
-    },
-    {
       "kind": "staking-explorer.com",
       "url": "https://staking-explorer.com/explorer/dhealth",
       "tx_page": "https://staking-explorer.com/transaction.php?chain=dhealth&tx=${txHash}",

--- a/doravota/chain.json
+++ b/doravota/chain.json
@@ -160,12 +160,6 @@
   },
   "explorers": [
     {
-      "kind": "Chainroot",
-      "url": "https://explorer.chainroot.io/doravota",
-      "tx_page": "https://explorer.chainroot.io/doravota/transactions/${txHash}",
-      "account_page": "https://explorer.chainroot.io/doravota/accounts/${accountAddress}"
-    },
-    {
       "kind": "Dora Vota Ping Pub",
       "url": "https://vota-explorer.dorafactory.org",
       "tx_page": "https://vota-explorer.dorafactory.org/doravota/tx/${txHash}"

--- a/dydx/chain.json
+++ b/dydx/chain.json
@@ -308,12 +308,6 @@
   },
   "explorers": [
     {
-      "kind": "Chainroot",
-      "url": "https://explorer.chainroot.io/dydx",
-      "tx_page": "https://explorer.chainroot.io/dydx/transactions/${txHash}",
-      "account_page": "https://explorer.chainroot.io/dydx/accounts/${accountAddress}"
-    },
-    {
       "kind": "mintscan",
       "url": "https://www.mintscan.io/dydx",
       "tx_page": "https://www.mintscan.io/dydx/txs/${txHash}",

--- a/dymension/chain.json
+++ b/dymension/chain.json
@@ -530,12 +530,6 @@
   },
   "explorers": [
     {
-      "kind": "Chainroot",
-      "url": "https://explorer.chainroot.io/dymension",
-      "tx_page": "https://explorer.chainroot.io/dymension/transactions/${txHash}",
-      "account_page": "https://explorer.chainroot.io/dymension/accounts/${accountAddress}"
-    },
-    {
       "kind": "mintscan",
       "url": "https://www.mintscan.io/dymension",
       "tx_page": "https://www.mintscan.io/dymension/tx/${txHash}",

--- a/elys/chain.json
+++ b/elys/chain.json
@@ -436,12 +436,6 @@
   },
   "explorers": [
     {
-      "kind": "Chainroot",
-      "url": "https://explorer.chainroot.io/elys",
-      "tx_page": "https://explorer.chainroot.io/elys/transactions/${txHash}",
-      "account_page": "https://explorer.chainroot.io/elys/accounts/${accountAddress}"
-    },
-    {
       "kind": "NodeStake",
       "url": "https://explorer.nodestake.org/elys",
       "tx_page": "https://explorer.nodestake.org/elys/tx/${txHash}",

--- a/fetchhub/chain.json
+++ b/fetchhub/chain.json
@@ -299,12 +299,6 @@
   },
   "explorers": [
     {
-      "kind": "Chainroot",
-      "url": "https://explorer.chainroot.io/fetchai",
-      "tx_page": "https://explorer.chainroot.io/fetchai/transactions/${txHash}",
-      "account_page": "https://explorer.chainroot.io/fetchai/accounts/${accountAddress}"
-    },
-    {
       "kind": "mintscan",
       "url": "https://www.mintscan.io/fetchai",
       "tx_page": "https://www.mintscan.io/fetchai/transactions/${txHash}",

--- a/firmachain/chain.json
+++ b/firmachain/chain.json
@@ -179,12 +179,6 @@
   },
   "explorers": [
     {
-      "kind": "Chainroot",
-      "url": "https://explorer.chainroot.io/firmachain",
-      "tx_page": "https://explorer.chainroot.io/firmachain/transactions/${txHash}",
-      "account_page": "https://explorer.chainroot.io/firmachain/accounts/${accountAddress}"
-    },
-    {
       "kind": "staking-explorer.com",
       "url": "https://staking-explorer.com/explorer/firmachain",
       "tx_page": "https://staking-explorer.com/transaction.php?chain=firmachain&tx=${txHash}",

--- a/gitopia/chain.json
+++ b/gitopia/chain.json
@@ -572,12 +572,6 @@
   },
   "explorers": [
     {
-      "kind": "Chainroot",
-      "url": "https://explorer.chainroot.io/gitopia",
-      "tx_page": "https://explorer.chainroot.io/gitopia/transactions/${txHash}",
-      "account_page": "https://explorer.chainroot.io/gitopia/accounts/${accountAddress}"
-    },
-    {
       "kind": "ping.pub",
       "url": "https://ping.pub/gitopia",
       "tx_page": "https://ping.pub/gitopia/tx/${txHash}",

--- a/gravitybridge/chain.json
+++ b/gravitybridge/chain.json
@@ -286,12 +286,6 @@
   },
   "explorers": [
     {
-      "kind": "Chainroot",
-      "url": "https://explorer.chainroot.io/gravitybridge",
-      "tx_page": "https://explorer.chainroot.io/gravitybridge/transactions/${txHash}",
-      "account_page": "https://explorer.chainroot.io/gravitybridge/accounts/${accountAddress}"
-    },
-    {
       "kind": "ezstaking",
       "url": "https://ezstaking.app/gravitybridge",
       "tx_page": "https://ezstaking.app/gravitybridge/txs/${txHash}",

--- a/impacthub/chain.json
+++ b/impacthub/chain.json
@@ -186,12 +186,6 @@
   },
   "explorers": [
     {
-      "kind": "Chainroot",
-      "url": "https://explorer.chainroot.io/ixo",
-      "tx_page": "https://explorer.chainroot.io/ixo/transactions/${txHash}",
-      "account_page": "https://explorer.chainroot.io/ixo/accounts/${accountAddress}"
-    },
-    {
       "kind": "staking-explorer.com",
       "url": "https://staking-explorer.com/explorer/impacthub",
       "tx_page": "https://staking-explorer.com/transaction.php?chain=impacthub&tx=${txHash}",

--- a/injective/chain.json
+++ b/injective/chain.json
@@ -305,12 +305,6 @@
   },
   "explorers": [
     {
-      "kind": "Chainroot",
-      "url": "https://explorer.chainroot.io/injective",
-      "tx_page": "https://explorer.chainroot.io/injective/transactions/${txHash}",
-      "account_page": "https://explorer.chainroot.io/injective/accounts/${accountAddress}"
-    },
-    {
       "kind": "ezstaking",
       "url": "https://ezstaking.app/injective",
       "tx_page": "https://ezstaking.app/injective/txs/${txHash}",

--- a/irisnet/chain.json
+++ b/irisnet/chain.json
@@ -193,12 +193,6 @@
   },
   "explorers": [
     {
-      "kind": "Chainroot",
-      "url": "https://explorer.chainroot.io/iris",
-      "tx_page": "https://explorer.chainroot.io/iris/transactions/${txHash}",
-      "account_page": "https://explorer.chainroot.io/iris/accounts/${accountAddress}"
-    },
-    {
       "kind": "ezstaking",
       "url": "https://ezstaking.app/irisnet",
       "tx_page": "https://ezstaking.app/irisnet/txs/${txHash}",

--- a/jackal/chain.json
+++ b/jackal/chain.json
@@ -336,12 +336,6 @@
   },
   "explorers": [
     {
-      "kind": "Chainroot",
-      "url": "https://explorer.chainroot.io/jackal",
-      "tx_page": "https://explorer.chainroot.io/jackal/transactions/${txHash}",
-      "account_page": "https://explorer.chainroot.io/jackal/accounts/${accountAddress}"
-    },
-    {
       "kind": "ping.pub",
       "url": "https://ping.pub/jackal",
       "tx_page": "https://ping.pub/jackal/tx/${txHash}"

--- a/juno/chain.json
+++ b/juno/chain.json
@@ -374,12 +374,6 @@
       "url": "https://www.stake-hub.xyz/juno"
     },
     {
-      "kind": "Chainroot",
-      "url": "https://explorer.chainroot.io/juno",
-      "tx_page": "https://explorer.chainroot.io/juno/transactions/${txHash}",
-      "account_page": "https://explorer.chainroot.io/juno/accounts/${accountAddress}"
-    },
-    {
       "kind": "Valopers",
       "url": "https://juno.valopers.com/",
       "tx_page": "https://juno.valopers.com/transactions/${txHash}",

--- a/kava/chain.json
+++ b/kava/chain.json
@@ -223,12 +223,6 @@
   },
   "explorers": [
     {
-      "kind": "Chainroot",
-      "url": "https://explorer.chainroot.io/kava",
-      "tx_page": "https://explorer.chainroot.io/kava/transactions/${txHash}",
-      "account_page": "https://explorer.chainroot.io/kava/accounts/${accountAddress}"
-    },
-    {
       "kind": "mintscan",
       "url": "https://www.mintscan.io/kava",
       "tx_page": "https://www.mintscan.io/kava/transactions/${txHash}",

--- a/kichain/chain.json
+++ b/kichain/chain.json
@@ -200,12 +200,6 @@
   },
   "explorers": [
     {
-      "kind": "Chainroot",
-      "url": "https://explorer.chainroot.io/kichain",
-      "tx_page": "https://explorer.chainroot.io/kichain/transactions/${txHash}",
-      "account_page": "https://explorer.chainroot.io/kichain/accounts/${accountAddress}"
-    },
-    {
       "kind": "ezstaking",
       "url": "https://ezstaking.app/kichain",
       "tx_page": "https://ezstaking.app/kichain/txs/${txHash}",

--- a/kujira/chain.json
+++ b/kujira/chain.json
@@ -397,12 +397,6 @@
   },
   "explorers": [
     {
-      "kind": "Chainroot",
-      "url": "https://explorer.chainroot.io/kujira",
-      "tx_page": "https://explorer.chainroot.io/kujira/transactions/${txHash}",
-      "account_page": "https://explorer.chainroot.io/kujira/accounts/${accountAddress}"
-    },
-    {
       "kind": "kujira",
       "url": "https://finder.kujira.app",
       "tx_page": "https://finder.kujira.app/kaiyo-1/tx/${txHash}"

--- a/kyve/chain.json
+++ b/kyve/chain.json
@@ -278,12 +278,6 @@
   },
   "explorers": [
     {
-      "kind": "Chainroot",
-      "url": "https://explorer.chainroot.io/kyve",
-      "tx_page": "https://explorer.chainroot.io/kyve/transactions/${txHash}",
-      "account_page": "https://explorer.chainroot.io/kyve/accounts/${accountAddress}"
-    },
-    {
       "kind": "ezstaking",
       "url": "https://ezstaking.app/kyve",
       "tx_page": "https://ezstaking.app/kyve/txs/${txHash}",

--- a/lava/chain.json
+++ b/lava/chain.json
@@ -386,12 +386,6 @@
       "account_page": "https://explorer.onenov.xyz/lava/accounts/${accountAddress}"
     },
     {
-      "kind": "Chainroot",
-      "url": "https://explorer.chainroot.io/lava",
-      "tx_page": "https://explorer.chainroot.io/lava/transactions/${txHash}",
-      "account_page": "https://explorer.chainroot.io/lava/accounts/${accountAddress}"
-    },
-    {
       "kind": "finteh",
       "url": "https://explorer.finteh.org/lava",
       "tx_page": "https://explorer.finteh.org/lava/tx/${txHash}",

--- a/likecoin/chain.json
+++ b/likecoin/chain.json
@@ -184,12 +184,6 @@
   },
   "explorers": [
     {
-      "kind": "Chainroot",
-      "url": "https://explorer.chainroot.io/likecoin",
-      "tx_page": "https://explorer.chainroot.io/likecoin/transactions/${txHash}",
-      "account_page": "https://explorer.chainroot.io/likecoin/accounts/${accountAddress}"
-    },
-    {
       "kind": "staking-explorer.com",
       "url": "https://staking-explorer.com/explorer/likecoin",
       "tx_page": "https://staking-explorer.com/transaction.php?chain=likecoin&tx=${txHash}",

--- a/lumnetwork/chain.json
+++ b/lumnetwork/chain.json
@@ -188,12 +188,6 @@
   },
   "explorers": [
     {
-      "kind": "Chainroot",
-      "url": "https://explorer.chainroot.io/lum",
-      "tx_page": "https://explorer.chainroot.io/lum/transactions/${txHash}",
-      "account_page": "https://explorer.chainroot.io/lum/accounts/${accountAddress}"
-    },
-    {
       "kind": "ezstaking",
       "url": "https://ezstaking.app/lumnetwork",
       "tx_page": "https://ezstaking.app/lumnetwork/txs/${txHash}",

--- a/mantrachain/chain.json
+++ b/mantrachain/chain.json
@@ -174,12 +174,6 @@
   },
   "explorers": [
     {
-      "kind": "Chainroot",
-      "url": "https://explorer.chainroot.io/mantra",
-      "tx_page": "https://explorer.chainroot.io/mantra/transactions/${txHash}",
-      "account_page": "https://explorer.chainroot.io/mantra/accounts/${accountAddress}"
-    },
-    {
       "kind": "mintscan",
       "url": "https://www.mintscan.io/mantra",
       "tx_page": "https://mintscan.io/mantra/txs/${txHash}",

--- a/migaloo/chain.json
+++ b/migaloo/chain.json
@@ -157,12 +157,6 @@
   },
   "explorers": [
     {
-      "kind": "Chainroot",
-      "url": "https://explorer.chainroot.io/migaloo",
-      "tx_page": "https://explorer.chainroot.io/migaloo/transactions/${txHash}",
-      "account_page": "https://explorer.chainroot.io/migaloo/accounts/${accountAddress}"
-    },
-    {
       "kind": "Migaloo Explorers Guru",
       "url": "https://migaloo.explorers.guru",
       "tx_page": "https://migaloo.explorers.guru/transaction/${txHash}",

--- a/nibiru/chain.json
+++ b/nibiru/chain.json
@@ -336,12 +336,6 @@
   },
   "explorers": [
     {
-      "kind": "Chainroot",
-      "url": "https://explorer.chainroot.io/nibiru",
-      "tx_page": "https://explorer.chainroot.io/nibiru/transactions/${txHash}",
-      "account_page": "https://explorer.chainroot.io/nibiru/accounts/${accountAddress}"
-    },
-    {
       "kind": "Nodes Guru",
       "url": "https://nibiru.explorers.guru/",
       "tx_page": "https://nibiru.explorers.guru/transaction/${txHash}",

--- a/nillion/chain.json
+++ b/nillion/chain.json
@@ -147,12 +147,6 @@
   },
   "explorers": [
     {
-      "kind": "Chainroot",
-      "url": "https://explorer.chainroot.io/nillion",
-      "tx_page": "https://explorer.chainroot.io/nillion/transactions/${txHash}",
-      "account_page": "https://explorer.chainroot.io/nillion/accounts/${accountAddress}"
-    },
-    {
       "kind": "Nillionhub [Noders]",
       "url": "https://nillionhub.org/explorer/dashboard",
       "tx_page": "https://nillionhub.org/explorer/transactions/${txHash}",

--- a/noble/chain.json
+++ b/noble/chain.json
@@ -129,12 +129,6 @@
   },
   "explorers": [
     {
-      "kind": "Chainroot",
-      "url": "https://explorer.chainroot.io/noble",
-      "tx_page": "https://explorer.chainroot.io/noble/transactions/${txHash}",
-      "account_page": "https://explorer.chainroot.io/noble/accounts/${accountAddress}"
-    },
-    {
       "kind": "mintscan",
       "url": "https://www.mintscan.io/noble",
       "tx_page": "https://www.mintscan.io/noble/txs/${txHash}",

--- a/nolus/chain.json
+++ b/nolus/chain.json
@@ -265,12 +265,6 @@
   },
   "explorers": [
     {
-      "kind": "Chainroot",
-      "url": "https://explorer.chainroot.io/nolus",
-      "tx_page": "https://explorer.chainroot.io/nolus/transactions/${txHash}",
-      "account_page": "https://explorer.chainroot.io/nolus/accounts/${accountAddress}"
-    },
-    {
       "kind": "Nolus Explorer",
       "url": "https://explorer.nolus.io/pirin-1",
       "tx_page": "https://explorer.nolus.io/pirin-1/tx/${txHash}",

--- a/nyx/chain.json
+++ b/nyx/chain.json
@@ -182,12 +182,6 @@
   },
   "explorers": [
     {
-      "kind": "Chainroot",
-      "url": "https://explorer.chainroot.io/nym",
-      "tx_page": "https://explorer.chainroot.io/nym/transactions/${txHash}",
-      "account_page": "https://explorer.chainroot.io/nym/accounts/${accountAddress}"
-    },
-    {
       "kind": "Nodes Guru explorer",
       "url": "https://nym.explorers.guru/",
       "tx_page": "https://nym.explorers.guru/transaction/${txHash}",

--- a/odin/chain.json
+++ b/odin/chain.json
@@ -170,12 +170,6 @@
   },
   "explorers": [
     {
-      "kind": "Chainroot",
-      "url": "https://explorer.chainroot.io/odin",
-      "tx_page": "https://explorer.chainroot.io/odin/transactions/${txHash}",
-      "account_page": "https://explorer.chainroot.io/odin/accounts/${accountAddress}"
-    },
-    {
       "kind": "Runa",
       "url": "https://runa.odinprotocol.io/",
       "tx_page": "https://runa.odinprotocol.io/transactions/${txHash}"

--- a/omniflixhub/chain.json
+++ b/omniflixhub/chain.json
@@ -300,12 +300,6 @@
   },
   "explorers": [
     {
-      "kind": "Chainroot",
-      "url": "https://explorer.chainroot.io/omniflix",
-      "tx_page": "https://explorer.chainroot.io/omniflix/transactions/${txHash}",
-      "account_page": "https://explorer.chainroot.io/omniflix/accounts/${accountAddress}"
-    },
-    {
       "kind": "mintscan",
       "url": "https://www.mintscan.io/omniflix",
       "tx_page": "https://www.mintscan.io/omniflix/transactions/${txHash}",

--- a/oraichain/chain.json
+++ b/oraichain/chain.json
@@ -288,12 +288,6 @@
   },
   "explorers": [
     {
-      "kind": "Chainroot",
-      "url": "https://explorer.chainroot.io/oraichain",
-      "tx_page": "https://explorer.chainroot.io/oraichain/transactions/${txHash}",
-      "account_page": "https://explorer.chainroot.io/oraichain/accounts/${accountAddress}"
-    },
-    {
       "kind": "oraiscan",
       "url": "https://scan.orai.io",
       "tx_page": "https://scan.orai.io/txs/${txHash}"

--- a/osmosis/chain.json
+++ b/osmosis/chain.json
@@ -941,12 +941,6 @@
       "account_page": "https://mainnet.whispernode.com/osmosis/account/${accountAddress}"
     },
     {
-      "kind": "Chainroot",
-      "url": "https://explorer.chainroot.io/osmosis",
-      "tx_page": "https://explorer.chainroot.io/osmosis/transactions/${txHash}",
-      "account_page": "https://explorer.chainroot.io/osmosis/accounts/${accountAddress}"
-    },
-    {
       "kind": "Valopers",
       "url": "https://osmosis.valopers.com/",
       "tx_page": "https://osmosis.valopers.com/transactions/${txHash}",

--- a/paloma/chain.json
+++ b/paloma/chain.json
@@ -71,12 +71,6 @@
   },
   "explorers": [
     {
-      "kind": "Chainroot",
-      "url": "https://explorer.chainroot.io/paloma",
-      "tx_page": "https://explorer.chainroot.io/paloma/transactions/${txHash}",
-      "account_page": "https://explorer.chainroot.io/paloma/accounts/${accountAddress}"
-    },
-    {
       "kind": "explorers.guru",
       "url": "https://paloma.explorers.guru/",
       "tx_page": "https://paloma.explorers.guru/transaction/${txHash}"

--- a/panacea/chain.json
+++ b/panacea/chain.json
@@ -121,12 +121,6 @@
   },
   "explorers": [
     {
-      "kind": "Chainroot",
-      "url": "https://explorer.chainroot.io/medibloc",
-      "tx_page": "https://explorer.chainroot.io/medibloc/transactions/${txHash}",
-      "account_page": "https://explorer.chainroot.io/medibloc/accounts/${accountAddress}"
-    },
-    {
       "kind": "mintscan",
       "url": "https://www.mintscan.io/medibloc",
       "tx_page": "https://www.mintscan.io/medibloc/transactions/${txHash}",

--- a/passage/chain.json
+++ b/passage/chain.json
@@ -308,12 +308,6 @@
   },
   "explorers": [
     {
-      "kind": "Chainroot",
-      "url": "https://explorer.chainroot.io/passage",
-      "tx_page": "https://explorer.chainroot.io/passage/transactions/${txHash}",
-      "account_page": "https://explorer.chainroot.io/passage/accounts/${accountAddress}"
-    },
-    {
       "kind": "aneka",
       "url": "https://passage.aneka.io",
       "tx_page": "https://passage.aneka.io/txs/${txHash}",

--- a/persistence/chain.json
+++ b/persistence/chain.json
@@ -405,12 +405,6 @@
   },
   "explorers": [
     {
-      "kind": "Chainroot",
-      "url": "https://explorer.chainroot.io/persistence",
-      "tx_page": "https://explorer.chainroot.io/persistence/transactions/${txHash}",
-      "account_page": "https://explorer.chainroot.io/persistence/accounts/${accountAddress}"
-    },
-    {
       "kind": "mintscan",
       "url": "https://www.mintscan.io/persistence",
       "tx_page": "https://www.mintscan.io/persistence/transactions/${txHash}",

--- a/planq/chain.json
+++ b/planq/chain.json
@@ -317,12 +317,6 @@
   },
   "explorers": [
     {
-      "kind": "Chainroot",
-      "url": "https://explorer.chainroot.io/planq",
-      "tx_page": "https://explorer.chainroot.io/planq/transactions/${txHash}",
-      "account_page": "https://explorer.chainroot.io/planq/accounts/${accountAddress}"
-    },
-    {
       "kind": "bigdipper",
       "url": "https://explorer.planq.network",
       "tx_page": "https://explorer.planq.network/transactions/${txHash}"

--- a/provenance/chain.json
+++ b/provenance/chain.json
@@ -240,12 +240,6 @@
   },
   "explorers": [
     {
-      "kind": "Chainroot",
-      "url": "https://explorer.chainroot.io/provenance",
-      "tx_page": "https://explorer.chainroot.io/provenance/transactions/${txHash}",
-      "account_page": "https://explorer.chainroot.io/provenance/accounts/${accountAddress}"
-    },
-    {
       "kind": "Provenance",
       "url": "https://explorer.provenance.io",
       "tx_page": "https://explorer.provenance.io/tx/${txHash}"

--- a/pryzm/chain.json
+++ b/pryzm/chain.json
@@ -264,12 +264,6 @@
       "url": "https://staking-explorer.com/explorer/pryzm",
       "tx_page": "https://staking-explorer.com/transaction.php?chain=pryzm&tx=${txHash}",
       "account_page": "https://staking-explorer.com/account.php?chain=pryzm&addr=${accountAddress}"
-    },
-    {
-      "kind": "Chainroot",
-      "url": "https://explorer.chainroot.io/pryzm",
-      "tx_page": "https://explorer.chainroot.io/pryzm/transactions/${txHash}",
-      "account_page": "https://explorer.chainroot.io/pryzm/accounts/${accountAddress}"
     }
   ],
   "images": [

--- a/quasar/chain.json
+++ b/quasar/chain.json
@@ -292,12 +292,6 @@
       "url": "https://mainnet.whispernode.com/quasar",
       "tx_page": "https://mainnet.whispernode.com/quasar/tx/${txHash}",
       "account_page": "https://mainnet.whispernode.com/quasar/account/${accountAddress}"
-    },
-    {
-      "kind": "Chainroot",
-      "url": "https://explorer.chainroot.io/quasar",
-      "tx_page": "https://explorer.chainroot.io/quasar/transactions/${txHash}",
-      "account_page": "https://explorer.chainroot.io/quasar/accounts/${accountAddress}"
     }
   ],
   "keywords": [

--- a/quicksilver/chain.json
+++ b/quicksilver/chain.json
@@ -327,12 +327,6 @@
   },
   "explorers": [
     {
-      "kind": "Chainroot",
-      "url": "https://explorer.chainroot.io/quicksilver",
-      "tx_page": "https://explorer.chainroot.io/quicksilver/transactions/${txHash}",
-      "account_page": "https://explorer.chainroot.io/quicksilver/accounts/${accountAddress}"
-    },
-    {
       "kind": "stakeme",
       "url": "https://explorer.quicksilver.zone",
       "tx_page": "https://explorer.quicksilver.zone/transactions/${txHash}",

--- a/realio/chain.json
+++ b/realio/chain.json
@@ -280,12 +280,6 @@
   },
   "explorers": [
     {
-      "kind": "Chainroot",
-      "url": "https://explorer.chainroot.io/realio",
-      "tx_page": "https://explorer.chainroot.io/realio/transactions/${txHash}",
-      "account_page": "https://explorer.chainroot.io/realio/accounts/${accountAddress}"
-    },
-    {
       "kind": "🔥STAVR🔥 Explorer",
       "url": "https://explorer.stavr.tech/realio-mainnet",
       "tx_page": "https://explorer.stavr.tech/realio-mainnet/tx/${txHash}",

--- a/regen/chain.json
+++ b/regen/chain.json
@@ -212,12 +212,6 @@
   },
   "explorers": [
     {
-      "kind": "Chainroot",
-      "url": "https://explorer.chainroot.io/regen",
-      "tx_page": "https://explorer.chainroot.io/regen/transactions/${txHash}",
-      "account_page": "https://explorer.chainroot.io/regen/accounts/${accountAddress}"
-    },
-    {
       "kind": "ezstaking",
       "url": "https://ezstaking.app/regen",
       "tx_page": "https://ezstaking.app/regen/txs/${txHash}",

--- a/saga/chain.json
+++ b/saga/chain.json
@@ -250,12 +250,6 @@
       "url": "https://explorer.nodestake.org/saga",
       "tx_page": "https://explorer.nodestake.org/saga/tx/${txHash}",
       "account_page": "https://explorer.nodestake.org/saga/account/${accountAddress}"
-    },
-    {
-      "kind": "Chainroot",
-      "url": "https://explorer.chainroot.io/saga",
-      "tx_page": "https://explorer.chainroot.io/saga/transactions/${txHash}",
-      "account_page": "https://explorer.chainroot.io/saga/accounts/${accountAddress}"
     }
   ],
   "images": [

--- a/secretnetwork/chain.json
+++ b/secretnetwork/chain.json
@@ -179,12 +179,6 @@
   },
   "explorers": [
     {
-      "kind": "Chainroot",
-      "url": "https://explorer.chainroot.io/secret",
-      "tx_page": "https://explorer.chainroot.io/secret/transactions/${txHash}",
-      "account_page": "https://explorer.chainroot.io/secret/accounts/${accountAddress}"
-    },
-    {
       "kind": "ezstaking",
       "url": "https://ezstaking.app/secretnetwork",
       "tx_page": "https://ezstaking.app/secretnetwork/txs/${txHash}",

--- a/seda/chain.json
+++ b/seda/chain.json
@@ -291,12 +291,6 @@
       "tx_page": "https://explorer.tcnetwork.io/seda/transaction/${txHash}"
     },
     {
-      "kind": "Chainroot",
-      "url": "https://explorer.chainroot.io/seda",
-      "tx_page": "https://explorer.chainroot.io/seda/transactions/${txHash}",
-      "account_page": "https://explorer.chainroot.io/seda/accounts/${accountAddress}"
-    },
-    {
       "kind": "sedaexplorer",
       "url": "https://explorer.seda.xyz/",
       "tx_page": "https://explorer.seda.xyz/txs/${txHash}",

--- a/sei/chain.json
+++ b/sei/chain.json
@@ -238,12 +238,6 @@
   },
   "explorers": [
     {
-      "kind": "Chainroot",
-      "url": "https://explorer.chainroot.io/sei",
-      "tx_page": "https://explorer.chainroot.io/sei/transactions/${txHash}",
-      "account_page": "https://explorer.chainroot.io/sei/accounts/${accountAddress}"
-    },
-    {
       "kind": "blockscout",
       "url": "https://seitrace.com",
       "tx_page": "https://seitrace.com/tx/${txHash}?chain=pacific-1",

--- a/sge/chain.json
+++ b/sge/chain.json
@@ -299,12 +299,6 @@
   },
   "explorers": [
     {
-      "kind": "Chainroot",
-      "url": "https://explorer.chainroot.io/sge",
-      "tx_page": "https://explorer.chainroot.io/sge/transactions/${txHash}",
-      "account_page": "https://explorer.chainroot.io/sge/accounts/${accountAddress}"
-    },
-    {
       "kind": "ping.pub",
       "url": "https://blockexplorer.sgenetwork.io/sge",
       "tx_page": "https://blockexplorer.sgenetwork.io/sge/tx/${txHash}"

--- a/shentu/chain.json
+++ b/shentu/chain.json
@@ -341,12 +341,6 @@
       "account_page": "https://stakeflow.io/shentu/accounts/${accountAddress}"
     },
     {
-      "kind": "Chainroot",
-      "url": "https://explorer.chainroot.io/shentu",
-      "tx_page": "https://explorer.chainroot.io/shentu/transactions/${txHash}",
-      "account_page": "https://explorer.chainroot.io/shentu/accounts/${accountAddress}"
-    },
-    {
       "kind": "Node39",
       "url": "https://explorer.node39.top/shentu",
       "tx_page": "https://explorer.node39.top/shentu/transactions/${txHash}",

--- a/sifchain/chain.json
+++ b/sifchain/chain.json
@@ -149,12 +149,6 @@
   },
   "explorers": [
     {
-      "kind": "Chainroot",
-      "url": "https://explorer.chainroot.io/sifchain",
-      "tx_page": "https://explorer.chainroot.io/sifchain/transactions/${txHash}",
-      "account_page": "https://explorer.chainroot.io/sifchain/accounts/${accountAddress}"
-    },
-    {
       "kind": "ping.pub",
       "url": "https://ping.pub/sifchain",
       "tx_page": "https://ping.pub/sifchain/tx/${txHash}"

--- a/sommelier/chain.json
+++ b/sommelier/chain.json
@@ -206,12 +206,6 @@
   },
   "explorers": [
     {
-      "kind": "Chainroot",
-      "url": "https://explorer.chainroot.io/sommelier",
-      "tx_page": "https://explorer.chainroot.io/sommelier/transactions/${txHash}",
-      "account_page": "https://explorer.chainroot.io/sommelier/accounts/${accountAddress}"
-    },
-    {
       "kind": "sommscan",
       "url": "https://sommscan.io",
       "tx_page": "https://sommscan.io"

--- a/source/chain.json
+++ b/source/chain.json
@@ -382,12 +382,6 @@
   },
   "explorers": [
     {
-      "kind": "Chainroot",
-      "url": "https://explorer.chainroot.io/source",
-      "tx_page": "https://explorer.chainroot.io/source/transactions/${txHash}",
-      "account_page": "https://explorer.chainroot.io/source/accounts/${accountAddress}"
-    },
-    {
       "kind": "🔥STAVR🔥",
       "url": "https://explorer.stavr.tech/Source-Mainnet/",
       "tx_page": "https://explorer.stavr.tech/Source-Mainnet/tx/${txHash}",

--- a/stargaze/chain.json
+++ b/stargaze/chain.json
@@ -392,12 +392,6 @@
       "account_page": "https://mainnet.whispernode.com/stargaze/account/${accountAddress}"
     },
     {
-      "kind": "Chainroot",
-      "url": "https://explorer.chainroot.io/stargaze",
-      "tx_page": "https://explorer.chainroot.io/stargaze/transactions/${txHash}",
-      "account_page": "https://explorer.chainroot.io/stargaze/accounts/${accountAddress}"
-    },
-    {
       "kind": "Valopers",
       "url": "https://stargaze.valopers.com/",
       "tx_page": "https://stargaze.valopers.com/transactions/${txHash}",

--- a/stratos/chain.json
+++ b/stratos/chain.json
@@ -134,12 +134,6 @@
   },
   "explorers": [
     {
-      "kind": "Chainroot",
-      "url": "https://explorer.chainroot.io/stratos",
-      "tx_page": "https://explorer.chainroot.io/stratos/transactions/${txHash}",
-      "account_page": "https://explorer.chainroot.io/stratos/accounts/${accountAddress}"
-    },
-    {
       "kind": "bigdipper",
       "url": "https://explorer.thestratos.org",
       "tx_page": "https://explorer.thestratos.org/transactions/${txHash}",

--- a/teritori/chain.json
+++ b/teritori/chain.json
@@ -324,12 +324,6 @@
       "url": "https://explorer.whenmoonwhenlambo.money/teritori",
       "tx_page": "https://explorer.whenmoonwhenlambo.money/teritori/tx/${txHash}",
       "account_page": "https://explorer.whenmoonwhenlambo.money/teritori/account/${accountAddress}"
-    },
-    {
-      "kind": "Chainroot",
-      "url": "https://explorer.chainroot.io/teritori",
-      "tx_page": "https://explorer.chainroot.io/teritori/transactions/${txHash}",
-      "account_page": "https://explorer.chainroot.io/teritori/accounts/${accountAddress}"
     }
   ],
   "images": [

--- a/terra2/chain.json
+++ b/terra2/chain.json
@@ -302,12 +302,6 @@
       "account_page": "https://stakeflow.io/terra/accounts/${accountAddress}"
     },
     {
-      "kind": "Chainroot",
-      "url": "https://explorer.chainroot.io/terra",
-      "tx_page": "https://explorer.chainroot.io/terra/transactions/${txHash}",
-      "account_page": "https://explorer.chainroot.io/terra/accounts/${accountAddress}"
-    },
-    {
       "kind": "Node39",
       "url": "https://explorer.node39.top/terra",
       "tx_page": "https://explorer.node39.top/terra/transactions/${txHash}",

--- a/umee/chain.json
+++ b/umee/chain.json
@@ -371,12 +371,6 @@
   },
   "explorers": [
     {
-      "kind": "Chainroot",
-      "url": "https://explorer.chainroot.io/ux",
-      "tx_page": "https://explorer.chainroot.io/ux/transactions/${txHash}",
-      "account_page": "https://explorer.chainroot.io/ux/accounts/${accountAddress}"
-    },
-    {
       "kind": "🔥STAVR🔥 Explorer",
       "url": "https://explorer.stavr.tech/umee",
       "tx_page": "https://explorer.stavr.tech/umee/tx/${txHash}"

--- a/xion/chain.json
+++ b/xion/chain.json
@@ -228,12 +228,6 @@
   },
   "explorers": [
     {
-      "kind": "Chainroot",
-      "url": "https://explorer.chainroot.io/xion",
-      "tx_page": "https://explorer.chainroot.io/xion/transactions/${txHash}",
-      "account_page": "https://explorer.chainroot.io/xion/accounts/${accountAddress}"
-    },
-    {
       "kind": "mintscan",
       "url": "https://www.mintscan.io/xion",
       "tx_page": "https://www.mintscan.io/xion/transactions/${txHash}",

--- a/xpla/chain.json
+++ b/xpla/chain.json
@@ -206,12 +206,6 @@
   },
   "explorers": [
     {
-      "kind": "Chainroot",
-      "url": "https://explorer.chainroot.io/xpla",
-      "tx_page": "https://explorer.chainroot.io/xpla/transactions/${txHash}",
-      "account_page": "https://explorer.chainroot.io/xpla/accounts/${accountAddress}"
-    },
-    {
       "kind": "explorer.xpla",
       "url": "https://explorer.xpla.io/mainnet",
       "tx_page": "https://explorer.xpla.io/mainnet/tx/${txHash}"

--- a/zetachain/chain.json
+++ b/zetachain/chain.json
@@ -179,12 +179,6 @@
   },
   "explorers": [
     {
-      "kind": "Chainroot",
-      "url": "https://explorer.chainroot.io/zetachain",
-      "tx_page": "https://explorer.chainroot.io/zetachain/transactions/${txHash}",
-      "account_page": "https://explorer.chainroot.io/zetachain/accounts/${accountAddress}"
-    },
-    {
       "kind": "ZetaScan",
       "url": "https://explorer.zetachain.com/",
       "tx_page": "https://explorer.zetachain.com/cc/tx/${txHash}"


### PR DESCRIPTION
## Problem

The `explorer.chainroot.io` domain has expired and is no longer accessible. This causes issues because:

1. **Chainroot explorer entries are often listed first** in the `explorers` array for many chains
2. **Many products (e.g., SkipGO) use the first explorer** from the list as the default explorer
3. **This results in broken explorer links** being used by various tools and services that rely on chain registry data

## Solution

Remove all Chainroot explorer entries (`"kind": "Chainroot"`) from all `chain.json` files across the registry.

## Changes

- Removed Chainroot explorer entries from **85 chains** that contained them
- All entries were completely removed
- No other explorer entries were affected

## Impact

- ✅ Prevents broken explorer links from being used
- ✅ Ensures products using the first explorer get a working link
- ✅ No negative impact - the domain is already non-functional

