### PR TITLE
fix(neutron): remove dead RPC/REST/gRPC endpoints (3 providers)

### DIFF
--- a/neutron/chain.json
+++ b/neutron/chain.json
@@ -157,14 +157,6 @@
         "provider": "Lavender.Five Nodes 🐝"
       },
       {
-        "address": "https://rpc-neutron.whispernode.com",
-        "provider": "WhisperNode 🤐"
-      },
-      {
-        "address": "https://rpc-neutron.cosmos-spaces.cloud",
-        "provider": "Cosmos Spaces"
-      },
-      {
         "address": "https://neutron-rpc.publicnode.com:443",
         "provider": "Allnodes ⚡️ Nodes & Staking"
       },
@@ -215,14 +207,6 @@
         "provider": "Lavender.Five Nodes 🐝"
       },
       {
-        "address": "https://lcd-neutron.whispernode.com",
-        "provider": "WhisperNode 🤐"
-      },
-      {
-        "address": "https://api-neutron.cosmos-spaces.cloud",
-        "provider": "Cosmos Spaces"
-      },
-      {
         "address": "https://neutron-rest.publicnode.com",
         "provider": "Allnodes ⚡️ Nodes & Staking"
       },
@@ -249,20 +233,8 @@
         "provider": "Neutron"
       },
       {
-        "address": "neutron-grpc-pub.rpc.p2p.world:3001",
-        "provider": "P2P"
-      },
-      {
         "address": "neutron.lavenderfive.com:443",
         "provider": "Lavender.Five Nodes 🐝"
-      },
-      {
-        "address": "grpc-neutron.whispernode.com:443",
-        "provider": "WhisperNode 🤐"
-      },
-      {
-        "address": "grpc-neutron.cosmos-spaces.cloud:3090",
-        "provider": "Cosmos Spaces"
       },
       {
         "address": "neutron-grpc.publicnode.com:443",


### PR DESCRIPTION
## Summary

Removes 7 dead endpoints on `neutron-1` across 3 providers. Every removed host returns **NXDOMAIN** (DNS no longer resolves) — the highest-confidence failure mode. Verified over 3 resolution rounds with live-host calibration (PublicNode / Lavender.Five / Quokka Stake resolved fine in the same rounds, ruling out resolver flicker).

## Removed

| Provider | Type | Address |
|---|---|---|
| WhisperNode 🤐 | RPC | `https://rpc-neutron.whispernode.com` |
| WhisperNode 🤐 | REST | `https://lcd-neutron.whispernode.com` |
| WhisperNode 🤐 | gRPC | `grpc-neutron.whispernode.com:443` |
| Cosmos Spaces | RPC | `https://rpc-neutron.cosmos-spaces.cloud` |
| Cosmos Spaces | REST | `https://api-neutron.cosmos-spaces.cloud` |
| Cosmos Spaces | gRPC | `grpc-neutron.cosmos-spaces.cloud:3090` |
| P2P | gRPC | `neutron-grpc-pub.rpc.p2p.world:3001` |

## Notes
- **Cosmos Spaces** appears fully wound down — its root domain `cosmos-spaces.cloud` is also NXDOMAIN.
- **WhisperNode**'s per-chain `*-neutron.whispernode.com` hosts are gone (its root domain still resolves).
- **P2P** keeps its RPC/REST (`*.novel.remedy.tm.p2p.org` still resolve); only the separate gRPC host is removed.
- All surviving endpoints were confirmed serving `neutron-1`.

Scope intentionally limited to NXDOMAIN-only for a clean, low-risk diff.
