### PR TITLE
Remove OneNov API entries from chain.json

### DIFF
--- a/lava/chain.json
+++ b/lava/chain.json
@@ -161,10 +161,6 @@
   "apis": {
     "rpc": [
       {
-        "address": "https://rpc-lava.onenov.xyz",
-        "provider": "OneNov"
-      },
-      {
         "address": "https://lava.tendermintrpc.lava.build",
         "provider": "Lava Over Lava"
       },
@@ -246,10 +242,6 @@
       }
     ],
     "rest": [
-      {
-        "address": "https://api-lava.onenov.xyz",
-        "provider": "OneNov"
-      },
       {
         "address": "https://lava-api.finteh.org:443",
         "provider": "finteh"
@@ -391,12 +383,6 @@
     ]
   },
   "explorers": [
-    {
-      "kind": "OneNov",
-      "url": "https://explorer.onenov.xyz/lava",
-      "tx_page": "https://explorer.onenov.xyz/lava/transactions/${txHash}",
-      "account_page": "https://explorer.onenov.xyz/lava/accounts/${accountAddress}"
-    },
     {
       "kind": "finteh",
       "url": "https://explorer.finteh.org/lava",


### PR DESCRIPTION
Removed OneNov RPC and REST API entries from chain.json lava chain