### PR TITLE
Add https scheme to Nolus RPC and REST endpoints

### DIFF
--- a/nolus/chain.json
+++ b/nolus/chain.json
@@ -142,7 +142,7 @@
   "apis": {
     "rpc": [
       {
-        "address": "rpc.nolus.network",
+        "address": "https://rpc.nolus.network",
         "provider": "NolusProtocol"
       },
       {
@@ -184,7 +184,7 @@
     ],
     "rest": [
       {
-        "address": "lcd.nolus.network",
+        "address": "https://lcd.nolus.network",
         "provider": "NolusProtocol"
       },
       {


### PR DESCRIPTION
The `NolusProtocol` RPC and REST entries are listed as bare hostnames without a URL scheme:

- `rpc` `rpc.nolus.network`
- `rest` `lcd.nolus.network`

A scheme-less address is not a usable absolute URL, so clients that construct requests via `new URL(address)` reject these entries. This change prefixes both with `https://` to match the rest of the list.

Verified both respond over HTTPS:

- `https://rpc.nolus.network/status` -> 200
- `https://lcd.nolus.network/cosmos/base/tendermint/v1beta1/node_info` -> 200

The `grpc` entry (`grpc.nolus.network`) is intentionally left unchanged, as gRPC addresses are conventionally `host:port` without an http scheme.