### PR TITLE
fix(juno): remove dead RPC/REST/gRPC endpoints (4 providers)

### DIFF
--- a/juno/chain.json
+++ b/juno/chain.json
@@ -175,10 +175,6 @@
   "apis": {
     "rpc": [
       {
-        "address": "https://rpc-juno.itastakers.com",
-        "provider": "itastakers"
-      },
-      {
         "address": "https://juno.rpc.m.stavr.tech",
         "provider": "🔥STAVR🔥"
       },
@@ -199,10 +195,6 @@
         "provider": "Stake&Relax Validator 🦥"
       },
       {
-        "address": "https://rpc-juno-01.stakeflow.io",
-        "provider": "Stakeflow"
-      },
-      {
         "address": "https://juno-rpc.publicnode.com:443",
         "provider": "Allnodes ⚡️ Nodes & Staking"
       },
@@ -217,14 +209,6 @@
       {
         "address": "https://juno-rpc.cogwheel.zone",
         "provider": "Cogwheel"
-      },
-      {
-        "address": "https://juno.declab.pro:26610",
-        "provider": "Decloud Nodes Lab"
-      },
-      {
-        "address": "https://juno-rpc.chainroot.io",
-        "provider": "Chainroot"
       },
       {
         "address": "https://juno.api.pocket.network",
@@ -253,10 +237,6 @@
         "provider": "Stake&Relax Validator 🦥"
       },
       {
-        "address": "https://api-juno-01.stakeflow.io",
-        "provider": "Stakeflow"
-      },
-      {
         "address": "https://juno-rest.publicnode.com",
         "provider": "Allnodes ⚡️ Nodes & Staking"
       },
@@ -271,14 +251,6 @@
       {
         "address": "https://juno-api.cogwheel.zone",
         "provider": "Cogwheel"
-      },
-      {
-        "address": "https://juno.declab.pro:443",
-        "provider": "Decloud Nodes Lab"
-      },
-      {
-        "address": "https://juno-api.chainroot.io",
-        "provider": "Chainroot"
       },
       {
         "address": "https://juno.api.pocket.network",
@@ -307,20 +279,12 @@
         "provider": "Lavender.Five Nodes 🐝"
       },
       {
-        "address": "grpc-juno-01.stakeflow.io:2302",
-        "provider": "Stakeflow"
-      },
-      {
         "address": "juno-grpc.publicnode.com:443",
         "provider": "Allnodes ⚡️ Nodes & Staking"
       },
       {
         "address": "juno-grpc.cogwheel.zone:443",
         "provider": "Cogwheel"
-      },
-      {
-        "address": "juno-grpc.chainroot.io:443",
-        "provider": "Chainroot"
       },
       {
         "address": "grpc.juno.validatus.com:443",


### PR DESCRIPTION
## Summary

Removes 9 RPC/REST/gRPC endpoint entries across 4 providers whose Juno hostnames no longer resolve (DNS NXDOMAIN), keeping `juno/chain.json` accurate to the providers that still actually serve traffic.

## Verified-dead endpoints

All hostnames below return `Could not resolve host` from both `getent hosts` and `curl` (verified 2026-05-25):

| Provider | Endpoint(s) removed | Type |
|---|---|---|
| itastakers | `rpc-juno.itastakers.com` | RPC |
| Stakeflow | `rpc-juno-01.stakeflow.io`, `api-juno-01.stakeflow.io`, `grpc-juno-01.stakeflow.io` | RPC + REST + gRPC |
| Decloud Nodes Lab | `juno.declab.pro:26610`, `juno.declab.pro:443` | RPC + REST |
| Chainroot | `juno-rpc.chainroot.io`, `juno-api.chainroot.io`, `juno-grpc.chainroot.io` | RPC + REST + gRPC |

DNS NXDOMAIN is unambiguous — these hostnames have been retired on the providers' side; no maintenance window will restore them.

## Remaining providers verified working

The 8 remaining RPC providers (STAVR, Polkachu, Kleomedes, Stake&Relax, Allnodes/publicnode, Validatus, Cogwheel, Pocket Network) returned HTTP 200 with `chain_id=juno-1` at height ~38,236,460 during the same audit. They are untouched by this PR.

## Out of scope (intentionally not removed)

- **Lavender.Five** returned HTTP 503 specifically on the `/juno` path (their `cosmoshub` and `osmosis` paths returned 200, so this is a Juno-specific node-side issue rather than infrastructure-wide). Possibly transient — left in for now.
- **StakeTown** returns an empty reply after TLS handshake completes (verified under both HTTP/2 and HTTP/1.1). Could be a maintenance window; left in for now.

Both can be revisited in a follow-up PR if they remain broken after a few more days of testing.

## Test plan

- [x] `getent hosts` on each removed hostname returns `NO_DNS`
- [x] `curl -m 8 https://<host>/status` (or `/cosmos/base/tendermint/v1beta1/node_info` for REST) returns `Could not resolve host` (HTTP 000)
- [x] Remaining 8 RPC + 8 REST endpoints return 200 with `chain_id=juno-1`
- [x] JSON structure preserved (only the 9 entries removed; surrounding entries unchanged)
- [x] File parses as valid JSON post-edit
