### PR TITLE
Remove High Stakes on Secret Network

### DIFF
--- a/secretnetwork/chain.json
+++ b/secretnetwork/chain.json
@@ -120,10 +120,6 @@
         "provider": "1RPC - Automata Network"
       },
       {
-        "address": "https://secretnetwork-rpc.highstakes.ch",
-        "provider": "High Stakes 🇨🇭"
-      },
-      {
         "address": "https://rpc.mainnet.secretsaturn.net",
         "provider": "🪐 𝕊ecret 𝕊aturn"
       },
@@ -148,10 +144,6 @@
       {
         "address": "https://1rpc.io/scrt-lcd",
         "provider": "1RPC - Automata Network"
-      },
-      {
-        "address": "https://secretnetwork-api.highstakes.ch",
-        "provider": "High Stakes 🇨🇭"
       },
       {
         "address": "https://lcd.mainnet.secretsaturn.net",


### PR DESCRIPTION
We just have the one node now, and the public rpc/api have been disabled a while ago. Forgot to remove them from here