### PR TITLE
Add Snapshots for High Stakes

### DIFF
--- a/akash/chain.json
+++ b/akash/chain.json
@@ -393,5 +393,17 @@
       "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/akash/images/akt.png",
       "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/akash/images/akt.svg"
     }
-  ]
+  ],
+  "snapshots": [
+  {
+    "provider": "High Stakes 🇨🇭",
+    "url": "https://tools.highstakes.ch/snapshots/akash",
+    "latest_url": "https://tools.highstakes.ch/files/akash.tar.gz",
+    "type": "pruned",
+    "db_backend": "goleveldb",
+    "frequency": "every 3h",
+    "compression": "tar",
+    "checksum_available": true
+  }
+]
 }

--- a/bandchain/chain.json
+++ b/bandchain/chain.json
@@ -364,5 +364,16 @@
       "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/bandchain/images/band.png",
       "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/bandchain/images/band.svg"
     }
-  ]
+  ],
+  "snapshots": [
+  {
+    "provider": "High Stakes 🇨🇭",
+    "url": "https://tools.highstakes.ch/snapshots/bandprotocol",
+    "latest_url": "https://tools.highstakes.ch/files/bandprotocol.tar.gz",
+    "type": "pruned",
+    "db_backend": "goleveldb",
+    "frequency": "every 3h",
+    "compression": "tar",
+    "checksum_available": true
+  }
 }

--- a/bandchain/chain.json
+++ b/bandchain/chain.json
@@ -376,4 +376,5 @@
     "compression": "tar",
     "checksum_available": true
   }
+]   
 }

--- a/cosmoshub/chain.json
+++ b/cosmoshub/chain.json
@@ -765,5 +765,16 @@
       "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/cosmoshub/images/atom.png",
       "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/cosmoshub/images/atom.svg"
     }
-  ]
+  ],
+  "snapshots": [
+  {
+    "provider": "High Stakes 🇨🇭",
+    "url": "https://tools.highstakes.ch/snapshots/cosmos",
+    "latest_url": "https://tools.highstakes.ch/files/cosmos.tar.gz",
+    "type": "pruned",
+    "db_backend": "goleveldb",
+    "frequency": "every 3h",
+    "compression": "tar",
+    "checksum_available": true
+  }
 }

--- a/cosmoshub/chain.json
+++ b/cosmoshub/chain.json
@@ -777,4 +777,5 @@
     "compression": "tar",
     "checksum_available": true
   }
+  ]   
 }

--- a/fetchhub/chain.json
+++ b/fetchhub/chain.json
@@ -375,5 +375,17 @@
       "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/fetchhub/images/fet.png",
       "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/fetchhub/images/fet.svg"
     }
-  ]
+  ],
+   "snapshots": [
+  {
+    "provider": "High Stakes 🇨🇭",
+    "url": "https://tools.highstakes.ch/snapshots/fetchai",
+    "latest_url": "https://tools.highstakes.ch/files/fetchai.tar.gz",
+    "type": "pruned",
+    "db_backend": "goleveldb",
+    "frequency": "every 3h",
+    "compression": "tar",
+    "checksum_available": true
+  }
+]   
 }

--- a/injective/chain.json
+++ b/injective/chain.json
@@ -367,5 +367,27 @@
       "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/injective/images/inj.png",
       "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/injective/images/inj.svg"
     }
-  ]
+  ],
+  "snapshots": [
+  {
+    "provider": "High Stakes 🇨🇭",
+    "url": "https://tools.highstakes.ch/snapshots/injective",
+    "latest_url": "https://tools.highstakes.ch/files/injective.tar.gz",
+    "type": "pruned",
+    "db_backend": "goleveldb",
+    "frequency": "every 3h",
+    "compression": "tar",
+    "checksum_available": true
+  },
+   {
+    "provider": "High Stakes 🇨🇭",
+    "url": "https://tools.highstakes.ch/snapshots/injective",
+    "latest_url": "https://tools.highstakes.ch/files/injective_pebbledb.tar.gz",
+    "type": "pruned",
+    "db_backend": "pebbledb",
+    "frequency": "every 3h",
+    "compression": "tar",
+    "checksum_available": true
+  }  
+]   
 }

--- a/irisnet/chain.json
+++ b/irisnet/chain.json
@@ -264,4 +264,5 @@
     "compression": "tar",
     "checksum_available": true
   }
+]
 }

--- a/irisnet/chain.json
+++ b/irisnet/chain.json
@@ -253,5 +253,15 @@
       "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/irisnet/images/iris.png",
       "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/irisnet/images/iris.svg"
     }
-  ]
+  ],
+   {
+    "provider": "High Stakes 🇨🇭",
+    "url": "https://tools.highstakes.ch/snapshots/iris",
+    "latest_url": "https://tools.highstakes.ch/files/iris.tar.gz",
+    "type": "pruned",
+    "db_backend": "goleveldb",
+    "frequency": "every 3h",
+    "compression": "tar",
+    "checksum_available": true
+  }
 }

--- a/irisnet/chain.json
+++ b/irisnet/chain.json
@@ -254,6 +254,7 @@
       "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/irisnet/images/iris.svg"
     }
   ],
+  "snapshots": [
    {
     "provider": "High Stakes 🇨🇭",
     "url": "https://tools.highstakes.ch/snapshots/iris",

--- a/persistence/chain.json
+++ b/persistence/chain.json
@@ -455,5 +455,15 @@
       "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/persistence/images/xprt.png",
       "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/persistence/images/xprt.svg"
     }
-  ]
+  ],
+   {
+    "provider": "High Stakes 🇨🇭",
+    "url": "https://tools.highstakes.ch/snapshots/persistence",
+    "latest_url": "https://tools.highstakes.ch/files/persistence.tar.gz",
+    "type": "pruned",
+    "db_backend": "goleveldb",
+    "frequency": "every 3h",
+    "compression": "tar",
+    "checksum_available": true
+  }
 }

--- a/persistence/chain.json
+++ b/persistence/chain.json
@@ -456,6 +456,7 @@
       "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/persistence/images/xprt.svg"
     }
   ],
+  "snapshots": [
    {
     "provider": "High Stakes 🇨🇭",
     "url": "https://tools.highstakes.ch/snapshots/persistence",
@@ -466,4 +467,5 @@
     "compression": "tar",
     "checksum_available": true
   }
+  ]
 }

--- a/provenance/chain.json
+++ b/provenance/chain.json
@@ -317,6 +317,7 @@
       "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/provenance/images/prov.svg"
     }
   ],
+  "snapshots": [
    {
     "provider": "High Stakes 🇨🇭",
     "url": "https://tools.highstakes.ch/snapshots/provenance",
@@ -327,4 +328,5 @@
     "compression": "tar",
     "checksum_available": true
   }
+  ]
 }

--- a/provenance/chain.json
+++ b/provenance/chain.json
@@ -316,5 +316,15 @@
       "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/provenance/images/prov.png",
       "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/provenance/images/prov.svg"
     }
-  ]
+  ],
+   {
+    "provider": "High Stakes 🇨🇭",
+    "url": "https://tools.highstakes.ch/snapshots/provenance",
+    "latest_url": "https://tools.highstakes.ch/files/provenance_goleveldb.tar.gz",
+    "type": "pruned",
+    "db_backend": "goleveldb",
+    "frequency": "every 3h",
+    "compression": "tar",
+    "checksum_available": true
+  }
 }

--- a/terra2/chain.json
+++ b/terra2/chain.json
@@ -315,5 +315,15 @@
       "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/terra2/images/luna.png",
       "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/terra2/images/luna.svg"
     }
-  ]
+  ],
+   {
+    "provider": "High Stakes 🇨🇭",
+    "url": "https://tools.highstakes.ch/snapshots/terra",
+    "latest_url": "https://tools.highstakes.ch/files/terra.tar.gz",
+    "type": "pruned",
+    "db_backend": "goleveldb",
+    "frequency": "every 3h",
+    "compression": "tar",
+    "checksum_available": true
+  }
 }

--- a/terra2/chain.json
+++ b/terra2/chain.json
@@ -316,6 +316,7 @@
       "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/terra2/images/luna.svg"
     }
   ],
+  "snapshots": [
    {
     "provider": "High Stakes 🇨🇭",
     "url": "https://tools.highstakes.ch/snapshots/terra",
@@ -326,4 +327,5 @@
     "compression": "tar",
     "checksum_available": true
   }
+  ]   
 }


### PR DESCRIPTION
Here's the rest of the snapshots we generate.

A potentially important detail : for Injective, we provide two snapshots (pebble and golevel). So I have the two entries in the file, as I assume it's the right way to do it -- but let me know if not.