### PR TITLE
chore: mark sunset chains as killed

### DIFF
--- a/dhealth/chain.json
+++ b/dhealth/chain.json
@@ -1,7 +1,7 @@
 {
   "$schema": "../chain.schema.json",
   "chain_name": "dhealth",
-  "status": "live",
+  "status": "killed",
   "network_type": "mainnet",
   "website": "https://dhealth.com/",
   "pretty_name": "dHealth",

--- a/fxcore/chain.json
+++ b/fxcore/chain.json
@@ -5,7 +5,7 @@
   "chain_id": "fxcore",
   "website": "https://fx.pundi.ai",
   "pretty_name": "Pundi AIFX",
-  "status": "live",
+  "status": "killed",
   "network_type": "mainnet",
   "bech32_prefix": "fx",
   "daemon_name": "fxcored",

--- a/lambda/chain.json
+++ b/lambda/chain.json
@@ -1,7 +1,7 @@
 {
   "$schema": "../chain.schema.json",
   "chain_name": "lambda",
-  "status": "live",
+  "status": "killed",
   "network_type": "mainnet",
   "pretty_name": "Lambda",
   "chain_type": "cosmos",

--- a/milkyway/chain.json
+++ b/milkyway/chain.json
@@ -1,7 +1,7 @@
 {
   "$schema": "../chain.schema.json",
   "chain_name": "milkyway",
-  "status": "live",
+  "status": "killed",
   "network_type": "mainnet",
   "website": "https://milkyway.zone/",
   "pretty_name": "MilkyWay",

--- a/omniflixhub/chain.json
+++ b/omniflixhub/chain.json
@@ -1,7 +1,7 @@
 {
   "$schema": "../chain.schema.json",
   "chain_name": "omniflixhub",
-  "status": "live",
+  "status": "killed",
   "network_type": "mainnet",
   "website": "https://omniflix.network/",
   "pretty_name": "OmniFlix",

--- a/onex/chain.json
+++ b/onex/chain.json
@@ -1,7 +1,7 @@
 {
   "$schema": "../chain.schema.json",
   "chain_name": "onex",
-  "status": "live",
+  "status": "killed",
   "website": "https://app.onomy.io/",
   "network_type": "mainnet",
   "pretty_name": "ONEX",

--- a/onomy/chain.json
+++ b/onomy/chain.json
@@ -1,7 +1,7 @@
 {
   "$schema": "../chain.schema.json",
   "chain_name": "onomy",
-  "status": "live",
+  "status": "killed",
   "network_type": "mainnet",
   "website": "https://onomy.io/",
   "pretty_name": "Onomy",

--- a/routerchain/chain.json
+++ b/routerchain/chain.json
@@ -4,7 +4,7 @@
   "chain_type": "cosmos",
   "chain_id": "router_9600-1",
   "pretty_name": "Router Protocol",
-  "status": "live",
+  "status": "killed",
   "network_type": "mainnet",
   "website": "https://www.routerprotocol.com/",
   "bech32_prefix": "router",


### PR DESCRIPTION
Marks eight chains as `status: killed`. Each has publicly announced a shutdown / migration off its Cosmos chain, and all RPC/REST endpoints registered in this repo are unreachable (verified June 2026 — no endpoint returns a current block).

| Chain | Reference |
|-------|-----------|
| onomy | https://x.com/OnomyProtocol/status/1921962201138483461 (operations sunset, validators halted) |
| onex | Onomy consumer chain; shut down with Onomy — https://x.com/OnomyProtocol/status/1921962201138483461 |
| routerchain | https://routerprotocol.medium.com/proposal-to-sunset-router-chain-55ea9fd0e799 (governance sunset; ROUTE migrated to Ethereum) |
| fxcore | https://pundiscan.io/fxcore/proposals/76 (ceased operations 1 March 2026; migrated to Ethereum) |
| dhealth | https://www.dhealth.com/post/bridge-open-migrate-to-solana-native-dhp (sunset by governance; migrated to Solana; bridge closed 2026-04-11) |
| omniflixhub | https://paragraph.com/@flix/flix-to-fun-transformation-window-extended-to-jan-20th (migrated Cosmos to Base; FLIX to FUN) |
| lambda | https://docs.lambda.im/token-distribution/migrate-lamb-lambda (discontinued; migrated to an Ethereum L2) |
| milkyway | https://x.com/milky_way_zone/status/2011770175566332325 (chain permanently wound down; assets returned to origin chains) |

Status-only change; no other fields touched.