### PR TITLE
fix(stoc): correct testnet chain_id + align tx_page with EIP-3091

### DIFF
--- a/stoc/chain.json
+++ b/stoc/chain.json
@@ -106,7 +106,7 @@
     {
       "kind": "stochainscan",
       "url": "https://stochainscan.io/en",
-      "tx_page": "https://stochainscan.io/en/transaction/${txHash}",
+      "tx_page": "https://stochainscan.io/en/tx/${txHash}",
       "account_page": "https://stochainscan.io/en/address/${accountAddress}"
     }
   ],

--- a/testnets/tstoctestnet/chain.json
+++ b/testnets/tstoctestnet/chain.json
@@ -6,7 +6,7 @@
   "website": "https://www.stochain.io/",
   "pretty_name": "STO Chain Testnet",
   "chain_type": "cosmos",
-  "chain_id": "tstoc",
+  "chain_id": "tstoc_1999-1",
   "bech32_prefix": "stoc",
   "daemon_name": "stocd",
   "node_home": "$HOME/.stoc",
@@ -86,7 +86,7 @@
     {
       "kind": "stochainscan",
       "url": "https://stochainscan.io/en",
-      "tx_page": "https://stochainscan.io/en/transaction/${txHash}",
+      "tx_page": "https://stochainscan.io/en/tx/${txHash}",
       "account_page": "https://stochainscan.io/en/address/${accountAddress}"
     }
   ],


### PR DESCRIPTION
## Summary

Fixes two issues on the STO Chain entries:

1. **Testnet `chain_id` mismatch.** The STO Chain testnet was redeployed on 2026-06-09 with the full Evmos-style chain id (`<name>_<evm-id>-<rev>` = `tstoc_1999-1`) in its genesis, but `testnets/tstoctestnet/chain.json` still held the short form `tstoc`. Wallets, IBC relayers, and any tool that reads the registry and passes `chain_id=tstoc` to the live node get a `chain id mismatch` error on signing. Mainnet `stoc/chain.json` keeps `chain_id: "stoc"` because the mainnet genesis is the short form (unchanged).

2. **Explorer `tx_page` alignment with EIP-3091.** Both `stoc/chain.json` and `testnets/tstoctestnet/chain.json` point `tx_page` at `https://stochainscan.io/en/transaction/${txHash}`. The STOChain explorer ships `/tx/` as the canonical, EIP-3091-style path; `/transaction/` stays in place on our side as a backward-compatible alias so nothing breaks, but the registry should advertise the canonical path.

## Changes

- `testnets/tstoctestnet/chain.json`: `chain_id` → `tstoc_1999-1`, `tx_page` → `/tx/${txHash}`
- `stoc/chain.json`: `tx_page` → `/tx/${txHash}`

## Test plan

- [ ] Verify on-chain: `curl https://rpc-stoc-testnet.stochainscan.io/genesis | jq '.result.genesis.chain_id'` returns `"tstoc_1999-1"` (matches the registry value after this PR)
- [ ] Sign a tx on STO Chain testnet using a wallet that reads from chain-registry — succeeds (no `chain id mismatch`)
- [ ] Tap a STOChain tx link in any explorer/aggregator that consumes registry `tx_page` — opens `/en/tx/<hash>` successfully
- [ ] Mainnet `stoc/chain.json` `chain_id` left as `"stoc"` (intentional, matches mainnet genesis)