### PR TITLE
dungeon: keep only Dungeon Games as canonical explorer

### DIFF
--- a/dungeon/chain.json
+++ b/dungeon/chain.json
@@ -82,6 +82,18 @@
   },
   "explorers": [
     {
+      "kind": "🚀 WHEN MOON 🌕 WHEN LAMBO 🔥",
+      "url": "https://explorer.whenmoonwhenlambo.money/dungeon",
+      "tx_page": "https://explorer.whenmoonwhenlambo.money/dungeon/tx/${txHash}",
+      "account_page": "https://explorer.whenmoonwhenlambo.money/dungeon/account/${accountAddress}"
+    },
+    {
+      "kind": "ChainTools",
+      "url": "https://explorer.chaintools.tech/Dungeon",
+      "tx_page": "https://explorer.chaintools.tech/Dungeon/tx/${txHash}",
+      "account_page": "https://explorer.chaintools.tech/Dungeon/account/${accountAddress}"
+    },
+    {
       "kind": "Dungeon Games",
       "url": "https://explorer.dungeongames.io",
       "tx_page": "https://explorer.dungeongames.io/tx/${txHash}",

--- a/dungeon/chain.json
+++ b/dungeon/chain.json
@@ -82,24 +82,6 @@
   },
   "explorers": [
     {
-      "kind": "Ping.Pub",
-      "url": "https://ping.pub/Dungeonchain",
-      "tx_page": "https://ping.pub/Dungeonchain/tx/${txHash}",
-      "account_page": "https://ping.pub/Dungeonchain/account/${accountAddress}"
-    },
-    {
-      "kind": "🚀 WHEN MOON 🌕 WHEN LAMBO 🔥",
-      "url": "https://explorer.whenmoonwhenlambo.money/dungeon",
-      "tx_page": "https://explorer.whenmoonwhenlambo.money/dungeon/tx/${txHash}",
-      "account_page": "https://explorer.whenmoonwhenlambo.money/dungeon/account/${accountAddress}"
-    },
-    {
-      "kind": "ChainTools",
-      "url": "https://explorer.chaintools.tech/Dungeon",
-      "tx_page": "https://explorer.chaintools.tech/Dungeon/tx/${txHash}",
-      "account_page": "https://explorer.chaintools.tech/Dungeon/account/${accountAddress}"
-    },
-    {
       "kind": "Dungeon Games",
       "url": "https://explorer.dungeongames.io",
       "tx_page": "https://explorer.dungeongames.io/tx/${txHash}",


### PR DESCRIPTION
## Why

The first three explorer entries in `dungeon/chain.json` point to community-run instances that have rotted:

- `https://ping.pub/Dungeonchain` — DNS no longer resolves
- `https://explorer.whenmoonwhenlambo.money/dungeon` — DNS no longer resolves
- `https://explorer.chaintools.tech/Dungeon` — alive but stale

Downstream consumers (mapofzones, wallet UIs that pick `explorers[0]`) currently send users to a dead Ping.Pub URL.

## What

Reduce the explorer list to just **Dungeon Games**, which is operated by Crypto Dungeon LLC (the chain operator) and matches the existing `rpc.dungeongames.io` / `api.dungeongames.io` endpoints already listed in `apis`.

The other three entries can return as separate PRs from those operators if/when their services come back online.