### PR TITLE
feat(lumera): add Dungeon RPC + REST endpoints

### DIFF
--- a/lumera/chain.json
+++ b/lumera/chain.json
@@ -121,6 +121,10 @@
       {
         "address": "https://lumera-rpc.linknode.org",
         "provider": "AstroStake"
+      },
+      {
+        "address": "https://lumera-rpc.dungeon.games",
+        "provider": "Dungeon"
       }
     ],
     "rest": [
@@ -143,6 +147,10 @@
       {
         "address": "https://lumera-api.linknode.org",
         "provider": "AstroStake"
+      },
+      {
+        "address": "https://lumera-lcd.dungeon.games",
+        "provider": "Dungeon"
       }
     ],
     "grpc": [


### PR DESCRIPTION
## Summary
- Adds Dungeon's public Lumera (lumera-mainnet-1) endpoints to `apis.rpc` and `apis.rest`:
  - RPC: `https://lumera-rpc.dungeon.games`
  - REST: `https://lumera-lcd.dungeon.games`

## About the operator
Dungeon Games is a Cosmos validator operator running validators on dungeon-1 (own chain, $DGN), mantle-1, pocket, and lumera. Validator moniker on Lumera: **Dungeon** (operator `lumeravaloper1k6pqwpcd3f7qkqd67vww75de0wlwn6htr3t02s`).

## Endpoint details
- Both endpoints are Cloudflare-fronted (TLS at edge, DDoS protection, rate limiting).
- Backed by a fully-synced lumerad v1.12.0 node (current height matches public chain head).
- CORS is open for browser-based wallets.
- Service guarantee: best-effort 99.9% uptime, monitored 24/7 from a triple-redundant data center.

## Verification

```
curl -s https://lumera-rpc.dungeon.games/status | jq .result.node_info.network
# "lumera-mainnet-1"

curl -s https://lumera-lcd.dungeon.games/cosmos/base/tendermint/v1beta1/blocks/latest | jq .block.header.chain_id
# "lumera-mainnet-1"
```

## Test plan
- [x] Endpoints respond with `lumera-mainnet-1` chain_id
- [x] CORS headers present (`Access-Control-Allow-Origin: *`)
- [x] HTTPS works (CF-issued cert)
- [x] Both endpoints return matching block height