### PR TITLE
feat(zigchain): add SolvBTC (Solv Protocol BTC) asset

### DIFF
--- a/zigchain/assetlist.json
+++ b/zigchain/assetlist.json
@@ -607,7 +607,6 @@
           }
         }
       ],
-      "coingecko_id": "solv-btc",
       "type_asset": "ics20",
       "logo_URIs": {
         "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/_non-cosmos/ethereum/images/solvBTC.png",

--- a/zigchain/assetlist.json
+++ b/zigchain/assetlist.json
@@ -563,6 +563,66 @@
         }
       ],
       "coingecko_id": "stride-staked-atom"
+    },
+    {
+      "description": "SolvBTC on ZIGChain",
+      "denom_units": [
+        {
+          "denom": "ibc/F1E29C7A6E0A3782CD87D279722AC11FEDE1BAAB9BD5A25A2A7EAE44ED02ADD5",
+          "exponent": 0
+        },
+        {
+          "denom": "solvbtc",
+          "exponent": 18
+        }
+      ],
+      "base": "ibc/F1E29C7A6E0A3782CD87D279722AC11FEDE1BAAB9BD5A25A2A7EAE44ED02ADD5",
+      "name": "SolvBTC on ZIGChain",
+      "display": "solvbtc",
+      "symbol": "SolvBTC",
+      "traces": [
+        {
+          "type": "ibc-bridge",
+          "counterparty": {
+            "chain_name": "ethereum",
+            "base_denom": "0x7a56e1c57c7475ccf742a1832b028f0456652f97",
+            "channel_id": "channel-0"
+          },
+          "chain": {
+            "channel_id": "08-wasm-1369",
+            "path": "transfer/08-wasm-1369/0x7a56e1c57c7475ccf742a1832b028f0456652f97"
+          },
+          "provider": "Eureka"
+        },
+        {
+          "type": "ibc",
+          "counterparty": {
+            "chain_name": "cosmoshub",
+            "base_denom": "ibc/0C4417F123459B47B6933939BF6F128C362B0C1F9EDA6A6EBC08860E4672AF7E",
+            "channel_id": "channel-1555"
+          },
+          "chain": {
+            "channel_id": "channel-4",
+            "path": "transfer/channel-4/transfer/08-wasm-1369/0x7a56e1c57c7475ccf742a1832b028f0456652f97"
+          }
+        }
+      ],
+      "coingecko_id": "solv-btc",
+      "type_asset": "ics20",
+      "logo_URIs": {
+        "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/_non-cosmos/ethereum/images/solvBTC.png",
+        "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/_non-cosmos/ethereum/images/solvBTC.svg"
+      },
+      "images": [
+        {
+          "image_sync": {
+            "chain_name": "ethereum",
+            "base_denom": "0x7a56e1c57c7475ccf742a1832b028f0456652f97"
+          },
+          "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/_non-cosmos/ethereum/images/solvBTC.png",
+          "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/_non-cosmos/ethereum/images/solvBTC.svg"
+        }
+      ]
     }
   ]
 }


### PR DESCRIPTION
Add SolvBTC to the ZIGChain asset list. Bridged from Ethereum via IBC Eureka to Cosmos Hub, then relayed to ZIGChain. Images reference the existing solvBTC.png/svg in _non-cosmos/ethereum/images/.

Ethereum contract: 0x7a56e1c57c7475ccf742a1832b028f0456652f97
ZIGChain IBC denom: ibc/F1E29C7A6E0A3782CD87D279722AC11FEDE1BAAB9BD5A25A2A7EAE44ED02ADD5