### PR TITLE
fix(moo): add missing IBC INIT fee token to assetlist

### DIFF
--- a/moo/assetlist.json
+++ b/moo/assetlist.json
@@ -3,6 +3,46 @@
   "chain_name": "moo",
   "assets": [
     {
+      "description": "The native token of Initia",
+      "denom_units": [
+        {
+          "denom": "ibc/37A3FB4FED4CA04ED6D9E5DA36C6D27248645F0E22F585576A1488B8A89C5A50",
+          "exponent": 0
+        },
+        {
+          "denom": "INIT",
+          "exponent": 6
+        }
+      ],
+      "type_asset": "ics20",
+      "base": "ibc/37A3FB4FED4CA04ED6D9E5DA36C6D27248645F0E22F585576A1488B8A89C5A50",
+      "name": "Initia",
+      "display": "INIT",
+      "symbol": "INIT",
+      "traces": [
+        {
+          "type": "ibc",
+          "counterparty": {
+            "chain_name": "initia",
+            "base_denom": "uinit",
+            "channel_id": "channel-29"
+          },
+          "chain": {
+            "channel_id": "channel-0",
+            "path": "transfer/channel-0/uinit"
+          }
+        }
+      ],
+      "images": [
+        {
+          "image_sync": {
+            "chain_name": "initia",
+            "base_denom": "uinit"
+          }
+        }
+      ]
+    },
+    {
       "description": "MilkyWay's Liquid Staked INIT",
       "denom_units": [
         {


### PR DESCRIPTION
## Summary

- Add IBC'd INIT asset entry to `moo/assetlist.json`
- The `moo` chain's `chain.json` declares `ibc/37A3FB4FED4CA04ED6D9E5DA36C6D27248645F0E22F585576A1488B8A89C5A50` (INIT via `transfer/channel-0` from Initia) as its fee token, but this asset was **missing from the assetlist**
- This caused the `Validate Data` CI check to fail on **all open PRs**

## Root Cause

PR #7517 added the `moo` chain (Feb 2) without the IBC'd INIT fee token in the assetlist. The validation gap was masked by a bug in `checkChainNameMatchDirectory` which skips downstream checks (including fee token validation) for chains without `versions.json`. When PR #7543 (auto-sync) added `moo/versions.json` on Feb 16, the fee token check started running for the first time and exposed the missing asset.

## On-Chain Verification

| Field | Moo (moo-1) | Initia |
|-------|-------------|--------|
| Channel | `channel-0` | `channel-29` |
| Connection | `connection-0` | `connection-16` |
| State | STATE_OPEN | STATE_OPEN |

```
sha256("transfer/channel-0/uinit") = 37A3FB4FED4CA04ED6D9E5DA36C6D27248645F0E22F585576A1488B8A89C5A50 ✅
```

## Test plan

- [x] `Validate Data` CI check passes
- [x] `Lint JSON files` CI check passes
- [x] `validate-schema` CI check passes
- [ ] Fee token denom in `chain.json` matches the new asset's `base` in `assetlist.json`

🤖 Generated with [Claude Code](https://claude.com/claude-code)