### PR TITLE
Rebranding: new domain name

### DIFF
--- a/lumen/assetlist.json
+++ b/lumen/assetlist.json
@@ -24,7 +24,7 @@
         }
       ],
       "socials": {
-        "website": "https://lumen-network.org/",
+        "website": "https://lumen-browser.com/",
         "github": "https://github.com/network-lumen/",
         "telegram": "https://t.me/+HBWh_cUJCrZiODE0",
         "discord": "https://discord.gg/DwK6V9shKc",

--- a/lumen/chain.json
+++ b/lumen/chain.json
@@ -3,7 +3,7 @@
   "chain_name": "lumen",
   "status": "live",
   "network_type": "mainnet",
-  "website": "https://lumen-network.org/",
+  "website": "https://lumen-browser.com/",
   "pretty_name": "Lumen",
   "description": "Lumen is a Cosmos SDK chain focused on DNS auctions, release distribution, and gateway settlement flows.",
   "chain_type": "cosmos",


### PR DESCRIPTION
We are updating our brand strategy

- Old domain: lumen-network.org (now offline)
- New domain: lumen-browser.com