### PR TITLE
cleanup(injective): remove 12 dead API endpoints

### DIFF
--- a/injective/chain.json
+++ b/injective/chain.json
@@ -176,20 +176,12 @@
         "provider": "High Stakes 🇨🇭"
       },
       {
-        "address": "https://rpc.injective.goldenratiostaking.net",
-        "provider": "Golden Ratio Staking"
-      },
-      {
         "address": "https://injective-rpc.polkachu.com",
         "provider": "Polkachu"
       },
       {
         "address": "https://rpc.lavenderfive.com:443/injective",
         "provider": "Lavender.Five Nodes 🐝"
-      },
-      {
-        "address": "https://rpc-injective-01.stakeflow.io",
-        "provider": "Stakeflow"
       },
       {
         "address": "https://injective-rpc.publicnode.com:443",
@@ -224,14 +216,6 @@
     ],
     "grpc": [
       {
-        "address": "6d0ff611-9009-4bd1-a7a7-acec7c70d454.injective-1.mesa-grpc.newmetric.xyz:80",
-        "provider": "NewMetric"
-      },
-      {
-        "address": "grpc-injective-ia.cosmosia.notional.ventures:443",
-        "provider": "Notional"
-      },
-      {
         "address": "injective.lavenderfive.com:443",
         "provider": "Lavender.Five Nodes 🐝"
       },
@@ -244,32 +228,8 @@
         "provider": "AutoStake 🛡️ Slash Protected"
       },
       {
-        "address": "grpc-injective.cosmos-spaces.cloud:9900",
-        "provider": "Cosmos Spaces"
-      },
-      {
-        "address": "grpc.injective.posthuman.digital:80",
-        "provider": "POSTHUMAN ꝏ DVS"
-      },
-      {
-        "address": "grpc-injective.architectnodes.com:1443",
-        "provider": "Architect Nodes"
-      },
-      {
-        "address": "grpc-injective-01.stakeflow.io:2102",
-        "provider": "Stakeflow"
-      },
-      {
         "address": "injective-grpc.publicnode.com:443",
         "provider": "Allnodes ⚡️ Nodes & Staking"
-      },
-      {
-        "address": "injective-grpc.w3coins.io:14390",
-        "provider": "w3coins"
-      },
-      {
-        "address": "grpc-injective.whispernode.com:443",
-        "provider": "WhisperNode 🤐"
       },
       {
         "address": "grpc.injective.bronbro.io:443",
@@ -284,14 +244,6 @@
       {
         "address": "https://injective.json-rpc.decentrio.ventures",
         "provider": "Decentrio"
-      },
-      {
-        "address": "https://injective-evm-rpc.scvsecurity.io",
-        "provider": "SCV Security"
-      },
-      {
-        "address": "https://injective-evm-rpc.highstakes.ch",
-        "provider": "High Stakes 🇨🇭"
       },
       {
         "address": "https://sentry.evm-rpc.injective.network",


### PR DESCRIPTION
## Summary

Removes **12 dead API endpoints** from `injective/chain.json` (chain `injective-1`). All removals were verified unreachable and the failure mode confirmed independently before removal. No live endpoints were touched.

## Removed endpoints

**RPC (2)**
- `https://rpc.injective.goldenratiostaking.net` — Golden Ratio Staking — persistent HTTP 502 (Cloudflare origin down), provider site also down
- `https://rpc-injective-01.stakeflow.io` — Stakeflow — **NXDOMAIN** (DNS record removed)

**gRPC (8)**
- `…mesa-grpc.newmetric.xyz:80` — NewMetric — DNS SERVFAIL
- `grpc-injective-ia.cosmosia.notional.ventures:443` — Notional — NXDOMAIN
- `grpc-injective.cosmos-spaces.cloud:9900` — Cosmos Spaces — NXDOMAIN
- `grpc.injective.posthuman.digital:80` — POSTHUMAN — NXDOMAIN
- `grpc-injective.architectnodes.com:1443` — Architect Nodes — NXDOMAIN
- `grpc-injective-01.stakeflow.io:2102` — Stakeflow — NXDOMAIN
- `injective-grpc.w3coins.io:14390` — w3coins — NXDOMAIN
- `grpc-injective.whispernode.com:443` — WhisperNode — NXDOMAIN

**EVM JSON-RPC (2)**
- `https://injective-evm-rpc.scvsecurity.io` — SCV Security — Cloudflare 530 / error 1033 (tunnel down)
- `https://injective-evm-rpc.highstakes.ch` — High Stakes — persistent connection hang (TLS completes, no response @25s). Note: High Stakes' RPC/REST and other chains are healthy — only their EVM endpoint is broken.

## Verification method

- RPC: `/status` (network + block height); REST: `/syncing` + `node_info`; EVM: POST `eth_blockNumber`; gRPC: TCP/TLS reachability.
- Every dead candidate confirmed via Google DNS-over-HTTPS (NXDOMAIN/SERVFAIL) and retested for persistence.
- Provider infra cross-checked to rule out transient/infra-wide outages (e.g. AutoStake gRPC is healthy and was kept; High Stakes' other services are up).

## Remaining live (kept)
RPC 5 · REST 5 · gRPC 6 · EVM 3.
