### PR TITLE
fix(axelar): remove dead RPC/REST/gRPC endpoints (8 providers)

### DIFF
--- a/axelar/chain.json
+++ b/axelar/chain.json
@@ -141,12 +141,6 @@
     ]
   },
   "apis": {
-    "grpc-web": [
-      {
-        "address": "axelar-grpcweb.chainode.tech",
-        "provider": "Chainode"
-      }
-    ],
     "rpc": [
       {
         "address": "https://rpc-axelar.imperator.co:443",
@@ -155,10 +149,6 @@
       {
         "address": "https://axelar-rpc.quickapi.com:443",
         "provider": "chainlayer"
-      },
-      {
-        "address": "https://rpc-axelar.cosmos-spaces.cloud",
-        "provider": "Cosmos Spaces"
       },
       {
         "address": "https://axelar-rpc.pops.one:443",
@@ -173,28 +163,12 @@
         "provider": "nodes.guru"
       },
       {
-        "address": "https://rpc-axelar-ia.cosmosia.notional.ventures/",
-        "provider": "Notional"
-      },
-      {
         "address": "https://axelar-rpc.polkachu.com",
         "provider": "Polkachu"
       },
       {
         "address": "https://axelar.rpc.stakin-nodes.com",
         "provider": "Stakin"
-      },
-      {
-        "address": "https://rpc.axelar.bh.rocks",
-        "provider": "BlockHunters 🎯"
-      },
-      {
-        "address": "https://axelar-rpc.validatrium.club",
-        "provider": "Validatrium"
-      },
-      {
-        "address": "https://rpc-axelar.whispernode.com:443",
-        "provider": "WhisperNode 🤐"
       },
       {
         "address": "https://axelar.rpc.quantnode.xyz/",
@@ -213,16 +187,8 @@
         "provider": "Inter Blockchain Services"
       },
       {
-        "address": "https://rpc-axelar-01.stakeflow.io",
-        "provider": "Stakeflow"
-      },
-      {
         "address": "https://axelar-rpc.staketab.org:443",
         "provider": "Staketab"
-      },
-      {
-        "address": "https://axelar-rpc.w3coins.io",
-        "provider": "w3coins"
       },
       {
         "address": "https://axelar-rpc.publicnode.com:443",
@@ -243,10 +209,6 @@
         "provider": "chainlayer"
       },
       {
-        "address": "https://api-axelar.cosmos-spaces.cloud",
-        "provider": "Cosmos Spaces"
-      },
-      {
         "address": "https://axelar-lcd.qubelabs.io:443",
         "provider": "Qubelabs"
       },
@@ -255,28 +217,12 @@
         "provider": "nodes.guru"
       },
       {
-        "address": "https://api-axelar-ia.cosmosia.notional.ventures/",
-        "provider": "Notional"
-      },
-      {
         "address": "https://axelar-api.polkachu.com",
         "provider": "Polkachu"
       },
       {
         "address": "https://axelar.rest.stakin-nodes.com",
         "provider": "Stakin"
-      },
-      {
-        "address": "https://api.axelar.bh.rocks",
-        "provider": "BlockHunters 🎯"
-      },
-      {
-        "address": "https://axelar-api.validatrium.club",
-        "provider": "Validatrium"
-      },
-      {
-        "address": "https://lcd-axelar.whispernode.com:443",
-        "provider": "WhisperNode 🤐"
       },
       {
         "address": "https://axelar-mainnet-lcd.autostake.com:443",
@@ -291,16 +237,8 @@
         "provider": "Inter Blockchain Services"
       },
       {
-        "address": "https://api-axelar-01.stakeflow.io",
-        "provider": "Stakeflow"
-      },
-      {
         "address": "https://axelar-rest.staketab.org",
         "provider": "Staketab"
-      },
-      {
-        "address": "https://axelar-api.w3coins.io",
-        "provider": "w3coins"
       },
       {
         "address": "https://axelar-rest.publicnode.com",
@@ -317,18 +255,6 @@
         "provider": "Quantnode"
       },
       {
-        "address": "services.staketab.com:9080",
-        "provider": "Staketab"
-      },
-      {
-        "address": "grpc-axelar.cosmos-spaces.cloud:1590",
-        "provider": "Cosmos Spaces"
-      },
-      {
-        "address": "grpc-axelar-ia.cosmosia.notional.ventures:443",
-        "provider": "Notional"
-      },
-      {
         "address": "axelar-grpc.polkachu.com:15190",
         "provider": "Polkachu"
       },
@@ -339,18 +265,6 @@
       {
         "address": "axelar-mainnet-grpc.autostake.com:443",
         "provider": "AutoStake 🛡️ Slash Protected"
-      },
-      {
-        "address": "grpc-axelar-01.stakeflow.io:1602",
-        "provider": "Stakeflow"
-      },
-      {
-        "address": "axelar-grpc.w3coins.io:15190",
-        "provider": "w3coins"
-      },
-      {
-        "address": "grpc-axelar.whispernode.com:443",
-        "provider": "WhisperNode 🤐"
       },
       {
         "address": "axelar-grpc.publicnode.com:443",


### PR DESCRIPTION
## Remove dead Axelar endpoints

Removing 21 endpoints whose hostnames no longer resolve (DNS **NXDOMAIN**), verified 2026-06-17. Scope is intentionally conservative — **DNS-dead endpoints only**.

| Provider | RPC | REST | gRPC | Note |
|---|:--:|:--:|:--:|---|
| Cosmos Spaces | ✓ | ✓ | ✓ | provider fully wound down (root domain dead) |
| Notional | ✓ | ✓ | ✓ | provider fully wound down (root domain dead) |
| BlockHunters | ✓ | ✓ | — | provider fully wound down (root domain dead) |
| Validatrium | ✓ | ✓ | — | hosts decommissioned |
| WhisperNode | ✓ | ✓ | ✓ | hosts decommissioned |
| Stakeflow | ✓ | ✓ | ✓ | hosts decommissioned |
| w3coins | ✓ | ✓ | ✓ | hosts decommissioned |
| Staketab | — | — | ✓ | only gRPC `services.staketab.com` dead; RPC/REST kept (live) |
| Chainode | — | — | — | gRPC-web sole entry dead → empty `grpc-web` key removed |

**Result:** RPC 21→14, REST 18→11, gRPC 12→6, gRPC-web removed.

### Verification
- Every removed hostname returns no DNS record (`getent hosts` empty).
- Cosmos Spaces / Notional / BlockHunters: entire provider infra gone (root domains also NXDOMAIN).
- Validatrium / WhisperNode / Stakeflow / w3coins / Staketab / Chainode: provider root domains still resolve, but these specific Axelar hosts are decommissioned.
- All resolving endpoints were left untouched; remaining endpoints serve valid `axelar-dojo-1` data.
