### PR TITLE
Mark prefork dungeon-1 IBC channels INACTIVE

### DIFF
--- a/_IBC/cosmoshub-dungeon1.json
+++ b/_IBC/cosmoshub-dungeon1.json
@@ -25,8 +25,8 @@
       "ordering": "unordered",
       "version": "ics20-1",
       "tags": {
-        "preferred": true,
-        "status": "ACTIVE"
+        "preferred": false,
+        "status": "INACTIVE"
       }
     }
   ]

--- a/_IBC/dungeon1-migaloo.json
+++ b/_IBC/dungeon1-migaloo.json
@@ -25,8 +25,8 @@
       "ordering": "unordered",
       "version": "ics20-1",
       "tags": {
-        "preferred": true,
-        "status": "ACTIVE"
+        "preferred": false,
+        "status": "INACTIVE"
       }
     }
   ]

--- a/_IBC/dungeon1-neutron.json
+++ b/_IBC/dungeon1-neutron.json
@@ -25,8 +25,8 @@
       "ordering": "unordered",
       "version": "ics20-1",
       "tags": {
-        "preferred": true,
-        "status": "ACTIVE"
+        "preferred": false,
+        "status": "INACTIVE"
       }
     }
   ]

--- a/_IBC/dungeon1-osmosis.json
+++ b/_IBC/dungeon1-osmosis.json
@@ -25,8 +25,8 @@
       "ordering": "unordered",
       "version": "ics20-1",
       "tags": {
-        "preferred": true,
-        "status": "ACTIVE"
+        "preferred": false,
+        "status": "INACTIVE"
       }
     }
   ]

--- a/_IBC/dungeon1-stride.json
+++ b/_IBC/dungeon1-stride.json
@@ -25,8 +25,8 @@
       "ordering": "unordered",
       "version": "ics20-1",
       "tags": {
-        "preferred": true,
-        "status": "ACTIVE"
+        "preferred": false,
+        "status": "INACTIVE"
       }
     }
   ]

--- a/_IBC/dungeon1-terra2.json
+++ b/_IBC/dungeon1-terra2.json
@@ -25,8 +25,8 @@
       "ordering": "unordered",
       "version": "ics20-1",
       "tags": {
-        "preferred": true,
-        "status": "ACTIVE"
+        "preferred": false,
+        "status": "INACTIVE"
       }
     }
   ]


### PR DESCRIPTION
## Summary
The `dungeon1/` chain entry has `status: "killed"` — it's the pre-fork dungeon-1 chain, replaced by the post-fork `dungeon/` entry per the [Dungeon-1 hard fork update (#6090)](https://github.com/cosmos/chain-registry/pull/6090).

However, its 6 IBC channel files in `_IBC/` were still tagged `"status": "ACTIVE"` and `"preferred": true`. This causes Map of Zones and similar indexers to render the dead chain as a live zone with frozen pre-fork stats.

This PR flips those tags on the prefork-only IBC files to match the chain's killed status.

## Changes
For each file: `"status": "ACTIVE"` → `"status": "INACTIVE"` and `"preferred": true` → `"preferred": false`.

- `_IBC/cosmoshub-dungeon1.json`
- `_IBC/dungeon1-migaloo.json`
- `_IBC/dungeon1-neutron.json`
- `_IBC/dungeon1-osmosis.json`
- `_IBC/dungeon1-stride.json`
- `_IBC/dungeon1-terra2.json`

## Not affected (post-fork live IBC paths)
- `_IBC/cosmoshub-dungeon.json`
- `_IBC/dungeon-osmosis.json`
- `_IBC/dungeon-noble.json`
- `_IBC/dungeon-neutron.json`
- `_IBC/atomone-dungeon.json`

These continue to reflect the current live channels on the post-fork chain (chain_name `dungeon`).

## Test plan
- [x] `dungeon1/chain.json` is `status: killed`
- [x] All 6 prefork IBC files now reflect INACTIVE + non-preferred channels
- [x] No live `dungeon/` IBC files modified