### PR TITLE
feat: add Sunima Testnet (sunima-testnet-1)

### DIFF
--- a/testnets/sunimatestnet/assetlist.json
+++ b/testnets/sunimatestnet/assetlist.json
@@ -6,7 +6,7 @@
       "description": "The native staking and gas token of the Sunima Testnet.",
       "denom_units": [
         {
-          "denom": "stake",
+          "denom": "tsuna",
           "exponent": 0
         },
         {
@@ -14,8 +14,8 @@
           "exponent": 6
         }
       ],
-      "base": "stake",
-      "name": "Sunima Testnet Stake",
+      "base": "tsuna",
+      "name": "Sunima Testnet",
       "display": "tSUNA",
       "symbol": "tSUNA",
       "logo_URIs": {

--- a/testnets/sunimatestnet/assetlist.json
+++ b/testnets/sunimatestnet/assetlist.json
@@ -1,0 +1,32 @@
+{
+  "$schema": "../../assetlist.schema.json",
+  "chain_name": "sunimatestnet",
+  "assets": [
+    {
+      "description": "The native staking and gas token of the Sunima Testnet.",
+      "denom_units": [
+        {
+          "denom": "stake",
+          "exponent": 0
+        },
+        {
+          "denom": "tSUNA",
+          "exponent": 6
+        }
+      ],
+      "base": "stake",
+      "name": "Sunima Testnet Stake",
+      "display": "tSUNA",
+      "symbol": "tSUNA",
+      "logo_URIs": {
+        "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/testnets/sunimatestnet/images/sunima.svg"
+      },
+      "images": [
+        {
+          "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/testnets/sunimatestnet/images/sunima.svg"
+        }
+      ],
+      "type_asset": "sdk.coin"
+    }
+  ]
+}

--- a/testnets/sunimatestnet/chain.json
+++ b/testnets/sunimatestnet/chain.json
@@ -17,7 +17,7 @@
   "fees": {
     "fee_tokens": [
       {
-        "denom": "stake",
+        "denom": "tsuna",
         "fixed_min_gas_price": 0,
         "low_gas_price": 0,
         "average_gas_price": 0.025,
@@ -28,7 +28,7 @@
   "staking": {
     "staking_tokens": [
       {
-        "denom": "stake"
+        "denom": "tsuna"
       }
     ]
   },

--- a/testnets/sunimatestnet/chain.json
+++ b/testnets/sunimatestnet/chain.json
@@ -1,0 +1,62 @@
+{
+  "$schema": "../../chain.schema.json",
+  "chain_name": "sunimatestnet",
+  "status": "live",
+  "website": "https://sunima.uk/",
+  "network_type": "testnet",
+  "pretty_name": "Sunima Testnet",
+  "chain_type": "cosmos",
+  "chain_id": "sunima-testnet-1",
+  "bech32_prefix": "sunima",
+  "daemon_name": "sunimad",
+  "node_home": "$HOME/.sunima",
+  "key_algos": [
+    "secp256k1"
+  ],
+  "slip44": 118,
+  "fees": {
+    "fee_tokens": [
+      {
+        "denom": "stake",
+        "fixed_min_gas_price": 0,
+        "low_gas_price": 0,
+        "average_gas_price": 0.025,
+        "high_gas_price": 0.04
+      }
+    ]
+  },
+  "staking": {
+    "staking_tokens": [
+      {
+        "denom": "stake"
+      }
+    ]
+  },
+  "codebase": {
+    "genesis": {
+      "genesis_url": "https://sunima.uk/chain/genesis.json"
+    }
+  },
+  "logo_URIs": {
+    "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/testnets/sunimatestnet/images/sunima.svg"
+  },
+  "apis": {
+    "rpc": [
+      {
+        "address": "https://sunima.uk/chain-rpc/",
+        "provider": "Sunima Labs"
+      }
+    ],
+    "rest": [
+      {
+        "address": "https://sunima.uk/chain-rest/",
+        "provider": "Sunima Labs"
+      }
+    ]
+  },
+  "images": [
+    {
+      "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/testnets/sunimatestnet/images/sunima.svg"
+    }
+  ]
+}

--- a/testnets/sunimatestnet/chain.json
+++ b/testnets/sunimatestnet/chain.json
@@ -40,6 +40,16 @@
   "logo_URIs": {
     "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/testnets/sunimatestnet/images/sunima.svg"
   },
+  "peers": {
+    "seeds": [
+      {
+        "id": "26b7a844f1840bf8bc9535b5329de93d8bd8f45f",
+        "address": "seed.sunima.uk:26656",
+        "provider": "Sunima Labs"
+      }
+    ],
+    "persistent_peers": []
+  },
   "apis": {
     "rpc": [
       {

--- a/testnets/sunimatestnet/images/sunima.svg
+++ b/testnets/sunimatestnet/images/sunima.svg
@@ -1,0 +1,27 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
+  <defs>
+    <radialGradient id="h" cx="50%" cy="50%" r="50%">
+      <stop offset="0%" stop-color="#22d3ee" stop-opacity="0.45"/>
+      <stop offset="60%" stop-color="#22d3ee" stop-opacity="0.08"/>
+      <stop offset="100%" stop-color="#22d3ee" stop-opacity="0"/>
+    </radialGradient>
+    <linearGradient id="r" x1="0" x2="1" y1="0" y2="1">
+      <stop offset="0%" stop-color="#7dd3fc" stop-opacity="0.4"/>
+      <stop offset="50%" stop-color="#22d3ee" stop-opacity="1"/>
+      <stop offset="100%" stop-color="#7dd3fc" stop-opacity="0.4"/>
+    </linearGradient>
+  </defs>
+  <circle cx="50" cy="50" r="46" fill="url(#h)"/>
+  <g fill="none" stroke="url(#r)" stroke-width="2.4">
+    <ellipse cx="50" cy="50" rx="42" ry="18" transform="rotate(45 50 50)"/>
+    <ellipse cx="50" cy="50" rx="42" ry="18" transform="rotate(-45 50 50)"/>
+  </g>
+  <g transform="translate(50 50)">
+    <polygon points="0,-18 18,0 0,18 -18,0" fill="url(#h)" opacity="0.8"/>
+    <polygon points="0,-14 14,0 0,0" fill="#67e8f9"/>
+    <polygon points="0,-14 -14,0 0,0" fill="#22d3ee"/>
+    <polygon points="14,0 0,14 0,0" fill="#0891b2"/>
+    <polygon points="-14,0 0,14 0,0" fill="#155e75"/>
+    <polygon points="0,-10 6,-2 0,-2 -6,-2" fill="#cffafe" opacity="0.95"/>
+  </g>
+</svg>


### PR DESCRIPTION
## Summary

Adds **Sunima Testnet** under `testnets/sunimatestnet/`.

Sunima Testnet is a Cosmos SDK 0.50 / CometBFT chain operated by Sunima Labs.
Genesis: 2026-05-07T23:15:43Z. Currently in single-validator bootstrap phase
while operator onboarding continues; topology will diversify as external
validators join the set.

## Chain parameters

| field | value |
| --- | --- |
| `chain_id` | `sunima-testnet-1` |
| `chain_name` (registry) | `sunimatestnet` |
| `pretty_name` | `Sunima Testnet` |
| `bech32_prefix` | `sunima` |
| `daemon_name` | `sunimad` |
| `node_home` | `$HOME/.sunima` |
| `bond_denom` | `stake` |
| `display_denom` | `tSUNA` (6 decimals) |
| `slip44` | 118 |
| `key_algos` | `secp256k1` |

## Files

- `testnets/sunimatestnet/chain.json` — chain metadata + RPC/REST endpoints
- `testnets/sunimatestnet/assetlist.json` — `stake` / `tSUNA` denom
- `testnets/sunimatestnet/images/sunima.svg` — logo

## Public endpoints

- **RPC:** https://sunima.uk/chain-rpc/
- **REST:** https://sunima.uk/chain-rest/
- **Genesis:** https://sunima.uk/chain/genesis.json
- **Website:** https://sunima.uk/

No seed nodes / persistent peers are listed in this PR by design — operator
program is still in onboarding phase and we don't want to publish individual
node addresses until the validator set diversifies.

## Validation

- Both `chain.json` and `assetlist.json` validate against the repo's
  `chain.schema.json` / `assetlist.schema.json`.
- Chain is healthy and not catching up:
  ```
  $ curl -s https://sunima.uk/chain-rpc/status | jq .result.sync_info
  "latest_block_height": "97173+",
  "catching_up": false,
  "earliest_block_time": "2026-05-07T23:15:43.268077294Z"
  ```

Happy to address any review comments — first PR from Sunima Labs to the
registry, so let me know if anything is off.