### PR TITLE
terra2: remove broken High Stakes REST endpoint (401 on staking + tx broadcast)

### DIFF
--- a/terra2/chain.json
+++ b/terra2/chain.json
@@ -198,10 +198,6 @@
         "provider": "Stakeflow"
       },
       {
-        "address": "https://terra-phoenix-api.highstakes.ch",
-        "provider": "High Stakes 🇨🇭"
-      },
-      {
         "address": "https://terra2.tdrsys.com",
         "provider": "TdrSys"
       },


### PR DESCRIPTION
## Summary

Remove `https://terra-phoenix-api.highstakes.ch` from `terra2/chain.json` `apis.rest`. The endpoint returns **HTTP 401 Unauthorized** on critical paths while basic Tendermint queries still succeed, so health-checks pass but real usage breaks.

## Probe results (2026-04-26)

```
GET  /cosmos/base/tendermint/v1beta1/node_info        → 200
GET  /cosmos/base/tendermint/v1beta1/blocks/latest    → 200
GET  /cosmos/staking/v1beta1/validators?...           → 401   ← broken
POST /cosmos/tx/v1beta1/txs                           → 401   ← broken
```

## Impact

`rest.cosmos.directory/terra2` round-robins across the chain-registry endpoints and ~30–50% of staking queries / tx broadcasts hit this backend, so apps that use the directory proxy (notably **restake.app**) intermittently fail with:

> `Failed to broadcast: Request failed with status code 401`

A real user reported this today while trying to delegate to a Terra2 validator via restake.app.

## Scope

- Removes only the **REST** entry. The matching RPC `https://terra-phoenix-rpc.highstakes.ch` is healthy (`/status`, `/broadcast_tx_sync`, `/abci_query` all 200) and is left untouched.
- High Stakes can re-add the REST endpoint via a follow-up PR once the auth is removed or `/cosmos/staking` and `/cosmos/tx` paths are unblocked.

## Test plan

- [x] `python3 -c "import json; json.load(open('terra2/chain.json'))"` — JSON parses
- [x] Re-probed remaining REST endpoints (`publicnode`, `cosmosrescue`, `tdrsys`, `onnode`, `stakeflow`) — all return 200 on staking + tx paths