### PR TITLE
chore: mark unreachable chains as killed

### DIFF
--- a/nillion/chain.json
+++ b/nillion/chain.json
@@ -1,7 +1,7 @@
 {
   "$schema": "../chain.schema.json",
   "chain_name": "nillion",
-  "status": "live",
+  "status": "killed",
   "network_type": "mainnet",
   "pretty_name": "Nillion",
   "chain_type": "cosmos",

--- a/starname/chain.json
+++ b/starname/chain.json
@@ -1,7 +1,7 @@
 {
   "$schema": "../chain.schema.json",
   "chain_name": "starname",
-  "status": "live",
+  "status": "killed",
   "network_type": "mainnet",
   "website": "https://www.starname.me/",
   "pretty_name": "Starname",

--- a/tgrade/chain.json
+++ b/tgrade/chain.json
@@ -1,7 +1,7 @@
 {
   "$schema": "../chain.schema.json",
   "chain_name": "tgrade",
-  "status": "live",
+  "status": "killed",
   "network_type": "mainnet",
   "website": "https://tgrade.finance/",
   "pretty_name": "Tgrade",


### PR DESCRIPTION
Marks three chains as `status: killed`. These are no longer producing blocks: every RPC and REST endpoint registered in this repo is unreachable (verified June 2026 — none returns a current block). No active endpoint or explorer could be found.

| Chain | Notes |
|-------|-------|
| nillion | NilChain halted ~23 March 2026; all registered endpoints unreachable |
| starname | Starname (IOV); long defunct, no longer producing blocks; all registered endpoints unreachable |
| tgrade | Stopped producing blocks and no longer maintained; all registered endpoints unreachable |

Status-only change; no other fields touched. Happy to add further references or split per chain if maintainers prefer.