### PR TITLE
Add missing Valopers explorers

### DIFF
--- a/babylon/chain.json
+++ b/babylon/chain.json
@@ -291,6 +291,12 @@
       "url": "https://explorer.nodeshub.online/babylon/",
       "tx_page": "https://explorer.nodeshub.online/babylon/tx/${txHash}",
       "account_page": "https://explorer.nodeshub.online/babylon/accounts/${accountAddress}"
+    },
+    {
+      "kind": "Valopers",
+      "url": "https://babylon.valopers.com/",
+      "tx_page": "https://babylon.valopers.com/transactions/${txHash}",
+      "account_page": "https://babylon.valopers.com/account/${accountAddress}"
     }
   ],
   "images": [

--- a/bandchain/chain.json
+++ b/bandchain/chain.json
@@ -357,6 +357,12 @@
       "kind": "kjnodes Explorer",
       "url": "https://explorer.kjnodes.com/band",
       "tx_page": "https://explorer.kjnodes.com/band/tx/${txHash}"
+    },
+    {
+      "kind": "Valopers",
+      "url": "https://band.valopers.com/",
+      "tx_page": "https://band.valopers.com/transactions/${txHash}",
+      "account_page": "https://band.valopers.com/account/${accountAddress}"
     }
   ],
   "images": [

--- a/neutron/chain.json
+++ b/neutron/chain.json
@@ -329,6 +329,12 @@
       "url": "https://validatorinfo.com/networks/neutron/overview",
       "validator_page": "https://validatorinfo.com/networks/neutron/validators",
       "proposal_page": "https://validatorinfo.com/networks/neutron/governance"
+    },
+    {
+      "kind": "Valopers",
+      "url": "https://neutron.valopers.com/",
+      "tx_page": "https://neutron.valopers.com/transactions/${txHash}",
+      "account_page": "https://neutron.valopers.com/account/${accountAddress}"
     }
   ],
   "images": [

--- a/noble/chain.json
+++ b/noble/chain.json
@@ -144,6 +144,12 @@
       "kind": "Stakeflow",
       "url": "https://stakeflow.io/noble",
       "account_page": "https://stakeflow.io/noble/accounts/${accountAddress}"
+    },
+    {
+      "kind": "Valopers",
+      "url": "https://noble.valopers.com/",
+      "tx_page": "https://noble.valopers.com/transactions/${txHash}",
+      "account_page": "https://noble.valopers.com/account/${accountAddress}"
     }
   ],
   "images": [

--- a/terra/chain.json
+++ b/terra/chain.json
@@ -339,6 +339,12 @@
       "url": "https://finder.terraport.finance/",
       "tx_page": "https://finder.terraport.finance/mainnet/tx/${txHash}",
       "account_page": "https://finder.terraport.finance/mainnet/address/${accountAddress}"
+    },
+    {
+      "kind": "Valopers",
+      "url": "https://terra-classic.valopers.com/",
+      "tx_page": "https://terra-classic.valopers.com/transactions/${txHash}",
+      "account_page": "https://terra-classic.valopers.com/account/${accountAddress}"
     }
   ],
   "images": [

--- a/terra2/chain.json
+++ b/terra2/chain.json
@@ -308,6 +308,12 @@
       "url": "https://explorer.onnode.org/terra",
       "tx_page": "https://explorer.onnode.org/terra/transactions/${txHash}",
       "account_page": "https://explorer.onnode.org/terra/accounts/${accountAddress}"
+    },
+    {
+      "kind": "Valopers",
+      "url": "https://terra.valopers.com/",
+      "tx_page": "https://terra.valopers.com/transactions/${txHash}",
+      "account_page": "https://terra.valopers.com/account/${accountAddress}"
     }
   ],
   "images": [

--- a/testnets/atomonetestnet/chain.json
+++ b/testnets/atomonetestnet/chain.json
@@ -165,6 +165,12 @@
       "url": "https://testnet.explorer.aviaone.com/atomone",
       "tx_page": "https://testnet.explorer.aviaone.com/atomone/tx/${txHash}",
       "account_page": "https://testnet.explorer.aviaone.com/atomone/account/${accountAddress}"
+    },
+    {
+      "kind": "Valopers",
+      "url": "https://testnet.atomone.valopers.com/",
+      "tx_page": "https://testnet.atomone.valopers.com/transactions/${txHash}",
+      "account_page": "https://testnet.atomone.valopers.com/account/${accountAddress}"
     }
   ],
   "images": [

--- a/testnets/axelartestnet/chain.json
+++ b/testnets/axelartestnet/chain.json
@@ -98,6 +98,12 @@
       "url": "https://mintscan.io/axelar-testnet",
       "tx_page": "https://mintscan.io/axelar-testnet/txs/${txHash}",
       "account_page": "https://mintscan.io/axelar-testnet/account/${accountAddress}"
+    },
+    {
+      "kind": "Valopers",
+      "url": "https://testnet.axelar.valopers.com/",
+      "tx_page": "https://testnet.axelar.valopers.com/transactions/${txHash}",
+      "account_page": "https://testnet.axelar.valopers.com/account/${accountAddress}"
     }
   ]
 }

--- a/testnets/junotestnet/chain.json
+++ b/testnets/junotestnet/chain.json
@@ -122,6 +122,12 @@
     {
       "kind": "Stake Hub by Kleomedes",
       "url": "https://www.stake-hub.xyz/junotestnet"
+    },
+    {
+      "kind": "Valopers",
+      "url": "https://testnet.juno.valopers.com/",
+      "tx_page": "https://testnet.juno.valopers.com/transactions/${txHash}",
+      "account_page": "https://testnet.juno.valopers.com/account/${accountAddress}"
     }
   ]
 }

--- a/testnets/osmosistestnet/chain.json
+++ b/testnets/osmosistestnet/chain.json
@@ -141,6 +141,12 @@
       "url": "https://explorer.osmotest5.osmosis.zone",
       "tx_page": "https://explorer.osmotest5.osmosis.zone/osmo-test-5/tx/${txHash}",
       "account_page": "https://explorer.osmotest5.osmosis.zone/osmo-test-5/account/${accountAddress}"
+    },
+    {
+      "kind": "Valopers",
+      "url": "https://testnet.osmosis.valopers.com/",
+      "tx_page": "https://testnet.osmosis.valopers.com/transactions/${txHash}",
+      "account_page": "https://testnet.osmosis.valopers.com/account/${accountAddress}"
     }
   ],
   "keywords": [

--- a/testnets/safrochaintestnet/chain.json
+++ b/testnets/safrochaintestnet/chain.json
@@ -70,6 +70,12 @@
       "kind": "bigdipper",
       "url": "https://explorer.testnet.safrochain.com",
       "tx_page": "https://explorer.testnet.safrochain.com/transactions/${txHash}"
+    },
+    {
+      "kind": "Valopers",
+      "url": "https://testnet.safrochain.valopers.com/",
+      "tx_page": "https://testnet.safrochain.valopers.com/transactions/${txHash}",
+      "account_page": "https://testnet.safrochain.valopers.com/account/${accountAddress}"
     }
   ],
   "logo_URIs": {

--- a/testnets/xrplevmtestnet/chain.json
+++ b/testnets/xrplevmtestnet/chain.json
@@ -398,6 +398,12 @@
       "url": "https://governance.testnet.xrplevm.org",
       "tx_page": "https://governance.testnet.xrplevm.org/xrplevm/transactions/${txHash}",
       "account_page": "https://governance.testnet.xrplevm.org/xrplevm/accounts/${accountAddress}"
+    },
+    {
+      "kind": "Valopers",
+      "url": "https://testnet.xrplevm.valopers.com/",
+      "tx_page": "https://testnet.xrplevm.valopers.com/transactions/${txHash}",
+      "account_page": "https://testnet.xrplevm.valopers.com/account/${accountAddress}"
     }
   ],
   "keywords": [

--- a/wolochain/chain.json
+++ b/wolochain/chain.json
@@ -80,6 +80,14 @@
       }
     ]
   },
+  "explorers": [
+    {
+      "kind": "Valopers",
+      "url": "https://wolochain.valopers.com/",
+      "tx_page": "https://wolochain.valopers.com/transactions/${txHash}",
+      "account_page": "https://wolochain.valopers.com/account/${accountAddress}"
+    }
+  ],
   "images": [
     {
       "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/wolochain/images/wolo.png",

--- a/xrplevm/chain.json
+++ b/xrplevm/chain.json
@@ -144,6 +144,12 @@
       "url": "https://governance.xrplevm.org",
       "tx_page": "https://governance.xrplevm.org/xrplevm/transactions/${txHash}",
       "account_page": "https://governance.xrplevm.org/xrplevm/accounts/${accountAddress}"
+    },
+    {
+      "kind": "Valopers",
+      "url": "https://xrplevm.valopers.com/",
+      "tx_page": "https://xrplevm.valopers.com/transactions/${txHash}",
+      "account_page": "https://xrplevm.valopers.com/account/${accountAddress}"
     }
   ],
   "keywords": [


### PR DESCRIPTION
## Summary

Adds Valopers explorer entries to existing chain-registry `chain.json` files for Valopers chains that were already present in the registry but did not yet list our explorer.

Included chain IDs:

- `atomone-testnet-1`
- `axelar-testnet-lisbon-3`
- `bbn-1`
- `laozi-mainnet`
- `neutron-1`
- `noble-1`
- `uni-7`
- `osmo-test-5`
- `safro-testnet-1`
- `phoenix-1`
- `columbus-5`
- `xrplevm_1440000-1`
- `xrplevm_1449000-1`
- `wolo-1`

No new chain entries were added. Chains from the Valopers list that are not present in chain-registry by the same `chain_id` are intentionally left out for separate manual handling.

## Verification

- `jq empty` on all edited `chain.json` files
- `git diff --check`
- `npx -y @chain-registry/cli@1.47.0 validate --registryDir . --logLevel error`
- `npx eslint ./`
- `node validate_data.mjs NO_API` from `.github/workflows/utility`

## Manual review checklist

- Confirm each Valopers URL resolves to the expected explorer.
- Confirm transaction and account page templates match the current Valopers routes.
- Confirm the intentionally omitted chains should remain out of this PR.
