### PR TITLE
fix(celestia): remove dead RPC/REST/gRPC endpoints (8 providers)

### DIFF
--- a/celestia/chain.json
+++ b/celestia/chain.json
@@ -211,10 +211,6 @@
         "provider": "Numia"
       },
       {
-        "address": "https://celestia-rpc.mesa.newmetric.xyz",
-        "provider": "Newmetric"
-      },
-      {
         "address": "https://rpc.lunaroasis.net",
         "provider": "Lunar Oasis"
       },
@@ -225,18 +221,6 @@
       {
         "address": "https://rpc.lavenderfive.com:443/celestia",
         "provider": "Lavender.Five Nodes 🐝"
-      },
-      {
-        "address": "https://rpc-celestia-01.stakeflow.io",
-        "provider": "Stakeflow"
-      },
-      {
-        "address": "https://rpc-celestia.cosmos-spaces.cloud",
-        "provider": "Cosmos Spaces"
-      },
-      {
-        "address": "http://celestia.rpc.nodersteam.com:29657",
-        "provider": "[NODERS]TEAM"
       },
       {
         "address": "https://celestia.rpc.interchain.validao.xyz",
@@ -279,24 +263,12 @@
         "provider": "Validatus"
       },
       {
-        "address": "https://celestia-rpc.sr20de.xyz",
-        "provider": "Sr20de"
-      },
-      {
-        "address": "https://rpc-celestia-full.avril14th.org",
-        "provider": "Avril 14th"
-      },
-      {
         "address": "https://rpc.freshstaking.com/celestia",
         "provider": "FreshSTAKING"
       },
       {
         "address": "https://celestia.cumulo.org.es/",
         "provider": "Cumulo"
-      },
-      {
-        "address": "https://celestia-rpc.stake-town.com",
-        "provider": "StakeTown"
       },
       {
         "address": "https://rpc.celestia-app.bronbro.io",
@@ -337,14 +309,6 @@
         "provider": "Numia"
       },
       {
-        "address": "https://celestia-rest.mesa.newmetric.xyz",
-        "provider": "Newmetric"
-      },
-      {
-        "address": "http://celestia.rpc.nodersteam.com:1617",
-        "provider": "[NODERS]TEAM"
-      },
-      {
         "address": "https://api.lunaroasis.net",
         "provider": "Lunar Oasis"
       },
@@ -355,14 +319,6 @@
       {
         "address": "https://rest.lavenderfive.com:443/celestia",
         "provider": "Lavender.Five Nodes 🐝"
-      },
-      {
-        "address": "https://api-celestia-01.stakeflow.io",
-        "provider": "Stakeflow"
-      },
-      {
-        "address": "https://api-celestia.cosmos-spaces.cloud",
-        "provider": "Cosmos Spaces"
       },
       {
         "address": "https://celestia.rest.interchain.validao.xyz",
@@ -397,24 +353,12 @@
         "provider": "Validatus"
       },
       {
-        "address": "https://celestia-api.sr20de.xyz",
-        "provider": "Sr20de"
-      },
-      {
         "address": "https://celestia-mainnet-lcd.autostake.com:443",
         "provider": "AutoStake | Delegate for StakeDrops"
       },
       {
-        "address": "https://api-celestia-full.avril14th.org",
-        "provider": "Avril 14th"
-      },
-      {
         "address": "https://celestia.api.cumulo.org.es",
         "provider": "Cumulo"
-      },
-      {
-        "address": "https://celestia-api.stake-town.com",
-        "provider": "StakeTown"
       },
       {
         "address": "https://lcd.celestia-app.bronbro.io",
@@ -459,18 +403,6 @@
         "provider": "Lavender.Five Nodes 🐝"
       },
       {
-        "address": "celestia.grpc.nodersteam.com:9690",
-        "provider": "[NODERS]TEAM"
-      },
-      {
-        "address": "grpc-celestia-01.stakeflow.io:15002",
-        "provider": "Stakeflow"
-      },
-      {
-        "address": "grpc-celestia.cosmos-spaces.cloud:443",
-        "provider": "Cosmos Spaces"
-      },
-      {
         "address": "celestia.grpc.interchain.validao.xyz:443",
         "provider": "ValiDAO"
       },
@@ -499,20 +431,8 @@
         "provider": "Validatus"
       },
       {
-        "address": "celestia-grpc.sr20de.xyz",
-        "provider": "Sr20de"
-      },
-      {
-        "address": "grpc-celestia-full.avril14th.org",
-        "provider": "Avril 14th"
-      },
-      {
         "address": "celestia.grpc.cumulo.org.es",
         "provider": "Cumulo"
-      },
-      {
-        "address": "https://celestia-grpc.stake-town.com",
-        "provider": "StakeTown"
       },
       {
         "address": "grpc.celestia-app.bronbro.io:443",
@@ -525,10 +445,6 @@
       {
         "address": "celestia-mainnet-grpc.itrocket.net:443",
         "provider": "itrocket"
-      },
-      {
-        "address": "grpc.celestia.mainnet.dteam.tech:28090",
-        "provider": "DTEAM"
       },
       {
         "address": "http://celestia-grpc.stakeandrelax.net:11690",


### PR DESCRIPTION
## Summary

Removes 21 dead Celestia (`celestia`) API endpoints across 8 providers. Healthy endpoints are untouched. All endpoints were probed externally; given the large number of providers, **only DNS (NXDOMAIN) and TCP-port state were treated as definitive** to avoid false positives from any single vantage point.

## Removed — NXDOMAIN (20 entries)

| Provider | Endpoints | Note |
|---|---|---|
| **Newmetric** | rpc, rest | `celestia-{rpc,rest}.mesa.newmetric.xyz` — mesa subdomain gone (no gRPC entry existed) |
| **Stakeflow** | rpc, rest, grpc | `{rpc,api,grpc}-celestia-01.stakeflow.io` — `-01` scheme is also NXDOMAIN on cosmos/osmosis/akash (registry-wide decommission) |
| **Cosmos Spaces** | rpc, rest, grpc | root `cosmos-spaces.cloud` itself is NXDOMAIN |
| **StakeTown** | rpc, rest, grpc | root `stake-town.com` itself is NXDOMAIN |
| **Sr20de** | rpc, rest, grpc | `celestia-{rpc,api,grpc}.sr20de.xyz` |
| **Avril 14th** | rpc, rest, grpc | `{rpc,api,grpc}-celestia-full.avril14th.org` |
| **[NODERS]TEAM** | rpc, rest, grpc | `celestia.{rpc,grpc}.nodersteam.com` — provider migrated to `noders.services`, **which resolves and is kept** |

## Removed — TCP ConnectionRefused (1 entry)

| Provider | Endpoint | Note |
|---|---|---|
| **DTEAM** | grpc `grpc.celestia.mainnet.dteam.tech:28090` | persistent `ConnectionRefused` on the IPv4 host across repeated retests. DTEAM **rpc/rest are healthy (200) and kept** |

## Deliberately NOT removed

- gRPC ports on Pro-Nodes75 / Stake&Relax / Validatus-archive returned connection *timeouts* (not refusals) from my vantage — these can be vantage-side filtering rather than real outages, so they were left in place.
- AutoStake resolves and was not probed as dead here.
- All host removals are matched by exact address; the `[NODERS]TEAM` and `DTEAM` providers keep their still-working endpoints.
