### PR TITLE
feat(osmosis): add snapshot information

### DIFF
--- a/osmosis/chain.json
+++ b/osmosis/chain.json
@@ -872,6 +872,18 @@
       }
     ]
   },
+  "snapshots": [
+    {
+      "provider": "Osmosis",
+      "url": "https://snapshots.osmosis.zone",
+      "latest_url": "https://snapshots.osmosis.zone/latest",
+      "type": "pruned",
+      "db_backend": "goleveldb",
+      "frequency": "every 2h",
+      "compression": "lz4",
+      "checksum_available": true
+    }
+  ],
   "explorers": [
     {
       "kind": "ezstaking",


### PR DESCRIPTION
Adds the official Osmosis pruned snapshot service to `osmosis/chain.json`, using the top-level `snapshots` field.

| Field | Value | Notes |
|-------|-------|-------|
| provider | Osmosis | Official, first-party |
| url | https://snapshots.osmosis.zone | Snapshot landing/info page |
| latest_url | https://snapshots.osmosis.zone/latest | Stable redirector to the current `.tar.lz4` |
| type | pruned | |
| db_backend | goleveldb | |
| frequency | every 2h | |
| compression | lz4 | Served as `application/x-lz4` |
| checksum_available | true | MD5 exposed via the object's `x-amz-meta-md5chksum` header |

Follows the existing convention (e.g. akash) of `url` = info page, `latest_url` = direct download. Status-only addition; no other fields changed.