### PR TITLE
fix: remove dead PRO Delegators endpoints registry-wide (9 chains)

### DIFF
--- a/atomone/chain.json
+++ b/atomone/chain.json
@@ -206,10 +206,6 @@
         "provider": "crosnest"
       },
       {
-        "address": "https://community.nuxian-node.ch:6797/atomone/trpc",
-        "provider": "PRO Delegators"
-      },
-      {
         "address": "https://atomone-rpc.publicnode.com:443",
         "provider": "Allnodes ⚡️ Nodes & Staking"
       },
@@ -334,10 +330,6 @@
       {
         "address": "https://rest-atomone-1.cros-nest.com:443",
         "provider": "crosnest"
-      },
-      {
-        "address": "https://community.nuxian-node.ch:6797/atomone/crpc",
-        "provider": "PRO Delegators"
       },
       {
         "address": "https://atomone-rest.publicnode.com",

--- a/babylon/chain.json
+++ b/babylon/chain.json
@@ -160,10 +160,6 @@
         "provider": "AutoStake 🛡️ Slash Protected"
       },
       {
-        "address": "https://community.nuxian-node.ch:6797/babylon/trpc",
-        "provider": "PRO Delegators"
-      },
-      {
         "address": "https://rpc.babylon.validatus.com",
         "provider": "Validatus"
       }
@@ -188,10 +184,6 @@
       {
         "address": "https://babylon-mainnet-lcd.autostake.com:443",
         "provider": "AutoStake 🛡️ Slash Protected"
-      },
-      {
-        "address": "https://community.nuxian-node.ch:6797/babylon/crpc",
-        "provider": "PRO Delegators"
       },
       {
         "address": "https://api.babylon.validatus.com",

--- a/cosmoshub/chain.json
+++ b/cosmoshub/chain.json
@@ -274,10 +274,6 @@
         "provider": "w3coins"
       },
       {
-        "address": "https://community.nuxian-node.ch:6797/gaia/trpc",
-        "provider": "PRO Delegators"
-      },
-      {
         "address": "https://cosmos-rpc.highstakes.ch",
         "provider": "High Stakes 🇨🇭"
       },
@@ -403,10 +399,6 @@
       {
         "address": "https://cosmos-api.w3coins.io",
         "provider": "w3coins"
-      },
-      {
-        "address": "https://community.nuxian-node.ch:6797/gaia/crpc",
-        "provider": "PRO Delegators"
       },
       {
         "address": "https://cosmos-api.highstakes.ch",

--- a/dydx/chain.json
+++ b/dydx/chain.json
@@ -177,19 +177,11 @@
         "provider": "Enigma"
       },
       {
-        "address": "https://community.nuxian-node.ch:6797/dydx/trpc",
-        "provider": "PRO Delegators"
-      },
-      {
         "address": "https://dydx-rpc.noders.services",
         "provider": "[NODERS]TEAM"
       }
     ],
     "rest": [
-      {
-        "address": "https://community.nuxian-node.ch:6797/dydx/crpc",
-        "provider": "PRO Delegators"
-      },
       {
         "address": "https://dydx-dao-api.polkachu.com",
         "provider": "Polkachu"

--- a/dymension/chain.json
+++ b/dymension/chain.json
@@ -212,10 +212,6 @@
         "provider": "WhisperNode 🤐"
       },
       {
-        "address": "https://community.nuxian-node.ch:6797/dymension/trpc",
-        "provider": "PRO Delegators"
-      },
-      {
         "address": "https://dymension-rpc.enigma-validator.com",
         "provider": "Enigma"
       },
@@ -332,10 +328,6 @@
       {
         "address": "https://api-dymension.whispernode.com:443",
         "provider": "WhisperNode 🤐"
-      },
-      {
-        "address": "https://community.nuxian-node.ch:6797/dymension/crpc",
-        "provider": "PRO Delegators"
       },
       {
         "address": "https://dymension-lcd.enigma-validator.com",

--- a/elys/chain.json
+++ b/elys/chain.json
@@ -217,10 +217,6 @@
         "provider": "itrocket"
       },
       {
-        "address": "https://community.nuxian-node.ch:6797/elys/trpc",
-        "provider": "PRO Delegators"
-      },
-      {
         "address": "https://elys-rpc.stake-town.com:443",
         "provider": "StakeTown"
       },
@@ -257,10 +253,6 @@
       {
         "address": "https://elys-mainnet-api.itrocket.net",
         "provider": "itrocket"
-      },
-      {
-        "address": "https://community.nuxian-node.ch:6797/elys/crpc",
-        "provider": "PRO Delegators"
       },
       {
         "address": "https://elys-api.stake-town.com:443",

--- a/neutron/chain.json
+++ b/neutron/chain.json
@@ -170,10 +170,6 @@
         "provider": "Allnodes ⚡️ Nodes & Staking"
       },
       {
-        "address": "https://community.nuxian-node.ch:6797/neutron/trpc",
-        "provider": "PRO Delegators"
-      },
-      {
         "address": "https://rpc.neutron.bronbro.io:443",
         "provider": "Bro_n_Bro"
       },
@@ -227,10 +223,6 @@
       {
         "address": "https://neutron-rest.publicnode.com",
         "provider": "Allnodes ⚡️ Nodes & Staking"
-      },
-      {
-        "address": "https://community.nuxian-node.ch:6797/neutron/crpc",
-        "provider": "PRO Delegators"
       },
       {
         "address": "https://lcd.neutron.bronbro.io:443",

--- a/osmosis/chain.json
+++ b/osmosis/chain.json
@@ -731,10 +731,6 @@
         "provider": "Allnodes ⚡️ Nodes & Staking"
       },
       {
-        "address": "https://community.nuxian-node.ch:6797/osmosis/trpc",
-        "provider": "PRO Delegators"
-      },
-      {
         "address": "http://rpc-osmosis.freshstaking.com:31657",
         "provider": "FreshSTAKING"
       },
@@ -803,10 +799,6 @@
       {
         "address": "https://osmosis-rest.publicnode.com",
         "provider": "Allnodes ⚡️ Nodes & Staking"
-      },
-      {
-        "address": "https://community.nuxian-node.ch:6797/osmosis/crpc",
-        "provider": "PRO Delegators"
       },
       {
         "address": "https://osmosis-api.stake-town.com",

--- a/stride/chain.json
+++ b/stride/chain.json
@@ -281,10 +281,6 @@
         "provider": "Allnodes ⚡️ Nodes & Staking"
       },
       {
-        "address": "https://community.nuxian-node.ch:6797/stride/trpc",
-        "provider": "PRO Delegators"
-      },
-      {
         "address": "https://stride-rpc.stakeandrelax.net",
         "provider": "Stake&Relax 🦥"
       },
@@ -317,10 +313,6 @@
       {
         "address": "https://stride-rest.publicnode.com",
         "provider": "Allnodes ⚡️ Nodes & Staking"
-      },
-      {
-        "address": "https://community.nuxian-node.ch:6797/stride/crpc",
-        "provider": "PRO Delegators"
       },
       {
         "address": "https://stride-api.stakeandrelax.net",


### PR DESCRIPTION
Removes all **18 dead PRO Delegators RPC/REST endpoints** across **9 chains**.

### Why
PRO Delegators' endpoints (`community.nuxian-node.ch:6797/<chain>/{trpc,crpc}`) return **HTTP 404** on every chain path *and* on the proxy root — registry-wide (verified 2026-07-02 across cosmoshub, osmosis, juno, stargaze, dydx, and others). The proxy is up but serves nothing.

No `peers[]` entries — complete cleanup.
