### PR TITLE
Add Lumen to Osmosis IBC metadata

### DIFF
--- a/_IBC/lumen-osmosis.json
+++ b/_IBC/lumen-osmosis.json
@@ -1,0 +1,33 @@
+{
+  "$schema": "../ibc_data.schema.json",
+  "chain_1": {
+    "chain_name": "lumen",
+    "chain_id": "lumen",
+    "client_id": "07-tendermint-1",
+    "connection_id": "connection-1"
+  },
+  "chain_2": {
+    "chain_name": "osmosis",
+    "chain_id": "osmosis-1",
+    "client_id": "07-tendermint-3676",
+    "connection_id": "connection-11040"
+  },
+  "channels": [
+    {
+      "chain_1": {
+        "channel_id": "channel-1",
+        "port_id": "transfer"
+      },
+      "chain_2": {
+        "channel_id": "channel-109674",
+        "port_id": "transfer"
+      },
+      "ordering": "unordered",
+      "version": "ics20-1",
+      "tags": {
+        "preferred": true,
+        "status": "ACTIVE"
+      }
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

This PR adds the live Lumen <-> Osmosis IBC route to the chain registry.

Added file:
- `_IBC/lumen-osmosis.json`

## Verified live metadata

Lumen:
- chain_id: `lumen`
- client_id: `07-tendermint-1`
- connection_id: `connection-1`
- transfer channel: `channel-1`

Osmosis:
- chain_id: `osmosis-1`
- client_id: `07-tendermint-3676`
- connection_id: `connection-11040`
- transfer channel: `channel-109674`

Channel details:
- port: `transfer`
- ordering: `unordered`
- version: `ics20-1`

This route was verified against live public RPC/REST endpoints before preparing this PR.