### PR TITLE
Add IBC asset entries (ATOM, TIA, INJ) for The Jay Network

### DIFF
--- a/thejaynetwork/assetlist.json
+++ b/thejaynetwork/assetlist.json
@@ -30,6 +30,144 @@
         "website": "https://thejaynetwork.com"
       },
       "type_asset": "sdk.coin"
+    },
+    {
+      "description": "Cosmos Hub ATOM transferred via IBC to The Jay Network.",
+      "denom_units": [
+        {
+          "denom": "ibc/C4CFF46FD6DE35CA4CF4CE031E643C8FDC9BA4B99AE598E9B0ED98FE3A2319F9",
+          "exponent": 0
+        },
+        {
+          "denom": "atom",
+          "exponent": 6
+        }
+      ],
+      "type_asset": "ics20",
+      "base": "ibc/C4CFF46FD6DE35CA4CF4CE031E643C8FDC9BA4B99AE598E9B0ED98FE3A2319F9",
+      "name": "Cosmos Hub Atom",
+      "display": "atom",
+      "symbol": "ATOM",
+      "traces": [
+        {
+          "type": "ibc",
+          "counterparty": {
+            "chain_name": "cosmoshub",
+            "base_denom": "uatom",
+            "channel_id": "channel-1871"
+          },
+          "chain": {
+            "channel_id": "channel-1",
+            "path": "transfer/channel-1/uatom"
+          }
+        }
+      ],
+      "logo_URIs": {
+        "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/cosmoshub/images/atom.png",
+        "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/cosmoshub/images/atom.svg"
+      },
+      "images": [
+        {
+          "image_sync": {
+            "chain_name": "cosmoshub",
+            "base_denom": "uatom"
+          },
+          "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/cosmoshub/images/atom.png",
+          "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/cosmoshub/images/atom.svg"
+        }
+      ]
+    },
+    {
+      "description": "Celestia TIA transferred via IBC to The Jay Network.",
+      "denom_units": [
+        {
+          "denom": "ibc/101B0938079BD4E8E89BD547635F86CCE4406C634E1427FE5226358F4BAD41F4",
+          "exponent": 0
+        },
+        {
+          "denom": "tia",
+          "exponent": 6
+        }
+      ],
+      "type_asset": "ics20",
+      "base": "ibc/101B0938079BD4E8E89BD547635F86CCE4406C634E1427FE5226358F4BAD41F4",
+      "name": "Celestia",
+      "display": "tia",
+      "symbol": "TIA",
+      "traces": [
+        {
+          "type": "ibc",
+          "counterparty": {
+            "chain_name": "celestia",
+            "base_denom": "utia",
+            "channel_id": "channel-277"
+          },
+          "chain": {
+            "channel_id": "channel-2",
+            "path": "transfer/channel-2/utia"
+          }
+        }
+      ],
+      "logo_URIs": {
+        "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/celestia/images/celestia.png",
+        "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/celestia/images/celestia.svg"
+      },
+      "images": [
+        {
+          "image_sync": {
+            "chain_name": "celestia",
+            "base_denom": "utia"
+          },
+          "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/celestia/images/celestia.png",
+          "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/celestia/images/celestia.svg"
+        }
+      ]
+    },
+    {
+      "description": "Injective INJ transferred via IBC to The Jay Network.",
+      "denom_units": [
+        {
+          "denom": "ibc/1C2D8505A29823310B4484E4C63CFDCB08C0D3B57537A615A45F4E5D42CDC789",
+          "exponent": 0
+        },
+        {
+          "denom": "INJ",
+          "exponent": 18
+        }
+      ],
+      "type_asset": "ics20",
+      "base": "ibc/1C2D8505A29823310B4484E4C63CFDCB08C0D3B57537A615A45F4E5D42CDC789",
+      "name": "Injective",
+      "display": "INJ",
+      "symbol": "INJ",
+      "traces": [
+        {
+          "type": "ibc",
+          "counterparty": {
+            "chain_name": "injective",
+            "base_denom": "inj",
+            "channel_id": "channel-450"
+          },
+          "chain": {
+            "channel_id": "channel-3",
+            "path": "transfer/channel-3/inj"
+          }
+        }
+      ],
+      "logo_URIs": {
+        "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/injective/images/inj.png",
+        "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/injective/images/inj.svg"
+      },
+      "images": [
+        {
+          "image_sync": {
+            "chain_name": "injective",
+            "base_denom": "inj"
+          },
+          "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/injective/images/inj.png",
+          "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/injective/images/inj.svg"
+        }
+      ]
     }
   ]
 }


### PR DESCRIPTION
## Summary

Add IBC token entries to thejaynetwork/assetlist.json for the three active IBC channels:

| Token | IBC Denom Hash | Jay Network Channel | Counterparty Channel |
|-------|---------------|--------------------|--------------------|
| ATOM | ibc/C4CFF46F... | channel-1 | cosmoshub channel-1871 |
| TIA | ibc/101B0938... | channel-2 | celestia channel-277 |
| INJ | ibc/1C2D8505... | channel-3 | injective channel-450 |

## Details

- All three IBC channels are STATE_OPEN on-chain and registered in the _IBC directory
- Denom hashes are verified via SHA256(transfer/channel-X/denom)
- Each entry includes type_asset: ics20, traces with correct counterparty info, and image_sync references to the origin chain images
- No changes to existing native JAY token entry