### PR TITLE
Add IBC channels: celestia <> cosmoshub and celestia <> xrplevm

### DIFF
--- a/_IBC/celestia-cosmoshub.json
+++ b/_IBC/celestia-cosmoshub.json
@@ -1,0 +1,33 @@
+{
+  "$schema": "../ibc_data.schema.json",
+  "chain_1": {
+    "chain_name": "celestia",
+    "chain_id": "celestia",
+    "client_id": "07-tendermint-151",
+    "connection_id": "connection-103"
+  },
+  "chain_2": {
+    "chain_name": "cosmoshub",
+    "chain_id": "cosmoshub-4",
+    "client_id": "07-tendermint-1480",
+    "connection_id": "connection-1272"
+  },
+  "channels": [
+    {
+      "chain_1": {
+        "channel_id": "channel-278",
+        "port_id": "transfer"
+      },
+      "chain_2": {
+        "channel_id": "channel-1879",
+        "port_id": "transfer"
+      },
+      "ordering": "unordered",
+      "version": "ics20-1",
+      "tags": {
+        "preferred": true,
+        "status": "ACTIVE"
+      }
+    }
+  ]
+}

--- a/_IBC/celestia-xrplevm.json
+++ b/_IBC/celestia-xrplevm.json
@@ -1,0 +1,33 @@
+{
+  "$schema": "../ibc_data.schema.json",
+  "chain_1": {
+    "chain_name": "celestia",
+    "chain_id": "celestia",
+    "client_id": "07-tendermint-165",
+    "connection_id": "connection-105"
+  },
+  "chain_2": {
+    "chain_name": "xrplevm",
+    "chain_id": "xrplevm_1440000-1",
+    "client_id": "07-tendermint-13",
+    "connection_id": "connection-6"
+  },
+  "channels": [
+    {
+      "chain_1": {
+        "channel_id": "channel-280",
+        "port_id": "transfer"
+      },
+      "chain_2": {
+        "channel_id": "channel-6",
+        "port_id": "transfer"
+      },
+      "ordering": "unordered",
+      "version": "ics20-1",
+      "tags": {
+        "preferred": true,
+        "status": "ACTIVE"
+      }
+    }
+  ]
+}


### PR DESCRIPTION
This PR adds two new IBC transfer channels operated by Cumulo (cumulo.me):

1. celestia <> cosmoshub
   - First IBC channel between Celestia mainnet and Cosmos Hub
   - channel-278 (celestia) <> channel-1879 (cosmoshub-4)

2. celestia <> xrplevm
   - First IBC channel between Celestia mainnet and XRPL EVM
   - channel-280 (celestia) <> channel-6 (xrplevm_1440000-1)