### PR TITLE
feat(assetmantle): add Dungeon RPC + REST endpoints

### DIFF
--- a/assetmantle/chain.json
+++ b/assetmantle/chain.json
@@ -133,6 +133,10 @@
       {
         "address": "https://assetmantle-rpc.publicnode.com:443",
         "provider": "Allnodes ⚡️ Nodes & Staking"
+      },
+      {
+        "address": "https://mantle-rpc.dungeon.games",
+        "provider": "Dungeon"
       }
     ],
     "rest": [
@@ -155,6 +159,10 @@
       {
         "address": "https://assetmantle-rest.publicnode.com",
         "provider": "Allnodes ⚡️ Nodes & Staking"
+      },
+      {
+        "address": "https://mantle-lcd.dungeon.games",
+        "provider": "Dungeon"
       }
     ],
     "grpc": [


### PR DESCRIPTION
## Summary
- Adds Dungeon's public AssetMantle (mantle-1) endpoints to `apis.rpc` and `apis.rest`:
  - RPC: `https://mantle-rpc.dungeon.games`
  - REST: `https://mantle-lcd.dungeon.games`

## About the operator
Dungeon Games is a Cosmos validator operator running validators on dungeon-1 (own chain, \$DGN), mantle-1, pocket, and lumera. Validator moniker on Mantle: **Dungeon** (operator \`mantlevaloper15dvymxjw9vh4qt6vzch74z7cnwauq06y820uxn\`, BOND_STATUS_BONDED, active set).

## Why this matters for mantle-1
Several existing public RPC providers for AssetMantle are currently unreliable: polkachu often unreachable, lavenderfive and kjnodes return non-Tendermint responses, publicnode.com under \`mantle-rpc.publicnode.com\` actually serves the Mantle Network EVM L2 (eip155:5000) — a different chain entirely. Adding a known-working public RPC + REST helps the AssetMantle community.

## Endpoint details
- Both endpoints are Cloudflare-fronted (TLS at edge, DDoS protection, rate limiting).
- Backed by a fully-synced mantleNode v1.0.1 node.
- CORS is open for browser-based wallets.
- Service guarantee: best-effort 99.9% uptime, monitored 24/7 from a triple-redundant data center.

## Verification

\`\`\`
curl -s https://mantle-rpc.dungeon.games/status | jq .result.node_info.network
# \"mantle-1\"

curl -s https://mantle-lcd.dungeon.games/cosmos/base/tendermint/v1beta1/blocks/latest | jq .block.header.chain_id
# \"mantle-1\"
\`\`\`

## Test plan
- [x] Endpoints respond with \`mantle-1\` chain_id
- [x] CORS headers present (\`Access-Control-Allow-Origin: *\`)
- [x] HTTPS works (CF-issued cert)
- [x] Both endpoints return matching block height