### PR TITLE
fix: remove dead Notional endpoints registry-wide (30 chains)

### DIFF
--- a/agoric/chain.json
+++ b/agoric/chain.json
@@ -163,10 +163,6 @@
         "provider": "StakeWithUs"
       },
       {
-        "address": "https://rpc-agoric-ia.cosmosia.notional.ventures",
-        "provider": "Notional"
-      },
-      {
         "address": "https://agoric-rpc.stakeandrelax.net",
         "provider": "Stake&Relax 🦥"
       },
@@ -212,10 +208,6 @@
         "provider": "StakeWithUs"
       },
       {
-        "address": "https://api-agoric-ia.cosmosia.notional.ventures",
-        "provider": "Notional"
-      },
-      {
         "address": "https://agoric-api.stakeandrelax.net",
         "provider": "Stake&Relax 🦥"
       },
@@ -252,10 +244,6 @@
       {
         "address": "https://grpc.agoric.stakewith.us",
         "provider": "StakeWithUs"
-      },
-      {
-        "address": "grpc-agoric-ia.cosmosia.notional.ventures:443",
-        "provider": "Notional"
       },
       {
         "address": "agoric-grpc.stakeandrelax.net:14490",

--- a/assetmantle/chain.json
+++ b/assetmantle/chain.json
@@ -123,10 +123,6 @@
         "provider": "Polkachu"
       },
       {
-        "address": "https://rpc-assetmantle-ia.cosmosia.notional.ventures/",
-        "provider": "Notional"
-      },
-      {
         "address": "https://rpc.mantle.paranorm.pro:443",
         "provider": "paranorm"
       },
@@ -143,10 +139,6 @@
       {
         "address": "https://rest.assetmantle.one",
         "provider": "AssetMantle"
-      },
-      {
-        "address": "https://api-assetmantle-ia.cosmosia.notional.ventures",
-        "provider": "Notional"
       },
       {
         "address": "https://assetmantle-api.polkachu.com",
@@ -166,10 +158,6 @@
       }
     ],
     "grpc": [
-      {
-        "address": "grpc-assetmantle-ia.cosmosia.notional.ventures:443",
-        "provider": "Notional"
-      },
       {
         "address": "assetmantle-grpc.polkachu.com:14690",
         "provider": "Polkachu"

--- a/bandchain/chain.json
+++ b/bandchain/chain.json
@@ -155,10 +155,6 @@
         "provider": "bandprotocol"
       },
       {
-        "address": "https://rpc-bandchain-ia.cosmosia.notional.ventures/",
-        "provider": "Notional"
-      },
-      {
         "address": "https://band.ibs.team:443/rpc",
         "provider": "Inter Blockchain Services"
       },
@@ -209,10 +205,6 @@
         "provider": "bandprotocol"
       },
       {
-        "address": "https://api-bandchain-ia.cosmosia.notional.ventures/",
-        "provider": "Notional"
-      },
-      {
         "address": "https://band.ibs.team:443/api",
         "provider": "Inter Blockchain Services"
       },
@@ -258,10 +250,6 @@
       }
     ],
     "grpc": [
-      {
-        "address": "grpc-bandchain-ia.cosmosia.notional.ventures:443",
-        "provider": "Notional"
-      },
       {
         "address": "bandchain-mainnet-grpc.autostake.com:443",
         "provider": "AutoStake 🛡️ Slash Protected"

--- a/bostrom/chain.json
+++ b/bostrom/chain.json
@@ -70,10 +70,6 @@
         "provider": "cybercongress"
       },
       {
-        "address": "https://rpc-cyber-ia.cosmosia.notional.ventures/",
-        "provider": "Notional"
-      },
-      {
         "address": "https://rpc.cyber.bronbro.io:443",
         "provider": "Bro_n_Bro"
       }
@@ -84,19 +80,11 @@
         "provider": "cybercongress"
       },
       {
-        "address": "https://api-cyber-ia.cosmosia.notional.ventures/",
-        "provider": "Notional"
-      },
-      {
         "address": "https://lcd.cyber.bronbro.io:443",
         "provider": "Bro_n_Bro"
       }
     ],
     "grpc": [
-      {
-        "address": "grpc-cyber-ia.cosmosia.notional.ventures:443",
-        "provider": "Notional"
-      },
       {
         "address": "https://grpc.cyber.bronbro.io:443",
         "provider": "Bro_n_Bro"

--- a/cerberus/chain.json
+++ b/cerberus/chain.json
@@ -57,10 +57,6 @@
     "rest": [],
     "grpc": [
       {
-        "address": "grpc-cerberus-ia.cosmosia.notional.ventures:443",
-        "provider": "Notional"
-      },
-      {
         "address": "cerberus-grpc.polkachu.com:13890",
         "provider": "Polkachu"
       }

--- a/cheqd/chain.json
+++ b/cheqd/chain.json
@@ -145,10 +145,6 @@
         "provider": "🔥STAVR🔥"
       },
       {
-        "address": "https://rpc-cheqd-ia.cosmosia.notional.ventures/",
-        "provider": "Notional"
-      },
-      {
         "address": "https://rpc.cheqd.nodestake.org",
         "provider": "NodeStake"
       },
@@ -197,10 +193,6 @@
       {
         "address": "https://cheqd.api.m.stavr.tech",
         "provider": "🔥STAVR🔥"
-      },
-      {
-        "address": "https://api-cheqd-ia.cosmosia.notional.ventures/",
-        "provider": "Notional"
       },
       {
         "address": "https://cheqd-mainnet-lcd.autostake.com:443",
@@ -255,10 +247,6 @@
       {
         "address": "cheqd-mainnet-grpc.autostake.com:443",
         "provider": "AutoStake 🛡️ Slash Protected"
-      },
-      {
-        "address": "grpc-cheqd-ia.cosmosia.notional.ventures:443",
-        "provider": "Notional"
       },
       {
         "address": "grpc.cheqd.nodestake.org:443",

--- a/chihuahua/chain.json
+++ b/chihuahua/chain.json
@@ -139,10 +139,6 @@
         "provider": "Polkachu"
       },
       {
-        "address": "https://rpc-chihuahua-ia.cosmosia.notional.ventures",
-        "provider": "Notional"
-      },
-      {
         "address": "https://rpc.lavenderfive.com:443/chihuahua",
         "provider": "Lavender.Five Nodes 🐝"
       },
@@ -193,10 +189,6 @@
         "provider": "🔥STAVR🔥"
       },
       {
-        "address": "https://api-chihuahua-ia.cosmosia.notional.ventures",
-        "provider": "Notional"
-      },
-      {
         "address": "https://chihuahua-api.polkachu.com",
         "provider": "Polkachu"
       },
@@ -238,10 +230,6 @@
       }
     ],
     "grpc": [
-      {
-        "address": "grpc-chihuahua-ia.cosmosia.notional.ventures:443",
-        "provider": "Notional"
-      },
       {
         "address": "chihuahua-grpc.polkachu.com:12990",
         "provider": "Polkachu"

--- a/comdex/chain.json
+++ b/comdex/chain.json
@@ -263,10 +263,6 @@
     ],
     "grpc": [
       {
-        "address": "grpc-comdex-ia.cosmosia.notional.ventures:443",
-        "provider": "Notional"
-      },
-      {
         "address": "comdex-grpc.polkachu.com:13190",
         "provider": "Polkachu"
       },

--- a/composable/chain.json
+++ b/composable/chain.json
@@ -129,10 +129,6 @@
   "apis": {
     "rpc": [
       {
-        "address": "https://rpc-composable-ia.cosmosia.notional.ventures",
-        "provider": "Notional"
-      },
-      {
         "address": "https://composable-mainnet-rpc.autostake.com:443",
         "provider": "AutoStake 🛡️ Slash Protected"
       },
@@ -179,10 +175,6 @@
     ],
     "rest": [
       {
-        "address": "https://api-composable-ia.cosmosia.notional.ventures",
-        "provider": "Notional"
-      },
-      {
         "address": "https://composable-mainnet-lcd.autostake.com:443",
         "provider": "AutoStake 🛡️ Slash Protected"
       },
@@ -224,10 +216,6 @@
       }
     ],
     "grpc": [
-      {
-        "address": "https://grpc-composable-ia.cosmosia.notional.ventures",
-        "provider": "Notional"
-      },
       {
         "address": "grpc.composable.nodestake.top:9090",
         "provider": "NodeStake"

--- a/cryptoorgchain/chain.json
+++ b/cryptoorgchain/chain.json
@@ -105,10 +105,6 @@
         "provider": "cronos.org"
       },
       {
-        "address": "https://rpc-cryptoorgchain-ia.cosmosia.notional.ventures/",
-        "provider": "Notional"
-      },
-      {
         "address": "https://rpc-cryptoorgchain.ecostake.com",
         "provider": "ecostake"
       },
@@ -135,10 +131,6 @@
         "provider": "cronos.org"
       },
       {
-        "address": "https://api-cryptoorgchain-ia.cosmosia.notional.ventures/",
-        "provider": "Notional"
-      },
-      {
         "address": "https://cryptocom-api.polkachu.com",
         "provider": "Polkachu"
       },
@@ -163,10 +155,6 @@
       {
         "address": "grpc.mainnet.crypto.org:443",
         "provider": "cronos.org"
-      },
-      {
-        "address": "grpc-cryptoorgchain-ia.cosmosia.notional.ventures:443",
-        "provider": "Notional"
       },
       {
         "address": "cryptocom-grpc.polkachu.com:20290",

--- a/emoney/chain.json
+++ b/emoney/chain.json
@@ -122,10 +122,6 @@
         "provider": "e-Money"
       },
       {
-        "address": "https://rpc-emoney-ia.cosmosia.notional.ventures/",
-        "provider": "Notional"
-      },
-      {
         "address": "https://rpc.emoney.bh.rocks",
         "provider": "BlockHunters 🎯"
       }
@@ -136,19 +132,11 @@
         "provider": "e-Money"
       },
       {
-        "address": "https://api-emoney-ia.cosmosia.notional.ventures/",
-        "provider": "Notional"
-      },
-      {
         "address": "https://api.emoney.bh.rocks",
         "provider": "BlockHunters 🎯"
       }
     ],
     "grpc": [
-      {
-        "address": "grpc-emoney-ia.cosmosia.notional.ventures:443",
-        "provider": "Notional"
-      },
       {
         "address": "emoney-mainnet-grpc.autostake.com:443",
         "provider": "AutoStake 🛡️ Slash Protected"

--- a/evmos/chain.json
+++ b/evmos/chain.json
@@ -174,10 +174,6 @@
         "provider": "Blockdaemon"
       },
       {
-        "address": "https://rpc-evmos-ia.cosmosia.notional.ventures:443",
-        "provider": "Notional"
-      },
-      {
         "address": "https://rpc.evmos.testnet.run",
         "provider": "TestNetRun"
       },
@@ -256,10 +252,6 @@
         "provider": "Lavender.Five Nodes 🐝"
       },
       {
-        "address": "https://api-evmos-ia.cosmosia.notional.ventures/",
-        "provider": "Notional"
-      },
-      {
         "address": "https://evmos-api.polkachu.com",
         "provider": "Polkachu"
       },
@@ -322,10 +314,6 @@
         "provider": "evmos.org"
       },
       {
-        "address": "grpc-evmos-ia.cosmosia.notional.ventures:443",
-        "provider": "Notional"
-      },
-      {
         "address": "evmos.lavenderfive.com:443",
         "provider": "Lavender.Five Nodes 🐝"
       },
@@ -386,10 +374,6 @@
       {
         "address": "https://eth.bd.evmos.org:8545",
         "provider": "Blockdaemon"
-      },
-      {
-        "address": "https://jsonrpc-evmos-ia.cosmosia.notional.ventures/",
-        "provider": "Notional"
       },
       {
         "address": "https://evmos-json-rpc.stakely.io",

--- a/fetchhub/chain.json
+++ b/fetchhub/chain.json
@@ -124,10 +124,6 @@
         "provider": "fetch.ai"
       },
       {
-        "address": "https://rpc-fetchhub-ia.cosmosia.notional.ventures/",
-        "provider": "Notional"
-      },
-      {
         "address": "https://fetch-rpc.polkachu.com",
         "provider": "Polkachu"
       },
@@ -194,10 +190,6 @@
         "provider": "fetch.ai"
       },
       {
-        "address": "https://api-fetchhub-ia.cosmosia.notional.ventures/",
-        "provider": "Notional"
-      },
-      {
         "address": "https://fetch-api.polkachu.com",
         "provider": "Polkachu"
       },
@@ -262,10 +254,6 @@
       {
         "address": "grpc-fetchhub.fetch.ai:443",
         "provider": "fetch.ai"
-      },
-      {
-        "address": "grpc-fetchhub-ia.cosmosia.notional.ventures:443",
-        "provider": "Notional"
       },
       {
         "address": "fetch-grpc.polkachu.com:15290",

--- a/gravitybridge/chain.json
+++ b/gravitybridge/chain.json
@@ -147,10 +147,6 @@
         "provider": "Polkachu"
       },
       {
-        "address": "https://rpc-gravitybridge-ia.cosmosia.notional.ventures/",
-        "provider": "Notional"
-      },
-      {
         "address": "https://rpc.lavenderfive.com:443/gravitybridge",
         "provider": "Lavender.Five Nodes 🐝"
       },
@@ -191,10 +187,6 @@
       {
         "address": "https://gravitychain.io:1317",
         "provider": "althea"
-      },
-      {
-        "address": "https://api-gravitybridge-ia.cosmosia.notional.ventures/",
-        "provider": "Notional"
       },
       {
         "address": "https://gravity-api.polkachu.com",
@@ -241,10 +233,6 @@
       {
         "address": "gravity-bridge-1-08.nodes.amhost.net:9090",
         "provider": "amhost"
-      },
-      {
-        "address": "grpc-gravitybridge-ia.cosmosia.notional.ventures:443",
-        "provider": "Notional"
       },
       {
         "address": "gravity-grpc.polkachu.com:14290",

--- a/impacthub/chain.json
+++ b/impacthub/chain.json
@@ -115,10 +115,6 @@
         "provider": "🔥STAVR🔥"
       },
       {
-        "address": "https://rpc-ixo-ia.cosmosia.notional.ventures/",
-        "provider": "Notional"
-      },
-      {
         "address": "https://rpc.lavenderfive.com:443/impacthub",
         "provider": "Lavender.Five Nodes 🐝"
       },
@@ -149,10 +145,6 @@
         "provider": "🔥STAVR🔥"
       },
       {
-        "address": "https://api-ixo-ia.cosmosia.notional.ventures/",
-        "provider": "Notional"
-      },
-      {
         "address": "https://rest.lavenderfive.com:443/impacthub",
         "provider": "Lavender.Five Nodes 🐝"
       },
@@ -170,10 +162,6 @@
       }
     ],
     "grpc": [
-      {
-        "address": "grpc-ixo-ia.cosmosia.notional.ventures:443",
-        "provider": "Notional"
-      },
       {
         "address": "ixo.grpc.m.stavr.tech:2010",
         "provider": "🔥STAVR🔥"

--- a/irisnet/chain.json
+++ b/irisnet/chain.json
@@ -96,10 +96,6 @@
   "apis": {
     "rpc": [
       {
-        "address": "https://rpc-irisnet-ia.cosmosia.notional.ventures/",
-        "provider": "Notional"
-      },
-      {
         "address": "https://rpc-irisnet-01.stakeflow.io",
         "provider": "Stakeflow"
       },
@@ -122,10 +118,6 @@
     ],
     "rest": [
       {
-        "address": "https://api-irisnet-ia.cosmosia.notional.ventures/",
-        "provider": "Notional"
-      },
-      {
         "address": "https://api-irisnet-01.stakeflow.io",
         "provider": "Stakeflow"
       },
@@ -147,10 +139,6 @@
       }
     ],
     "grpc": [
-      {
-        "address": "grpc-irisnet-ia.cosmosia.notional.ventures:443",
-        "provider": "Notional"
-      },
       {
         "address": "grpc-irisnet-01.stakeflow.io:1902",
         "provider": "Stakeflow"

--- a/kichain/chain.json
+++ b/kichain/chain.json
@@ -109,10 +109,6 @@
         "provider": "Polkachu"
       },
       {
-        "address": "https://rpc-kichain-ia.cosmosia.notional.ventures/",
-        "provider": "Notional"
-      },
-      {
         "address": "https://kichain-mainnet-rpc.autostake.com:443",
         "provider": "AutoStake 🛡️ Slash Protected"
       },
@@ -137,10 +133,6 @@
       {
         "address": "https://api-mainnet.blockchain.ki",
         "provider": "kifoundation"
-      },
-      {
-        "address": "https://api-kichain-ia.cosmosia.notional.ventures/",
-        "provider": "Notional"
       },
       {
         "address": "https://kichain.api.m.stavr.tech",
@@ -172,10 +164,6 @@
       }
     ],
     "grpc": [
-      {
-        "address": "grpc-kichain-ia.cosmosia.notional.ventures:443",
-        "provider": "Notional"
-      },
       {
         "address": "kichain-mainnet-grpc.autostake.com:443",
         "provider": "AutoStake 🛡️ Slash Protected"

--- a/konstellation/chain.json
+++ b/konstellation/chain.json
@@ -89,29 +89,17 @@
   "apis": {
     "rpc": [
       {
-        "address": "https://rpc-konstellation-ia.cosmosia.notional.ventures/",
-        "provider": "Notional"
-      },
-      {
         "address": "https://konstellation-rpc.stakerhouse.com",
         "provider": "StakerHouse"
       }
     ],
     "rest": [
       {
-        "address": "https://api-konstellation-ia.cosmosia.notional.ventures/",
-        "provider": "Notional"
-      },
-      {
         "address": "https://konstellation-rest.stakerhouse.com",
         "provider": "StakerHouse"
       }
     ],
     "grpc": [
-      {
-        "address": "grpc-konstellation-ia.cosmosia.notional.ventures:443",
-        "provider": "Notional"
-      },
       {
         "address": "konstellation-grpc.polkachu.com:13390",
         "provider": "Polkachu"

--- a/kujira/chain.json
+++ b/kujira/chain.json
@@ -242,10 +242,6 @@
         "provider": "Lavender.Five Nodes 🐝"
       },
       {
-        "address": "https://rpc-kujira-ia.cosmosia.notional.ventures/",
-        "provider": "Notional"
-      },
-      {
         "address": "https://kujira.ibs.team:443/rpc",
         "provider": "Inter Blockchain Services"
       },
@@ -308,10 +304,6 @@
         "provider": "polkachu"
       },
       {
-        "address": "https://api-kujira-ia.cosmosia.notional.ventures/",
-        "provider": "Notional"
-      },
-      {
         "address": "https://kujira-lcd.wildsage.io/",
         "provider": "WildSage Labs"
       },
@@ -361,10 +353,6 @@
       }
     ],
     "grpc": [
-      {
-        "address": "grpc-kujira-ia.cosmosia.notional.ventures:443",
-        "provider": "Notional"
-      },
       {
         "address": "kujira.lavenderfive.com:443",
         "provider": "Lavender.Five Nodes 🐝"

--- a/omniflixhub/chain.json
+++ b/omniflixhub/chain.json
@@ -129,10 +129,6 @@
         "provider": "ChainTools"
       },
       {
-        "address": "https://rpc-omniflixhub-ia.cosmosia.notional.ventures/",
-        "provider": "Notional"
-      },
-      {
         "address": "https://rpc.lavenderfive.com:443/omniflixhub",
         "provider": "Lavender.Five Nodes 🐝"
       },
@@ -185,10 +181,6 @@
       {
         "address": "https://api.omniflix.nodestake.org",
         "provider": "NodeStake"
-      },
-      {
-        "address": "https://api-omniflixhub-ia.cosmosia.notional.ventures/",
-        "provider": "Notional"
       },
       {
         "address": "https://rest.lavenderfive.com:443/omniflixhub",
@@ -251,10 +243,6 @@
       {
         "address": "grpc.omniflix.nodestake.org:443",
         "provider": "NodeStake"
-      },
-      {
-        "address": "grpc-omniflixhub-ia.cosmosia.notional.ventures:443",
-        "provider": "Notional"
       },
       {
         "address": "omniflixhub.lavenderfive.com:443",

--- a/passage/chain.json
+++ b/passage/chain.json
@@ -149,10 +149,6 @@
         "provider": "Lavender.Five Nodes 🐝"
       },
       {
-        "address": "https://rpc-passage-ia.cosmosia.notional.ventures/",
-        "provider": "Notional"
-      },
-      {
         "address": "https://rpc-passage.cosmos-spaces.cloud",
         "provider": "Cosmos Spaces"
       },
@@ -211,10 +207,6 @@
         "provider": "Cosmos Spaces"
       },
       {
-        "address": "https://api-passage-ia.cosmosia.notional.ventures/",
-        "provider": "Notional"
-      },
-      {
         "address": "https://passage-api.polkachu.com",
         "provider": "Polkachu"
       },
@@ -252,10 +244,6 @@
       }
     ],
     "grpc": [
-      {
-        "address": "grpc-passage-ia.cosmosia.notional.ventures:443",
-        "provider": "Notional"
-      },
       {
         "address": "passage.lavenderfive.com:443",
         "provider": "Lavender.Five Nodes 🐝"

--- a/persistence/chain.json
+++ b/persistence/chain.json
@@ -162,10 +162,6 @@
         "provider": "Persistence"
       },
       {
-        "address": "https://rpc-persistent-ia.cosmosia.notional.ventures/",
-        "provider": "Notional"
-      },
-      {
         "address": "https://persistence.rpc.m.stavr.tech",
         "provider": "🔥STAVR🔥"
       },
@@ -252,10 +248,6 @@
         "provider": "Persistence"
       },
       {
-        "address": "https://api-persistent-ia.cosmosia.notional.ventures/",
-        "provider": "Notional"
-      },
-      {
         "address": "https://persistence.api.m.stavr.tech",
         "provider": "🔥STAVR🔥"
       },
@@ -340,10 +332,6 @@
       {
         "address": "grpc.core.persistence.one:443",
         "provider": "Persistence"
-      },
-      {
-        "address": "grpc-persistent-ia.cosmosia.notional.ventures:443",
-        "provider": "Notional"
       },
       {
         "address": "persistence.grpc.m.stavr.tech:410",

--- a/provenance/chain.json
+++ b/provenance/chain.json
@@ -133,10 +133,6 @@
         "provider": "Figure"
       },
       {
-        "address": "https://rpc-provenance-ia.cosmosia.notional.ventures/",
-        "provider": "Notional"
-      },
-      {
         "address": "https://provenance-mainnet-rpc.autostake.com:443",
         "provider": "AutoStake 🛡️ Slash Protected"
       },
@@ -187,10 +183,6 @@
         "provider": "🔥STAVR🔥"
       },
       {
-        "address": "https://api-provenance-ia.cosmosia.notional.ventures/",
-        "provider": "Notional"
-      },
-      {
         "address": "https://provenance.ibs.team:443/api",
         "provider": "Inter Blockchain Services"
       },
@@ -227,10 +219,6 @@
       {
         "address": "provenance-mainnet-grpc.autostake.com:443",
         "provider": "AutoStake 🛡️ Slash Protected"
-      },
-      {
-        "address": "grpc-provenance-ia.cosmosia.notional.ventures:443",
-        "provider": "Notional"
       },
       {
         "address": "provenance-grpc.panthea.eu:16780",

--- a/regen/chain.json
+++ b/regen/chain.json
@@ -121,10 +121,6 @@
         "provider": "forbole"
       },
       {
-        "address": "https://rpc-regen-ia.cosmosia.notional.ventures/",
-        "provider": "Notional"
-      },
-      {
         "address": "https://regen-mainnet-rpc.autostake.com:443",
         "provider": "AutoStake 🛡️ Slash Protected"
       },
@@ -159,10 +155,6 @@
         "provider": "🔥STAVR🔥"
       },
       {
-        "address": "https://api-regen-ia.cosmosia.notional.ventures/",
-        "provider": "Notional"
-      },
-      {
         "address": "https://regen-mainnet-lcd.autostake.com:443",
         "provider": "AutoStake 🛡️ Slash Protected"
       },
@@ -188,10 +180,6 @@
       }
     ],
     "grpc": [
-      {
-        "address": "grpc-regen-ia.cosmosia.notional.ventures:443",
-        "provider": "Notional"
-      },
       {
         "address": "regen-mainnet-grpc.autostake.com:443",
         "provider": "AutoStake 🛡️ Slash Protected"

--- a/sentinel/chain.json
+++ b/sentinel/chain.json
@@ -252,10 +252,6 @@
         "provider": "Busurnode"
       },
       {
-        "address": "https://rpc-sentinel-ia.cosmosia.notional.ventures/",
-        "provider": "Notional"
-      },
-      {
         "address": "https://rpc.sentinel.chaintools.tech/",
         "provider": "ChainTools"
       },
@@ -334,10 +330,6 @@
         "provider": "Busurnode"
       },
       {
-        "address": "https://api-sentinel-ia.cosmosia.notional.ventures/",
-        "provider": "Notional"
-      },
-      {
         "address": "https://api.sentinel.quokkastake.io",
         "provider": "🐹 Quokka Stake"
       },
@@ -399,10 +391,6 @@
       }
     ],
     "grpc": [
-      {
-        "address": "grpc-sentinel-ia.cosmosia.notional.ventures:443",
-        "provider": "Notional"
-      },
       {
         "address": "sentinel.grpcui.chaintools.host:443",
         "provider": "ChainTools"

--- a/sifchain/chain.json
+++ b/sifchain/chain.json
@@ -108,10 +108,6 @@
     ],
     "rest": [
       {
-        "address": "https://api-sifchain-ia.cosmosia.notional.ventures/",
-        "provider": "Notional"
-      },
-      {
         "address": "https://sifchain-api.polkachu.com",
         "provider": "Polkachu"
       },

--- a/stargaze/chain.json
+++ b/stargaze/chain.json
@@ -148,10 +148,6 @@
         "provider": "Polkachu"
       },
       {
-        "address": "https://rpc-stargaze-ia.cosmosia.notional.ventures/",
-        "provider": "Notional"
-      },
-      {
         "address": "https://stargaze.c29r3.xyz:443/rpc/",
         "provider": "c29r3"
       },
@@ -230,10 +226,6 @@
         "provider": "EZStaking.io"
       },
       {
-        "address": "https://api-stargaze-ia.cosmosia.notional.ventures/",
-        "provider": "Notional"
-      },
-      {
         "address": "https://stargaze.c29r3.xyz:443/api/",
         "provider": "c29r3"
       },
@@ -303,10 +295,6 @@
       }
     ],
     "grpc": [
-      {
-        "address": "grpc-stargaze-ia.cosmosia.notional.ventures:443",
-        "provider": "Notional"
-      },
       {
         "address": "stargaze-grpc.polkachu.com:13790",
         "provider": "Polkachu"

--- a/starname/chain.json
+++ b/starname/chain.json
@@ -66,28 +66,14 @@
   "apis": {
     "rpc": [
       {
-        "address": "https://rpc-starname-ia.cosmosia.notional.ventures/",
-        "provider": "Notional"
-      },
-      {
         "address": "https://rpc.starname.app",
         "provider": "Chainmasters"
       }
     ],
     "rest": [
       {
-        "address": "https://api-starname-ia.cosmosia.notional.ventures/",
-        "provider": "Notional"
-      },
-      {
         "address": "https://rest.starname.app",
         "provider": "Chainmasters"
-      }
-    ],
-    "grpc": [
-      {
-        "address": "grpc-starname-ia.cosmosia.notional.ventures:443",
-        "provider": "starname"
       }
     ]
   },

--- a/umee/chain.json
+++ b/umee/chain.json
@@ -172,10 +172,6 @@
         "provider": "Polkachu"
       },
       {
-        "address": "https://rpc-umee-ia.cosmosia.notional.ventures/",
-        "provider": "Notional"
-      },
-      {
         "address": "https://umee-mainnet-rpc.autostake.com:443",
         "provider": "AutoStake 🛡️ Slash Protected"
       },
@@ -238,10 +234,6 @@
     ],
     "rest": [
       {
-        "address": "https://api-umee-ia.cosmosia.notional.ventures/",
-        "provider": "Notional"
-      },
-      {
         "address": "https://umee.api.m.stavr.tech",
         "provider": "🔥STAVR🔥"
       },
@@ -303,10 +295,6 @@
       }
     ],
     "grpc": [
-      {
-        "address": "grpc-umee-ia.cosmosia.notional.ventures:443",
-        "provider": "Notional"
-      },
       {
         "address": "umee-grpc.polkachu.com:13690",
         "provider": "Polkachu"

--- a/vidulum/chain.json
+++ b/vidulum/chain.json
@@ -94,10 +94,6 @@
         "provider": "🔥STAVR🔥"
       },
       {
-        "address": "https://rpc-vidulum-ia.cosmosia.notional.ventures/",
-        "provider": "Notional"
-      },
-      {
         "address": "https://vidulum.declab.pro:26619",
         "provider": "Decloud Nodes Lab"
       }
@@ -106,10 +102,6 @@
       {
         "address": "https://mainnet-lcd.vidulum.app",
         "provider": "vidulum"
-      },
-      {
-        "address": "https://api-vidulum-ia.cosmosia.notional.ventures/",
-        "provider": "Notional"
       },
       {
         "address": "https://vidulum.api.m.stavr.tech",
@@ -125,10 +117,6 @@
       }
     ],
     "grpc": [
-      {
-        "address": "grpc-vidulum-ia.cosmosia.notional.ventures:443",
-        "provider": "Notional"
-      },
       {
         "address": "vidulum.grpc.m.stavr.tech:2040",
         "provider": "🔥STAVR🔥"


### PR DESCRIPTION
Removes all **85 dead Notional RPC/REST/gRPC endpoints** across **30 chains**.

### Why
Notional's public node infrastructure is fully decommissioned — **both domains are NXDOMAIN** (verified 2026-07-02):
- `notional.ventures` → does not resolve
- `cosmosia.notional.ventures` → does not resolve

Every registered endpoint on `*.cosmosia.notional.ventures` / `*.notional.ventures` is therefore dead.

### Notes
- Where a dead Notional entry was the sole element of an api array (e.g. `starname` gRPC), the now-empty array/key is removed.
- **`dig` is intentionally excluded**: its *only* endpoints were Notional, so removal would leave it with zero endpoints — it looks like a dead chain and should be reviewed separately rather than silently emptied here.
- Notional has **no** `peers[]` entries, so this is a complete cleanup.
