### PR TITLE
Update chain configuration for noble network

### DIFF
--- a/noble-1/chain.json
+++ b/noble-1/chain.json
@@ -1,0 +1,38 @@
+{
+  "$schema": "../chain.schema.json",
+  "chain_name": "noble",
+  "status": "live",
+  "network_type": "mainnet",
+  "pretty_name": "noble",
+  "chain_id": "noble-1",
+  "bech32_prefix": "noble",
+  "daemon_name": "noble",
+  "node_home": "$HOME/.noble",
+  "key_algos": [
+    "secp256k1"
+  ],
+  "slip44": 118,
+  "codebase": {
+    "git_repo": "https://github.com/strangelove-ventures/noble",
+    "recommended_version": "v11.2.0",
+    "compatible_versions": [
+      "v11.2.0"
+    ],
+    "cosmos_sdk_version": "0.50.14",
+    "ibc_go_version": "1.0.1",
+    "genesis": {
+      "genesis_url": "https://raw.githubusercontent.com/strangelove-ventures/noble-networks/main/mainnet/noble-1/genesis.json"
+    }
+  },
+  "fees": {
+    "fee_tokens": [
+      {
+        "denom": "uusdc",
+        "fixed_min_gas_price": 0.1,
+        "low_gas_price": 0.1,
+        "average_gas_price": 0.1,
+        "high_gas_price": 0.2
+      }
+    ]
+  }
+}


### PR DESCRIPTION
Updated the Noble chain configuration with the following technical details from Mintscan:
​Binary Version: Updated to v11.2.0.
​SDK/IBC Versions: Added Cosmos SDK v0.50.14 and IBC-go v1.0.1.
​Fee Tokens: Corrected fee denomination to uusdc.
​Cleanup: Removed duplicated genesis blocks and placeholder values.