### PR TITLE
fix(dydx): remove dead RPC/REST/gRPC endpoints (4 providers)

### DIFF
--- a/dydx/chain.json
+++ b/dydx/chain.json
@@ -161,10 +161,6 @@
         "provider": "Polkachu"
       },
       {
-        "address": "https://dydx-mainnet-full-rpc.public.blastapi.io",
-        "provider": "Bware Labs"
-      },
-      {
         "address": "https://rpc.lavenderfive.com:443/dydx",
         "provider": "Lavender.Five Nodes 🐝"
       },
@@ -173,16 +169,8 @@
         "provider": "AutoStake 🛡️ Slash Protected"
       },
       {
-        "address": "https://rpc-dydx.cosmos-spaces.cloud",
-        "provider": "Cosmos Spaces"
-      },
-      {
         "address": "https://dydx-rpc.publicnode.com:443",
         "provider": "Allnodes ⚡️ Nodes & Staking"
-      },
-      {
-        "address": "https://rpc-dydx.cros-nest.com:443",
-        "provider": "Crosnest"
       },
       {
         "address": "https://dydx-rpc.enigma-validator.com",
@@ -195,10 +183,6 @@
       {
         "address": "https://dydx-rpc.noders.services",
         "provider": "[NODERS]TEAM"
-      },
-      {
-        "address": "https://dydx.interstellar-lounge.org",
-        "provider": "Interstellar Lounge 🍸"
       }
     ],
     "rest": [
@@ -209,10 +193,6 @@
       {
         "address": "https://dydx-dao-api.polkachu.com",
         "provider": "Polkachu"
-      },
-      {
-        "address": "https://dydx-mainnet-full-lcd.public.blastapi.io",
-        "provider": "Bware Labs"
       },
       {
         "address": "https://dydx-rest.kingnodes.com:443",
@@ -227,16 +207,8 @@
         "provider": "AutoStake 🛡️ Slash Protected"
       },
       {
-        "address": "https://api-dydx.cosmos-spaces.cloud",
-        "provider": "Cosmos Spaces"
-      },
-      {
         "address": "https://dydx-rest.publicnode.com",
         "provider": "Allnodes ⚡️ Nodes & Staking"
-      },
-      {
-        "address": "https://rest-dydx.cros-nest.com:443",
-        "provider": "Crosnest"
       },
       {
         "address": "https://dydx-lcd.enigma-validator.com",
@@ -245,10 +217,6 @@
       {
         "address": "https://dydx-api.noders.services",
         "provider": "[NODERS]TEAM"
-      },
-      {
-        "address": "https://dydx-rest.interstellar-lounge.org",
-        "provider": "Interstellar Lounge 🍸"
       }
     ],
     "grpc": [
@@ -273,10 +241,6 @@
         "provider": "Polkachu (5)"
       },
       {
-        "address": "dydx-mainnet-full-grpc.public.blastapi.io:443",
-        "provider": "Bware Labs"
-      },
-      {
         "address": "https://dydx-grpc.kingnodes.com:443",
         "provider": "Kingnodes 👑"
       },
@@ -291,10 +255,6 @@
       {
         "address": "dydx.grpc.kjnodes.com:443",
         "provider": "kjnodes"
-      },
-      {
-        "address": "grpc-dydx.cosmos-spaces.cloud:4990",
-        "provider": "Cosmos Spaces"
       },
       {
         "address": "dydx-grpc.publicnode.com:443",


### PR DESCRIPTION
Removes **10 dead endpoint entries** across **4 providers** from `dydx/chain.json` (`dydx-mainnet-1`), after auditing every RPC, REST, and gRPC endpoint.

### Removed

| Provider | Endpoints | Failure mode |
|---|---|---|
| **Bware Labs** | RPC + REST + gRPC | `*.public.blastapi.io` **NXDOMAIN** (host gone registry-wide) |
| **Cosmos Spaces** | RPC + REST + gRPC | `cosmos-spaces.cloud` **fully NXDOMAIN** incl. root — provider wound down |
| **Crosnest** | RPC + REST | per-chain `*-dydx.cros-nest.com` **NXDOMAIN** |
| **Interstellar Lounge** | RPC + REST | Cloudflare **523 Origin Unreachable**, persistent |

Result: RPC 12 → 8, REST 12 → 8, gRPC 13 → 11. No empty arrays.

### Deliberately kept
- **AutoStake** and **PRO Delegators** — return `404` across *all* chains (cosmos/osmosis/akash/celestia), not dydx-specific. Removing here only would be inconsistent; better handled registry-wide.
- **[NODERS]TEAM** and **Enigma** — ambiguous (nginx 404 / connection timeout) and not cleanly attributable to a dydx-specific outage, so left untouched.
- Live providers all verified responding on `dydx-mainnet-1`: Kingnodes, Polkachu, Lavender.Five, Allnodes (publicnode), kjnodes.

Verification: DNS (`getent`), RPC `/status`, REST `/cosmos/base/tendermint/v1beta1/node_info`, and gRPC reflection — all reporting `network=dydx-mainnet-1` at consistent heights (~94.19M).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
