### PR TITLE
fix(stride): remove dead RPC/REST/gRPC endpoints (13 providers)

### DIFF
--- a/stride/chain.json
+++ b/stride/chain.json
@@ -265,48 +265,12 @@
         "provider": "Polkachu"
       },
       {
-        "address": "https://stride-rpc.onivalidator.com",
-        "provider": "Oni Validator ⛩️"
-      },
-      {
         "address": "https://rpc.lavenderfive.com:443/stride",
         "provider": "Lavender.Five Nodes 🐝"
       },
       {
-        "address": "https://rpc.stride.silentvalidator.com/",
-        "provider": "silent"
-      },
-      {
-        "address": "https://rpc-stride.cosmos-spaces.cloud",
-        "provider": "Cosmos Spaces"
-      },
-      {
-        "address": "https://stride.rpc.kjnodes.com",
-        "provider": "kjnodes"
-      },
-      {
-        "address": "https://rpc-stride.pupmos.network",
-        "provider": "PUPMØS"
-      },
-      {
-        "address": "https://rpc-stride.architectnodes.com",
-        "provider": "Architect Nodes"
-      },
-      {
-        "address": "https://rpc-stride.whispernode.com:443",
-        "provider": "WhisperNode 🤐"
-      },
-      {
         "address": "https://stride-mainnet-rpc.autostake.com:443",
         "provider": "AutoStake 🛡️ Slash Protected"
-      },
-      {
-        "address": "https://rpc-stride-01.stakeflow.io",
-        "provider": "Stakeflow"
-      },
-      {
-        "address": "https://stride-rpc.w3coins.io",
-        "provider": "w3coins"
       },
       {
         "address": "https://stride-rpc.publicnode.com:443",
@@ -321,16 +285,8 @@
         "provider": "Stake&Relax 🦥"
       },
       {
-        "address": "https://rpc.stride.bronbro.io:443",
-        "provider": "Bro_n_Bro"
-      },
-      {
         "address": "https://public.stakewolle.com/cosmos/stride/rpc",
         "provider": "Stakewolle"
-      },
-      {
-        "address": "https://stride.rpc.quasarstaking.ai:443",
-        "provider": "Quasar"
       },
       {
         "address": "https://rpc.stride.citizenweb3.com",
@@ -343,44 +299,12 @@
         "provider": "Polkachu"
       },
       {
-        "address": "https://api-stride.cosmos-spaces.cloud",
-        "provider": "Cosmos Spaces"
-      },
-      {
         "address": "https://rest.lavenderfive.com:443/stride",
         "provider": "Lavender.Five Nodes 🐝"
       },
       {
-        "address": "https://api.stride.silentvalidator.com/",
-        "provider": "silent"
-      },
-      {
-        "address": "https://stride.api.kjnodes.com",
-        "provider": "kjnodes"
-      },
-      {
-        "address": "https://api-stride.pupmos.network",
-        "provider": "PUPMØS"
-      },
-      {
         "address": "https://stride-mainnet-lcd.autostake.com:443",
         "provider": "AutoStake 🛡️ Slash Protected"
-      },
-      {
-        "address": "https://rest-stride.architectnodes.com",
-        "provider": "Architect Nodes"
-      },
-      {
-        "address": "https://lcd-stride.whispernode.com:443",
-        "provider": "WhisperNode 🤐"
-      },
-      {
-        "address": "https://api-stride-01.stakeflow.io",
-        "provider": "Stakeflow"
-      },
-      {
-        "address": "https://stride-api.w3coins.io",
-        "provider": "w3coins"
       },
       {
         "address": "https://stride-rest.publicnode.com",
@@ -395,16 +319,8 @@
         "provider": "Stake&Relax 🦥"
       },
       {
-        "address": "https://lcd.stride.bronbro.io:443",
-        "provider": "Bro_n_Bro"
-      },
-      {
         "address": "https://public.stakewolle.com/cosmos/stride/rest",
         "provider": "Stakewolle"
-      },
-      {
-        "address": "https://stride.api.quasarstaking.ai:443",
-        "provider": "Quasar"
       },
       {
         "address": "https://api.stride.citizenweb3.com",
@@ -412,10 +328,6 @@
       }
     ],
     "grpc": [
-      {
-        "address": "stride.grpc.bccnodes.com:443",
-        "provider": "BccNodes"
-      },
       {
         "address": "stride-grpc.polkachu.com:12290",
         "provider": "Polkachu"
@@ -425,28 +337,8 @@
         "provider": "Lavender.Five Nodes 🐝"
       },
       {
-        "address": "http://stride.grpc.m.stavr.tech:9986",
-        "provider": "🔥STAVR🔥"
-      },
-      {
-        "address": "grpc-stride.cosmos-spaces.cloud:1140",
-        "provider": "Cosmos Spaces"
-      },
-      {
         "address": "stride-mainnet-grpc.autostake.com:443",
         "provider": "AutoStake 🛡️ Slash Protected"
-      },
-      {
-        "address": "stride.grpc.kjnodes.com:11690",
-        "provider": "kjnodes"
-      },
-      {
-        "address": "grpc-stride-01.stakeflow.io:1802",
-        "provider": "Stakeflow"
-      },
-      {
-        "address": "stride-grpc.w3coins.io:12290",
-        "provider": "w3coins"
       },
       {
         "address": "stride-grpc.publicnode.com:443",
@@ -459,10 +351,6 @@
       {
         "address": "https://grpc.stride.bronbro.io:443",
         "provider": "Bro_n_Bro"
-      },
-      {
-        "address": "stride.grpc.quasarstaking.ai:80",
-        "provider": "Quasar"
       },
       {
         "address": "grpc.stride.citizenweb3.com:443",


### PR DESCRIPTION
Removes **28 dead endpoints** (13 providers) from `stride/chain.json`, verified via DNS + HTTP + TCP probing. Net effect on master: **RPC 20 → 9, REST 19 → 9, gRPC 14 → 7**.

### Removed

**Tier 1 — NXDOMAIN (hostname no longer resolves)**
| Provider | Removed |
|---|---|
| Stakeflow | rpc + rest + grpc |
| Cosmos Spaces | rpc + rest + grpc |
| w3coins | rpc + rest + grpc |
| PUPMØS | rpc + rest |
| silent | rpc + rest |
| WhisperNode | rpc + rest |
| Architect Nodes | rpc + rest |
| Oni Validator | rpc |
| BccNodes | grpc |
| 🔥STAVR🔥 | grpc |

**Tier 2 — hard-down, resolving**
| Provider | Removed | Signal |
|---|---|---|
| Bro_n_Bro | rpc + rest | Persistent HTTP `502` (3/3 retests). `cosmoshub.bronbro.io` = 200, so provider infra is alive — the Stride node is down. gRPC kept (TCP-open). |
| Quasar | rpc + rest + grpc | `Connection refused` on all three ports (3/3). |
| kjnodes | rpc + rest + grpc | Stride hosts time out (3/3) while `cosmoshub`/`osmosis` kjnodes hosts are reachable from the same vantage — Stride-specific. |

### Deliberately kept (verified false-positives)
- **AutoStake** & **PRO Delegators** — return `404`, but that's **registry-wide** (same 404 on cosmos/osmosis/akash/celestia), not Stride-specific. Out of scope for a single-chain PR.
- **Allnodes/publicnode** — `403` (bot-protection), provider live.
- **Stakewolle** — REST `503` was flapping (200/503/200) + RPC 200 → transient, kept.

All remaining endpoints (QUAD, Polkachu, Lavender.Five, Stake&Relax, Stakewolle, Citizen Web3, + kept AutoStake/PRO Delegators/Allnodes) respond.
