### PR TITLE
feat(limonatatestnet): add evm-http-jsonrpc endpoint

### DIFF
--- a/testnets/limonatatestnet/chain.json
+++ b/testnets/limonatatestnet/chain.json
@@ -41,6 +41,9 @@
     ],
     "rest": [
       { "address": "https://rest.limonata.xyz", "provider": "Limonata" }
+    ],
+    "evm-http-jsonrpc": [
+      { "address": "https://rpc.limonata.xyz", "provider": "Limonata" }
     ]
   },
   "explorers": [


### PR DESCRIPTION
Follow-up to #7766. Limonata is an EVM Layer 1 (EVM chain ID 10777), so this adds the EVM JSON-RPC endpoint to `apis.evm-http-jsonrpc` so EVM tooling can discover it from the registry.

- **evm-http-jsonrpc:** https://rpc.limonata.xyz (`eth_chainId` -> `0x2a19` = 10777)

Endpoint is live and CORS-enabled. No other fields changed.