### PR TITLE
osmosis: add Nether (NTHR) IBC asset from cosmoshub

### DIFF
--- a/osmosis/assetlist.json
+++ b/osmosis/assetlist.json
@@ -28132,6 +28132,54 @@
         "website": "https://greystoneinc.io"
       },
       "type_asset": "sdk.coin"
+    },
+    {
+      "description": "Nether (NTHR) is the utility token of the Underworld NFT ecosystem, issued via tokenfactory on the Cosmos Hub. NTHR powers the NecroVault, a soft-staking platform where holders of Underworld collections earn rewards while keeping their NFTs in their wallets. Fixed supply: 21,000.",
+      "extended_description": "Nether is the core utility and value token of the Underworld ecosystem — built around NFTs, soft staking, rewards, and on-chain interaction inside the NecroVault. Forged on Cosmos and tied directly to the Underworld economy, NTHR connects multiple systems together: NFT staking rewards, loot boxes and reward mechanics, vault perks and VIP access, future ecosystem utilities, and liquidity incentives and staking rewards. Unlike passive tokens, NTHR is designed to be used. Holders can stake it inside the NecroVault to unlock deeper rewards, multipliers, and exclusive features tied to the Underworld collections and platform mechanics. The ecosystem currently includes multiple NFT collections that generate rewards through the NecroVault soft staking system, where users can earn tokens like BANE, RUIN, and NTHR while keeping their NFTs liquid in their wallets. With a limited supply of only 21,000 tokens, NTHR acts as the long-term asset of the Underworld — powering future expansions, reward systems, vault mechanics, raffles, ecosystem distributions, and experimental game theory features.",
+      "denom_units": [
+        {
+          "denom": "ibc/EFAAE3AD05AA79647A1587E363A11B6126CC83C8C0593171BB1892A39EB550DF",
+          "exponent": 0
+        },
+        {
+          "denom": "nthr",
+          "exponent": 6
+        }
+      ],
+      "type_asset": "ics20",
+      "base": "ibc/EFAAE3AD05AA79647A1587E363A11B6126CC83C8C0593171BB1892A39EB550DF",
+      "name": "Nether",
+      "display": "nthr",
+      "symbol": "NTHR",
+      "traces": [
+        {
+          "type": "ibc",
+          "counterparty": {
+            "chain_name": "cosmoshub",
+            "base_denom": "factory/cosmos1wdja2gcsesyl07raq9jm3rcvu0sse5zkev0h8m/Nether",
+            "channel_id": "channel-141"
+          },
+          "chain": {
+            "channel_id": "channel-0",
+            "path": "transfer/channel-0/factory/cosmos1wdja2gcsesyl07raq9jm3rcvu0sse5zkev0h8m/Nether"
+          }
+        }
+      ],
+      "images": [
+        {
+          "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/cosmoshub/images/nthr.png",
+          "theme": {
+            "circle": true
+          }
+        }
+      ],
+      "logo_URIs": {
+        "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/cosmoshub/images/nthr.png"
+      },
+      "socials": {
+        "website": "https://www.necrovault.com/",
+        "x": "https://x.com/Underworld_NFTs"
+      }
     }
   ]
 }


### PR DESCRIPTION
Adds Nether (NTHR) — a tokenfactory token native to Cosmos Hub — to `osmosis/assetlist.json` as an IBC-bridged asset.

## Asset
- **Symbol:** NTHR
- **Name:** Nether
- **Base denom on Osmosis:** `ibc/EFAAE3AD05AA79647A1587E363A11B6126CC83C8C0593171BB1892A39EB550DF`
- **Origin:** cosmoshub-4 tokenfactory `factory/cosmos1wdja2gcsesyl07raq9jm3rcvu0sse5zkev0h8m/Nether`
- **Decimals:** 6
- **Fixed supply:** 21,000

## IBC trace
- Osmosis channel: `channel-0` (canonical Hub↔Osmosis path)
- Counterparty (cosmoshub) channel: `channel-141`
- Verified live on Osmosis LCD — `4,387,045,062 micro-NTHR` (~4,387 NTHR) currently in supply: `https://lcd.osmosis.zone/cosmos/bank/v1beta1/supply/by_denom?denom=ibc%2FEFAAE3AD05AA79647A1587E363A11B6126CC83C8C0593171BB1892A39EB550DF`

## Image
Re-uses the NTHR PNG already accepted into `cosmos/chain-registry` at `cosmoshub/images/nthr.png` to keep one canonical asset image across chains. Circular theme hint per the design (avatars/lists render the token round).

## Context
NTHR is the utility token of the Underworld NFT ecosystem on Cosmos Hub. Holders stake NTHR inside the NecroVault, a soft-staking platform that rewards Underworld NFT collection holders while their NFTs remain liquid in their wallets.

- Website: https://www.necrovault.com/
- X: https://x.com/Underworld_NFTs

## Related PRs
- [#7686](https://github.com/cosmos/chain-registry/pull/7686) — enriches the cosmoshub-side NTHR asset (description + extended_description + socials + circular theme). Same content used on this Osmosis entry so both surfaces stay in sync.
- [cosmostation/chainlist#2500](https://github.com/cosmostation/chainlist/pull/2500) — adds NTHR to the Cosmostation/Mintscan asset registry.

## Validation
- JSON parses cleanly (`json.load` succeeds, 592 total assets)
- Schema follows existing IBC asset shape (see ATOM-on-Osmosis as the reference template)
- IBC trace `channel_id` + counterparty match the canonical Hub↔Osmosis pair used by every other Hub-origin asset on Osmosis (ATOM, etc.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)