### PR TITLE
fix(babylon): remove dead RPC/REST/gRPC endpoints (4 providers)

### DIFF
--- a/babylon/chain.json
+++ b/babylon/chain.json
@@ -144,10 +144,6 @@
         "provider": "Nodes.Guru"
       },
       {
-        "address": "https://babylon-archive.nodes.guru/rpc",
-        "provider": "Nodes.Guru"
-      },
-      {
         "address": "https://babylon-rpc.polkachu.com",
         "provider": "Polkachu"
       },
@@ -168,18 +164,6 @@
         "provider": "PRO Delegators"
       },
       {
-        "address": "https://babylon-mainnet-rpc.shazoe.xyz",
-        "provider": "Shazoe"
-      },
-      {
-        "address": "https://babylon.rpc.nodeshub.online:443",
-        "provider": "NodesHub"
-      },
-      {
-        "address": "https://babylon-mainnet-rpc.shazoes.xyz",
-        "provider": "Shazoes"
-      },
-      {
         "address": "https://rpc.babylon.validatus.com",
         "provider": "Validatus"
       }
@@ -187,10 +171,6 @@
     "rest": [
       {
         "address": "https://babylon.nodes.guru/api",
-        "provider": "Nodes.Guru"
-      },
-      {
-        "address": "https://babylon-archive.nodes.guru/api",
         "provider": "Nodes.Guru"
       },
       {
@@ -214,18 +194,6 @@
         "provider": "PRO Delegators"
       },
       {
-        "address": "https://babylon-mainnet-api.shazoe.xyz",
-        "provider": "Shazoe"
-      },
-      {
-        "address": "https://babylon.api.nodeshub.online",
-        "provider": "NodesHub"
-      },
-      {
-        "address": "https://babylon-mainnet-api.shazoes.xyz",
-        "provider": "Shazoes"
-      },
-      {
         "address": "https://api.babylon.validatus.com",
         "provider": "Validatus"
       }
@@ -233,10 +201,6 @@
     "grpc": [
       {
         "address": "babylon.nodes.guru:443/grpc",
-        "provider": "Nodes.Guru"
-      },
-      {
-        "address": "babylon-archive.nodes.guru:443/grpc",
         "provider": "Nodes.Guru"
       },
       {
@@ -254,18 +218,6 @@
       {
         "address": "babylon-mainnet-grpc.autostake.com:443",
         "provider": "AutoStake 🛡️ Slash Protected"
-      },
-      {
-        "address": "babylon-mainnet-grpc.shazoe.xyz:30190",
-        "provider": "Shazoe"
-      },
-      {
-        "address": "babylon.grpc.nodeshub.online",
-        "provider": "NodesHub"
-      },
-      {
-        "address": "babylon-mainnet-grpc.shazoes.xyz:30190",
-        "provider": "Shazoes"
       },
       {
         "address": "grpc.babylon.validatus.com:443",


### PR DESCRIPTION
## Summary

Removes 12 dead Babylon (`bbn-1`) API endpoints across 4 providers (RPC + REST + gRPC each). Healthy endpoints (Nodes.Guru non-archive, Polkachu, Allnodes/publicnode, Validatus) are untouched.

## Removed

| Provider | Endpoints | Evidence |
|---|---|---|
| **NodesHub** | rpc/rest/grpc | `babylon.{rpc,api,grpc}.nodeshub.online` all **NXDOMAIN** — provider still serves other chains (`cosmos.rpc.nodeshub.online` + root resolve), so Babylon was deliberately decommissioned |
| **Shazoe** | rpc/rest/grpc | `babylon-mainnet-{rpc,api}.shazoe.xyz` return TLS `unrecognized name` (origin has no vhost for the host); `babylon-mainnet-grpc.shazoe.xyz:30190` TCP-closed |
| **Shazoes** | rpc/rest/grpc | `shazoes.xyz` root is **NXDOMAIN** and only the babylon hostnames resolve; gRPC port closed, RPC/REST non-responsive |
| **Nodes.Guru (archive)** | rpc/rest/grpc | `babylon-archive.nodes.guru` returns persistent **HTTP 503** on `/rpc`, `/api`, and `:443/grpc` across repeated, spaced retests. Non-archive `babylon.nodes.guru` is healthy (200) and is **kept** |

## Deliberately NOT removed

- **AutoStake** and **PRO Delegators** return HTTP 404 on Babylon, but they return **404 across all their chains** (cosmos/osmosis/akash/celestia) — this is infra-wide, not Babylon-specific, so removing them from one chain only would be inconsistent. Out of scope here.
- Polkachu / Validatus gRPC probes returned no HTTP banner from my vantage but the gRPC ports are open and their RPC/REST are healthy — kept as false positives.

All endpoints were probed externally; only DNS (NXDOMAIN) and TCP-port state were treated as definitive.
