### PR TITLE
fix(kava): remove dead RPC/REST/gRPC endpoints (4 providers)

### DIFF
--- a/kava/chain.json
+++ b/kava/chain.json
@@ -102,28 +102,12 @@
         "provider": "Polkachu"
       },
       {
-        "address": "https://rpc-kava-ia.cosmosia.notional.ventures/",
-        "provider": "Notional"
-      },
-      {
         "address": "https://kava-mainnet-rpc.autostake.com:443",
         "provider": "AutoStake 🛡️ Slash Protected"
       },
       {
-        "address": "https://kava.ibs.team:443/rpc",
-        "provider": "Inter Blockchain Services"
-      },
-      {
-        "address": "https://rpc-kava-01.stakeflow.io",
-        "provider": "Stakeflow"
-      },
-      {
         "address": "https://kava-rpc.publicnode.com:443",
         "provider": "Allnodes ⚡️ Nodes & Staking"
-      },
-      {
-        "address": "https://kava.drpc.org",
-        "provider": "dRPC"
       },
       {
         "address": "https://rpc.kava.nodestake.org",
@@ -140,24 +124,12 @@
         "provider": "kava"
       },
       {
-        "address": "https://api-kava-ia.cosmosia.notional.ventures/",
-        "provider": "Notional"
-      },
-      {
         "address": "https://kava-api.polkachu.com",
         "provider": "Polkachu"
       },
       {
         "address": "https://kava-mainnet-lcd.autostake.com:443",
         "provider": "AutoStake 🛡️ Slash Protected"
-      },
-      {
-        "address": "https://kava.ibs.team:443/api",
-        "provider": "Inter Blockchain Services"
-      },
-      {
-        "address": "https://api-kava-01.stakeflow.io",
-        "provider": "Stakeflow"
       },
       {
         "address": "https://kava-rest.publicnode.com",
@@ -178,20 +150,12 @@
         "provider": "kava"
       },
       {
-        "address": "grpc-kava-ia.cosmosia.notional.ventures:443",
-        "provider": "Notional"
-      },
-      {
         "address": "kava-grpc.polkachu.com:13990",
         "provider": "Polkachu"
       },
       {
         "address": "kava-mainnet-grpc.autostake.com:443",
         "provider": "AutoStake 🛡️ Slash Protected"
-      },
-      {
-        "address": "grpc-kava-01.stakeflow.io:1202",
-        "provider": "Stakeflow"
       },
       {
         "address": "kava-grpc.publicnode.com:443",


### PR DESCRIPTION
Removes 9 unreachable Kava (`kava_2222-10`) endpoint entries across 4 providers. Each was probed against the Cosmos RPC `/status`, REST `node_info`, and gRPC reflection, and cross-checked against the same provider on other chains to confirm the failure is real and not a transient/path issue.

### Removed

| Provider | Endpoints | Failure | Notes |
|---|---|---|---|
| **Notional** | rpc, rest, grpc | DNS **NXDOMAIN** | `*.cosmosia.notional.ventures` no longer resolves on any chain (cosmos/osmosis/akash/juno all NXDOMAIN) |
| **Stakeflow** | rpc, rest, grpc | DNS **NXDOMAIN** | `*-kava-01.stakeflow.io` no longer resolves; same on cosmos/osmosis/celestia/injective |
| **Inter Blockchain Services** | rpc, rest | persistent **HTTP 502** | `kava.ibs.team` resolves but origin returns 502 on repeated tests; IBS is healthy on other chains (cosmos/osmosis 200), so this is Kava-specific |
| **dRPC** | rpc | **HTTP 404** | `kava.drpc.org` 404 while `cosmos.drpc.org`/`akash.drpc.org` return 200 — Kava was dropped |

### Retained (verified healthy)
RPC/REST: kava.io, Polkachu, Allnodes (publicnode), NodeStake, Pocket Network. All 4 EVM JSON-RPC endpoints return `eth_chainId = 0x8ae` (2222). Polkachu/NodeStake gRPC confirmed reachable (TCP open).

### Intentionally NOT removed
**AutoStake** (rpc/rest/grpc) returns HTTP 404 — but it returns 404 on **every** chain tested (cosmos/osmosis/akash/celestia), so this looks like a provider-wide config change rather than a Kava outage. Removing it from Kava alone would be inconsistent; better handled by a registry-wide review.

Scope kept to a single chain per convention. No other files touched.
