### PR TITLE
cosmoshub: enrich Nether (NTHR) asset metadata

### DIFF
--- a/cosmoshub/assetlist.json
+++ b/cosmoshub/assetlist.json
@@ -1309,7 +1309,8 @@
       "coingecko_id": "dragon-coin-2"
     },
     {
-      "description": "Nether is a tokenfactory token on the Cosmos Hub.",
+      "description": "Nether (NTHR) is the utility token of the Underworld NFT ecosystem, issued via tokenfactory on the Cosmos Hub. NTHR powers the NecroVault, a soft-staking platform where holders of Underworld collections earn rewards while keeping their NFTs in their wallets. Fixed supply: 21,000.",
+      "extended_description": "Nether is the core utility token of the Underworld ecosystem, built around NFTs, soft staking, rewards, and on-chain interaction inside the NecroVault. Forged on Cosmos and tied directly to the Underworld economy, NTHR connects multiple systems: NFT staking rewards, loot boxes and reward mechanics, vault perks and VIP access, liquidity incentives, and future ecosystem utilities. Holders can stake NTHR inside the NecroVault to unlock deeper rewards, multipliers, and exclusive features tied to the Underworld collections. The ecosystem currently includes multiple NFT collections that generate rewards through the NecroVault soft staking system, where users earn tokens like BANE, RUIN, and NTHR while keeping their NFTs liquid in their wallets. With a limited supply of only 21,000 tokens, NTHR acts as the long-term asset of the Underworld, powering expansions, reward systems, vault mechanics, raffles, and ecosystem distributions.",
       "denom_units": [
         {
           "denom": "factory/cosmos1wdja2gcsesyl07raq9jm3rcvu0sse5zkev0h8m/Nether",
@@ -1327,11 +1328,18 @@
       "symbol": "NTHR",
       "images": [
         {
-          "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/cosmoshub/images/nthr.png"
+          "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/cosmoshub/images/nthr.png",
+          "theme": {
+            "circle": true
+          }
         }
       ],
       "logo_URIs": {
         "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/cosmoshub/images/nthr.png"
+      },
+      "socials": {
+        "website": "https://www.necrovault.com/",
+        "x": "https://x.com/Underworld_NFTs"
       }
     }
   ]


### PR DESCRIPTION
## Summary

Enriches the existing Nether (NTHR) tokenfactory entry on Cosmos Hub with:

- `description` — replaces the generic stub with a one-liner that names the token's role in the Underworld NFT ecosystem and NecroVault staking platform.
- `extended_description` — full project description covering soft-staking mechanics, fixed supply (21,000), and ecosystem utilities.
- `socials.website` — https://www.necrovault.com/
- `socials.x` — https://x.com/Underworld_NFTs
- `images[0].theme.circle: true` — tells frontends to render the logo in a circular crop.

No changes to `base`, `denom_units`, image URLs, or `type_asset`. Logo file already in repo from #7666.

## Validation

- `chain-registry validate --registryDir . --logLevel error` → ✅ 2192 tests passed.
- JSON parses cleanly.