### PR TITLE
fix(cosmoshub): remove dead RPC/REST/gRPC endpoints (13 providers)

### DIFF
--- a/cosmoshub/chain.json
+++ b/cosmoshub/chain.json
@@ -206,14 +206,6 @@
         "provider": "Chainlayer"
       },
       {
-        "address": "https://cosmos-rpc.onivalidator.com",
-        "provider": "Oni Validator ⛩️"
-      },
-      {
-        "address": "https://rpc-cosmoshub.whispernode.com:443",
-        "provider": "WhisperNode 🤐"
-      },
-      {
         "address": "https://rpc.lavenderfive.com:443/cosmoshub",
         "provider": "Lavender.Five Nodes 🐝"
       },
@@ -226,14 +218,6 @@
         "provider": "GetBlock RPC Nodes"
       },
       {
-        "address": "https://rpc-cosmoshub.pupmos.network",
-        "provider": "PUPMØS"
-      },
-      {
-        "address": "https://rpc-cosmoshub.cosmos-spaces.cloud",
-        "provider": "Cosmos Spaces"
-      },
-      {
         "address": "https://cosmos-rpc.polkachu.com",
         "provider": "Polkachu"
       },
@@ -242,24 +226,12 @@
         "provider": "Staketab"
       },
       {
-        "address": "https://rpc-cosmoshub-ia.cosmosia.notional.ventures/",
-        "provider": "Notional"
-      },
-      {
-        "address": "https://rpc-cosmoshub.architectnodes.com",
-        "provider": "Architect Nodes"
-      },
-      {
         "address": "https://rpc.cosmos.dragonstake.io",
         "provider": "DragonStake"
       },
       {
         "address": "https://cosmoshub.rpc.stakin-nodes.com",
         "provider": "Stakin"
-      },
-      {
-        "address": "https://rpc.cosmos.bh.rocks",
-        "provider": "BlockHunters 🎯"
       },
       {
         "address": "https://cosmos-rpc.rockrpc.net",
@@ -278,10 +250,6 @@
         "provider": "NodeStake"
       },
       {
-        "address": "https://cosmos.rpc.silknodes.io",
-        "provider": "Silk Nodes"
-      },
-      {
         "address": "https://cosmos-rpc.publicnode.com:443",
         "provider": "Allnodes ⚡️ Nodes & Staking"
       },
@@ -294,16 +262,8 @@
         "provider": "Golden Ratio Staking"
       },
       {
-        "address": "https://rpc-cosmos-hub-01.stakeflow.io",
-        "provider": "Stakeflow"
-      },
-      {
         "address": "https://cosmos-rpc.w3coins.io",
         "provider": "w3coins"
-      },
-      {
-        "address": "https://rpc-cosmoshub.mms.team",
-        "provider": "MMS"
       },
       {
         "address": "https://community.nuxian-node.ch:6797/gaia/trpc",
@@ -324,10 +284,6 @@
       {
         "address": "https://public.stakewolle.com/cosmos/cosmoshub/rpc",
         "provider": "Stakewolle"
-      },
-      {
-        "address": "https://rpc-cosmos.kewrnode.com",
-        "provider": "Kewr Node"
       },
       {
         "address": "https://rpc.cosmoshub-4.citizenweb3.com",
@@ -385,18 +341,6 @@
         "provider": "Lavender.Five Nodes 🐝"
       },
       {
-        "address": "https://api-cosmoshub.pupmos.network",
-        "provider": "PUPMØS"
-      },
-      {
-        "address": "https://api-cosmoshub.cosmos-spaces.cloud",
-        "provider": "Cosmos Spaces"
-      },
-      {
-        "address": "https://api-cosmoshub-ia.cosmosia.notional.ventures/",
-        "provider": "Notional"
-      },
-      {
         "address": "https://cosmos-rest.staketab.org",
         "provider": "Staketab"
       },
@@ -409,16 +353,8 @@
         "provider": "Stakin"
       },
       {
-        "address": "https://rest-cosmoshub.architectnodes.com",
-        "provider": "Architect Nodes"
-      },
-      {
         "address": "https://rest-cosmoshub.ecostake.com",
         "provider": "ecostake"
-      },
-      {
-        "address": "https://lcd-cosmoshub.whispernode.com:443",
-        "provider": "WhisperNode 🤐"
       },
       {
         "address": "https://cosmos-lcd.easy2stake.com",
@@ -441,16 +377,8 @@
         "provider": "kjnodes"
       },
       {
-        "address": "https://api-cosmos-hub-01.stakeflow.io",
-        "provider": "Stakeflow"
-      },
-      {
         "address": "https://cosmos-api.w3coins.io",
         "provider": "w3coins"
-      },
-      {
-        "address": "https://api-cosmoshub.mms.team",
-        "provider": "MMS"
       },
       {
         "address": "https://community.nuxian-node.ch:6797/gaia/crpc",
@@ -471,10 +399,6 @@
       {
         "address": "https://public.stakewolle.com/cosmos/cosmoshub/rest",
         "provider": "Stakewolle"
-      },
-      {
-        "address": "https://rest-cosmos.kewrnode.com",
-        "provider": "Kewr Node"
       },
       {
         "address": "https://cosmos-api.stakeandrelax.net",
@@ -520,20 +444,12 @@
         "provider": "Lavender.Five Nodes 🐝"
       },
       {
-        "address": "grpc-cosmoshub-ia.cosmosia.notional.ventures:443",
-        "provider": "Notional"
-      },
-      {
         "address": "cosmos-grpc.polkachu.com:14990",
         "provider": "Polkachu"
       },
       {
         "address": "grpc.cosmos.interbloc.org:443",
         "provider": "Interbloc"
-      },
-      {
-        "address": "services.staketab.com:9030",
-        "provider": "Staketab"
       },
       {
         "address": "grpc.cosmos.dragonstake.io:443",
@@ -552,36 +468,16 @@
         "provider": "Allnodes ⚡️ Nodes & Staking"
       },
       {
-        "address": "grpc-cosmoshub.cosmos-spaces.cloud:3910",
-        "provider": "Cosmos Spaces"
-      },
-      {
         "address": "cosmoshub.grpc.kjnodes.com:11390",
         "provider": "kjnodes"
-      },
-      {
-        "address": "grpc-cosmos-hub-01.stakeflow.io:9090",
-        "provider": "Stakeflow"
-      },
-      {
-        "address": "grpc-cosmoshub.whispernode.com:443",
-        "provider": "WhisperNode 🤐"
       },
       {
         "address": "cosmos-grpc.w3coins.io:14990",
         "provider": "w3coins"
       },
       {
-        "address": "grpc-cosmoshub.mms.team:443",
-        "provider": "MMS"
-      },
-      {
         "address": "cosmoshub-mainnet.grpc.l0vd.com:80",
         "provider": "L0vd.com ❤️"
-      },
-      {
-        "address": "https://grpc-cosmos.nodeist.net",
-        "provider": "Nodeist"
       },
       {
         "address": "cosmos-grpc.stakeandrelax.net:15090",


### PR DESCRIPTION
Removes 26 unreachable Cosmos Hub (`cosmoshub-4`) endpoint entries across 13 providers. **Scope is intentionally limited to hostnames that fail DNS resolution (NXDOMAIN)** — i.e. definitively decommissioned. Endpoints returning HTTP errors (502/523/404) or transient/TLS failures were deliberately left in place pending verification from a clean network, to avoid false positives.

### Removed — all NXDOMAIN (DNS no longer resolves)

| Provider | rpc | rest | grpc |
|---|:--:|:--:|:--:|
| Notional | ✓ | ✓ | ✓ |
| WhisperNode | ✓ | ✓ | ✓ |
| Cosmos Spaces | ✓ | ✓ | ✓ |
| Stakeflow | ✓ | ✓ | ✓ |
| MMS | ✓ | ✓ | ✓ |
| PUPMØS | ✓ | ✓ | |
| Architect Nodes | ✓ | ✓ | |
| Kewr Node | ✓ | ✓ | |
| Oni Validator | ✓ | | |
| BlockHunters | ✓ | | |
| Silk Nodes | ✓ | | |
| Staketab | | | ✓ |
| Nodeist | | | ✓ |

Totals: RPC −11, REST −8, gRPC −7 = **26 entries**. Each hostname was confirmed NXDOMAIN via DNS lookup; providers whose RPC/REST hosts still resolve (e.g. Staketab, Silk Nodes REST) were left untouched and only their NXDOMAIN host removed.

Healthy endpoints (Polkachu, Allnodes/publicnode, kjnodes, Lava, Pocket Network, etc.) are retained. No other files touched.
