### PR TITLE
Add QUAD public RPC/REST endpoints (Cosmos Hub, Akash, Celestia, Stride)

### DIFF
--- a/akash/chain.json
+++ b/akash/chain.json
@@ -241,6 +241,10 @@
   "apis": {
     "rpc": [
       {
+        "address": "https://akash.rpc.uquad.org:443",
+        "provider": "QUAD"
+      },
+      {
         "address": "https://rpc-akash.ecostake.com:443",
         "provider": "ecostake"
       },
@@ -270,6 +274,10 @@
       }
     ],
     "rest": [
+      {
+        "address": "https://akash.rpc.uquad.org:443",
+        "provider": "QUAD"
+      },
       {
         "address": "https://rest-akash.ecostake.com",
         "provider": "ecostake"

--- a/celestia/chain.json
+++ b/celestia/chain.json
@@ -207,6 +207,10 @@
   "apis": {
     "rpc": [
       {
+        "address": "https://celestia.rpc.uquad.org:443",
+        "provider": "QUAD"
+      },
+      {
         "address": "https://public-celestia-rpc.numia.xyz",
         "provider": "Numia"
       },
@@ -304,6 +308,10 @@
       }
     ],
     "rest": [
+      {
+        "address": "https://celestia.rpc.uquad.org:443",
+        "provider": "QUAD"
+      },
       {
         "address": "https://public-celestia-lcd.numia.xyz",
         "provider": "Numia"

--- a/cosmoshub/chain.json
+++ b/cosmoshub/chain.json
@@ -197,6 +197,10 @@
   "apis": {
     "rpc": [
       {
+        "address": "https://cosmos.rpc.uquad.org:443",
+        "provider": "QUAD"
+      },
+      {
         "address": "https://rpc.cosmoshub-main.ccvalidators.com:443",
         "provider": "CryptoCrew",
         "archive": true
@@ -335,6 +339,10 @@
       }
     ],
     "rest": [
+      {
+        "address": "https://cosmos.rpc.uquad.org:443",
+        "provider": "QUAD"
+      },
       {
         "address": "https://rest.cosmoshub-main.ccvalidators.com:443",
         "provider": "CryptoCrew",

--- a/stride/chain.json
+++ b/stride/chain.json
@@ -261,6 +261,10 @@
   "apis": {
     "rpc": [
       {
+        "address": "https://stride.rpc.uquad.org:443",
+        "provider": "QUAD"
+      },
+      {
         "address": "https://stride-rpc.polkachu.com/",
         "provider": "Polkachu"
       },
@@ -338,6 +342,10 @@
       }
     ],
     "rest": [
+      {
+        "address": "https://stride.rpc.uquad.org:443",
+        "provider": "QUAD"
+      },
       {
         "address": "https://stride-api.polkachu.com/",
         "provider": "Polkachu"


### PR DESCRIPTION
Adds public, free (rate-limited) RPC + REST endpoints operated by QUAD (https://rpc.uquad.org) for Cosmos Hub, Akash, Celestia, and Stride.

- Cosmos Hub: `https://cosmos.rpc.uquad.org:443`
- Akash: `https://akash.rpc.uquad.org:443`
- Celestia: `https://celestia.rpc.uquad.org:443`
- Stride: `https://stride.rpc.uquad.org:443`

All four currently pass the registry health checks:
- RPC `/status` -> 200
- REST `/cosmos/base/tendermint/v1beta1/syncing` -> 200

Nodes are pruned/state-synced (not archival), so no `archive` flag is set.
