### PR TITLE
fix: remove dead AutoStake endpoints & peers registry-wide (83 chains)

### DIFF
--- a/acrechain/chain.json
+++ b/acrechain/chain.json
@@ -67,11 +67,6 @@
         "id": "d86d7a9d8059ae726f3322ff1eb9e2797fe62a72",
         "address": "65.108.233.44:26616",
         "provider": "StakeTab"
-      },
-      {
-        "id": "ebc272824924ea1a27ea3183dd0b9ba713494f83",
-        "address": "acrechain-mainnet-seed.autostake.com:26956",
-        "provider": "AutoStake 🛡️ Slash Protected"
       }
     ],
     "persistent_peers": [
@@ -89,11 +84,6 @@
         "id": "bac90a590452337700e0033315e96430d19a3ffa",
         "address": "23.106.238.167:26656",
         "provider": "Synergy Nodes"
-      },
-      {
-        "id": "ebc272824924ea1a27ea3183dd0b9ba713494f83",
-        "address": "acrechain-mainnet-peer.autostake.com:26956",
-        "provider": "AutoStake 🛡️ Slash Protected"
       },
       {
         "id": "82726047c95e4ddf9a0fa82e4c4c4f17cbf3f140",
@@ -119,10 +109,6 @@
         "provider": "Synergy Nodes"
       },
       {
-        "address": "https://acrechain-mainnet-rpc.autostake.com:443",
-        "provider": "AutoStake 🛡️ Slash Protected"
-      },
-      {
         "address": "https://mainnet-acre-rpc.konsortech.xyz",
         "provider": "KonsorTech"
       },
@@ -137,10 +123,6 @@
         "provider": "Synergy Nodes"
       },
       {
-        "address": "https://acrechain-mainnet-lcd.autostake.com:443",
-        "provider": "AutoStake 🛡️ Slash Protected"
-      },
-      {
         "address": "https://mainnet-acre-api.konsortech.xyz",
         "provider": "KonsorTech"
       },
@@ -150,10 +132,6 @@
       }
     ],
     "grpc": [
-      {
-        "address": "acrechain-mainnet-grpc.autostake.com:443",
-        "provider": "AutoStake 🛡️ Slash Protected"
-      },
       {
         "address": "acre-grpc.genznodes.dev:27090",
         "provider": "genznodes"

--- a/agoric/chain.json
+++ b/agoric/chain.json
@@ -88,11 +88,6 @@
         "provider": "kjnodes"
       },
       {
-        "id": "ebc272824924ea1a27ea3183dd0b9ba713494f83",
-        "address": "agoric-mainnet-seed.autostake.com:27106",
-        "provider": "AutoStake 🛡️ Slash Protected"
-      },
-      {
         "id": "6ab5521047ae8e7bb0273a90029a6d445eb1a0a1",
         "address": "seed-agoric-01.stakeflow.io:2206",
         "provider": "Stakeflow"
@@ -107,11 +102,6 @@
       {
         "id": "6e26a1b4afa6889f841d7957e8c2b5d50d32d485",
         "address": "95.216.53.26:26656"
-      },
-      {
-        "id": "ebc272824924ea1a27ea3183dd0b9ba713494f83",
-        "address": "agoric-mainnet-peer.autostake.com:27106",
-        "provider": "AutoStake 🛡️ Slash Protected"
       },
       {
         "id": "6ab5521047ae8e7bb0273a90029a6d445eb1a0a1",
@@ -137,10 +127,6 @@
       {
         "address": "https://agoric.rpc.kjnodes.com",
         "provider": "kjnodes"
-      },
-      {
-        "address": "https://agoric-mainnet-rpc.autostake.com:443",
-        "provider": "AutoStake 🛡️ Slash Protected"
       },
       {
         "address": "https://rpc-agoric-01.stakeflow.io",
@@ -184,10 +170,6 @@
         "provider": "kjnodes"
       },
       {
-        "address": "https://agoric-mainnet-lcd.autostake.com:443",
-        "provider": "AutoStake 🛡️ Slash Protected"
-      },
-      {
         "address": "https://api-agoric-01.stakeflow.io",
         "provider": "Stakeflow"
       },
@@ -220,10 +202,6 @@
       {
         "address": "agoric-grpc.polkachu.com:14490",
         "provider": "Polkachu"
-      },
-      {
-        "address": "agoric-mainnet-grpc.autostake.com:443",
-        "provider": "AutoStake 🛡️ Slash Protected"
       },
       {
         "address": "agoric.grpc.kjnodes.com:12790",

--- a/akash/chain.json
+++ b/akash/chain.json
@@ -75,11 +75,6 @@
         "provider": "Lavender.Five Nodes 🐝"
       },
       {
-        "id": "ebc272824924ea1a27ea3183dd0b9ba713494f83",
-        "address": "akash-mainnet-seed.autostake.com:26696",
-        "provider": "AutoStake 🛡️ Slash Protected"
-      },
-      {
         "id": "8542cd7e6bf9d260fef543bc49e59be5a3fa9074",
         "address": "seed.publicnode.com:26656",
         "provider": "Allnodes ⚡️ Nodes & Staking"

--- a/andromeda/chain.json
+++ b/andromeda/chain.json
@@ -69,11 +69,6 @@
         "provider": "StakerHouse"
       },
       {
-        "id": "ebc272824924ea1a27ea3183dd0b9ba713494f83",
-        "address": "andromeda-mainnet-peer.autostake.com:27126",
-        "provider": "AutoStake 🛡️ Slash Protected"
-      },
-      {
         "id": "400f3d9e30b69e78a7fb891f60d76fa3c73f0ecc",
         "address": "andromeda.rpc.kjnodes.com:14759",
         "provider": "kjnodes.com 🦄"
@@ -109,11 +104,6 @@
         "id": "20e1000e88125698264454a884812746c2eb4807",
         "address": "seeds.lavenderfive.com:14956",
         "provider": "Lavender.Five Nodes 🐝"
-      },
-      {
-        "id": "ebc272824924ea1a27ea3183dd0b9ba713494f83",
-        "address": "andromeda-mainnet-seed.autostake.com:27126",
-        "provider": "AutoStake 🛡️ Slash Protected"
       }
     ]
   },
@@ -134,10 +124,6 @@
       {
         "address": "https://rpc.lavenderfive.com:443/andromeda",
         "provider": "Lavender.Five Nodes 🐝"
-      },
-      {
-        "address": "https://andromeda-mainnet-rpc.autostake.com:443",
-        "provider": "AutoStake 🛡️ Slash Protected"
       },
       {
         "address": "https://andromeda-rpc.stakerhouse.com:443",
@@ -178,10 +164,6 @@
         "provider": "Lavender.Five Nodes 🐝"
       },
       {
-        "address": "https://andromeda-mainnet-lcd.autostake.com:443",
-        "provider": "AutoStake 🛡️ Slash Protected"
-      },
-      {
         "address": "https://andromeda-rest.stakerhouse.com:443",
         "provider": "StakerHouse"
       },
@@ -210,10 +192,6 @@
       {
         "address": "andromeda.grpc.kjnodes.com:443",
         "provider": "kjnodes"
-      },
-      {
-        "address": "andromeda-mainnet-grpc.autostake.com:443",
-        "provider": "AutoStake 🛡️ Slash Protected"
       },
       {
         "address": "https://andromeda.grpc.nodex.one:443",

--- a/andromeda1/chain.json
+++ b/andromeda1/chain.json
@@ -44,11 +44,6 @@
         "provider": "StakerHouse"
       },
       {
-        "id": "ebc272824924ea1a27ea3183dd0b9ba713494f83",
-        "address": "andromeda-mainnet-peer.autostake.com:27126",
-        "provider": "AutoStake 🛡️ Slash Protected"
-      },
-      {
         "id": "400f3d9e30b69e78a7fb891f60d76fa3c73f0ecc",
         "address": "nibiru.rpc.kjnodes.com:13959",
         "provider": "kjnodes.com 🦄"
@@ -84,11 +79,6 @@
         "id": "20e1000e88125698264454a884812746c2eb4807",
         "address": "seeds.lavenderfive.com:14956",
         "provider": "Lavender.Five Nodes 🐝"
-      },
-      {
-        "id": "ebc272824924ea1a27ea3183dd0b9ba713494f83",
-        "address": "andromeda-mainnet-seed.autostake.com:27126",
-        "provider": "AutoStake 🛡️ Slash Protected"
       }
     ]
   },
@@ -113,10 +103,6 @@
       {
         "address": "https://rpc.lavenderfive.com:443/andromeda",
         "provider": "Lavender.Five Nodes 🐝"
-      },
-      {
-        "address": "https://andromeda-mainnet-rpc.autostake.com:443",
-        "provider": "AutoStake 🛡️ Slash Protected"
       },
       {
         "address": "https://andromeda-rpc.stakerhouse.com:443",
@@ -157,10 +143,6 @@
         "provider": "Lavender.Five Nodes 🐝"
       },
       {
-        "address": "https://andromeda-mainnet-lcd.autostake.com:443",
-        "provider": "AutoStake 🛡️ Slash Protected"
-      },
-      {
         "address": "https://andromeda-rest.stakerhouse.com:443",
         "provider": "StakerHouse"
       },
@@ -189,10 +171,6 @@
       {
         "address": "andromeda.grpc.kjnodes.com:443",
         "provider": "kjnodes"
-      },
-      {
-        "address": "andromeda-mainnet-grpc.autostake.com:443",
-        "provider": "AutoStake 🛡️ Slash Protected"
       },
       {
         "address": "https://andromeda.grpc.nodex.one:443",

--- a/archway/chain.json
+++ b/archway/chain.json
@@ -85,11 +85,6 @@
         "provider": "AM Solutions"
       },
       {
-        "id": "ebc272824924ea1a27ea3183dd0b9ba713494f83",
-        "address": "archway-mainnet-seed.autostake.com:26946",
-        "provider": "AutoStake 🛡️ Slash Protected"
-      },
-      {
         "id": "20e1000e88125698264454a884812746c2eb4807",
         "address": "seeds.lavenderfive.com:11556",
         "provider": "Lavender.Five Nodes 🐝"
@@ -131,11 +126,6 @@
       }
     ],
     "persistent_peers": [
-      {
-        "id": "ebc272824924ea1a27ea3183dd0b9ba713494f83",
-        "address": "archway-mainnet-peer.autostake.com:26946",
-        "provider": "AutoStake 🛡️ Slash Protected"
-      },
       {
         "id": "a477bfcef79f283d82e531ec1a6717677c8caf59",
         "address": "peer-archway.mms.team:56108",

--- a/arkeo/chain.json
+++ b/arkeo/chain.json
@@ -91,11 +91,6 @@
         "address": "peer2.arkeo.network:26656"
       },
       {
-        "id": "ebc272824924ea1a27ea3183dd0b9ba713494f83",
-        "address": "arkeo-mainnet-peer.autostake.com:27356",
-        "provider": "AutoStake 🛡️ Slash Protected"
-      },
-      {
         "id": "7e2765366b5dd6873827ae4fa3253b508e6c4287",
         "address": "p2p.tendermint.roomit.xyz:26600",
         "provider": "Roomit"
@@ -107,10 +102,6 @@
       {
         "address": "https://rpc-seed.arkeo.network",
         "provider": "Arkeo"
-      },
-      {
-        "address": "https://arkeo-mainnet-rpc.autostake.com:443",
-        "provider": "AutoStake 🛡️ Slash Protected"
       },
       {
         "address": "https://rpc.arkeo.roomit.xyz",
@@ -129,10 +120,6 @@
       {
         "address": "https://rest-seed.arkeo.network",
         "provider": "Arkeo"
-      },
-      {
-        "address": "https://arkeo-mainnet-lcd.autostake.com:443",
-        "provider": "AutoStake 🛡️ Slash Protected"
       },
       {
         "address": "https://api.arkeo.roomit.xyz",

--- a/atomone/chain.json
+++ b/atomone/chain.json
@@ -86,11 +86,6 @@
         "provider": "Inter Blockchain Services"
       },
       {
-        "id": "ebc272824924ea1a27ea3183dd0b9ba713494f83",
-        "address": "atomone-mainnet-seed.autostake.com:27396",
-        "provider": "AutoStake 🛡️ Slash Protected"
-      },
-      {
         "id": "258f523c96efde50d5fe0a9faeea8a3e83be22ca",
         "address": "seed.atomone-1.atomone.aviaone.com:10293",
         "provider": "AVIAONE.com 🟢"
@@ -130,11 +125,6 @@
       {
         "id": "9dac79c27e4dba77cb22b0b25933fee6c8121cf7",
         "address": "72.46.84.243:26656"
-      },
-      {
-        "id": "ebc272824924ea1a27ea3183dd0b9ba713494f83",
-        "address": "atomone-mainnet-peer.autostake.com:27396",
-        "provider": "AutoStake 🛡️ Slash Protected"
       },
       {
         "id": "eec666a28728bad46a31fd352cc61bc5998efc1d",
@@ -216,10 +206,6 @@
       {
         "address": "https://atomone.ibs.team:443/rpc",
         "provider": "Inter Blockchain Services"
-      },
-      {
-        "address": "https://atomone-mainnet-rpc.autostake.com:443",
-        "provider": "AutoStake 🛡️ Slash Protected"
       },
       {
         "address": "https://rpc.atomone-1.atomone.aviaone.com:443",
@@ -344,10 +330,6 @@
         "provider": "Inter Blockchain Services"
       },
       {
-        "address": "https://atomone-mainnet-lcd.autostake.com:443",
-        "provider": "AutoStake 🛡️ Slash Protected"
-      },
-      {
         "address": "https://api.atomone-1.atomone.aviaone.com",
         "provider": "AVIAONE.com 🟢"
       },
@@ -456,10 +438,6 @@
       {
         "address": "atomone-grpc.publicnode.com:443",
         "provider": "Allnodes ⚡️ Nodes & Staking"
-      },
-      {
-        "address": "atomone-mainnet-grpc.autostake.com:443",
-        "provider": "AutoStake 🛡️ Slash Protected"
       },
       {
         "address": "http://grpc.atomone-1.atomone.aviaone.com:9102",

--- a/aura/chain.json
+++ b/aura/chain.json
@@ -77,11 +77,6 @@
         "address": "18.143.52.13:26656"
       },
       {
-        "id": "ebc272824924ea1a27ea3183dd0b9ba713494f83",
-        "address": "auranetwork-mainnet-seed.autostake.com:26966",
-        "provider": "AutoStake 🛡️ Slash Protected"
-      },
-      {
         "id": "0b8bd8c1b956b441f036e71df3a4d96e85f843b8",
         "address": "13.250.159.219:26656"
       },
@@ -102,11 +97,6 @@
       }
     ],
     "persistent_peers": [
-      {
-        "id": "ebc272824924ea1a27ea3183dd0b9ba713494f83",
-        "address": "auranetwork-mainnet-peer.autostake.com:26966",
-        "provider": "AutoStake 🛡️ Slash Protected"
-      },
       {
         "id": "ced3a13f4f7200ce1a2392a5738c88532f794359",
         "address": "mainnet-aura.konsortech.xyz:25656",
@@ -275,10 +265,6 @@
       {
         "address": "https://grpc.aura.network",
         "provider": "Aura Network Foundation"
-      },
-      {
-        "address": "auranetwork-mainnet-grpc.autostake.com:443",
-        "provider": "AutoStake 🛡️ Slash Protected"
       },
       {
         "address": "aura.mainnet.grpc.nodersteam.com:9100/",

--- a/aura1/chain.json
+++ b/aura1/chain.json
@@ -68,11 +68,6 @@
         "address": "18.143.52.13:26656"
       },
       {
-        "id": "ebc272824924ea1a27ea3183dd0b9ba713494f83",
-        "address": "auranetwork-mainnet-seed.autostake.com:26966",
-        "provider": "AutoStake 🛡️ Slash Protected"
-      },
-      {
         "id": "0b8bd8c1b956b441f036e71df3a4d96e85f843b8",
         "address": "13.250.159.219:26656"
       },
@@ -93,11 +88,6 @@
       }
     ],
     "persistent_peers": [
-      {
-        "id": "ebc272824924ea1a27ea3183dd0b9ba713494f83",
-        "address": "auranetwork-mainnet-peer.autostake.com:26966",
-        "provider": "AutoStake 🛡️ Slash Protected"
-      },
       {
         "id": "ced3a13f4f7200ce1a2392a5738c88532f794359",
         "address": "mainnet-aura.konsortech.xyz:25656",
@@ -287,10 +277,6 @@
       {
         "address": "https://grpc.aura.network",
         "provider": "Aura Network Foundation"
-      },
-      {
-        "address": "auranetwork-mainnet-grpc.autostake.com:443",
-        "provider": "AutoStake 🛡️ Slash Protected"
       },
       {
         "address": "aura.mainnet.grpc.nodersteam.com:9100/",

--- a/axelar/chain.json
+++ b/axelar/chain.json
@@ -93,11 +93,6 @@
         "provider": "Polkachu"
       },
       {
-        "id": "ebc272824924ea1a27ea3183dd0b9ba713494f83",
-        "address": "axelar-mainnet-seed.autostake.com:26826",
-        "provider": "AutoStake 🛡️ Slash Protected"
-      },
-      {
         "id": "c28827cb96c14c905b127b92065a3fb4cd77d7f6",
         "address": "seeds.whispernode.com:15156",
         "provider": "WhisperNode 🤐"
@@ -122,11 +117,6 @@
       {
         "id": "353f7d0962594bcbfb63c81594e35e39c4c89a1a",
         "address": "18.223.127.165:26656"
-      },
-      {
-        "id": "ebc272824924ea1a27ea3183dd0b9ba713494f83",
-        "address": "axelar-mainnet-peer.autostake.com:26826",
-        "provider": "AutoStake 🛡️ Slash Protected"
       },
       {
         "id": "3470414cd299d15911e9bb28557f6bffb8e514c6",
@@ -175,10 +165,6 @@
         "provider": "QuantNode"
       },
       {
-        "address": "https://axelar-mainnet-rpc.autostake.com:443",
-        "provider": "AutoStake 🛡️ Slash Protected"
-      },
-      {
         "address": "https://axelar-rpc.rockrpc.net/",
         "provider": "RockawayX Infra"
       },
@@ -225,10 +211,6 @@
         "provider": "Stakin"
       },
       {
-        "address": "https://axelar-mainnet-lcd.autostake.com:443",
-        "provider": "AutoStake 🛡️ Slash Protected"
-      },
-      {
         "address": "https://axelar.lcd.quantnode.xyz/",
         "provider": "QuantNode"
       },
@@ -261,10 +243,6 @@
       {
         "address": "axelar.grpc.stakin-nodes.com:443",
         "provider": "Stakin"
-      },
-      {
-        "address": "axelar-mainnet-grpc.autostake.com:443",
-        "provider": "AutoStake 🛡️ Slash Protected"
       },
       {
         "address": "axelar-grpc.publicnode.com:443",

--- a/babylon/chain.json
+++ b/babylon/chain.json
@@ -126,11 +126,6 @@
         "provider": "Polkachu"
       },
       {
-        "id": "ebc272824924ea1a27ea3183dd0b9ba713494f83",
-        "address": "babylon-mainnet-seed.autostake.com:27116",
-        "provider": "AutoStake 🛡️ Slash Protected"
-      },
-      {
         "id": "637077d431f618181597706810a65c826524fd74",
         "address": "babylon.rpc.nodeshub.online:20656",
         "provider": "NodesHub"
@@ -156,10 +151,6 @@
         "provider": "Allnodes ⚡️ Nodes & Staking"
       },
       {
-        "address": "https://babylon-mainnet-rpc.autostake.com:443",
-        "provider": "AutoStake 🛡️ Slash Protected"
-      },
-      {
         "address": "https://rpc.babylon.validatus.com",
         "provider": "Validatus"
       }
@@ -182,10 +173,6 @@
         "provider": "Allnodes ⚡️ Nodes & Staking"
       },
       {
-        "address": "https://babylon-mainnet-lcd.autostake.com:443",
-        "provider": "AutoStake 🛡️ Slash Protected"
-      },
-      {
         "address": "https://api.babylon.validatus.com",
         "provider": "Validatus"
       }
@@ -206,10 +193,6 @@
       {
         "address": "babylon-grpc.publicnode.com:443",
         "provider": "Allnodes ⚡️ Nodes & Staking"
-      },
-      {
-        "address": "babylon-mainnet-grpc.autostake.com:443",
-        "provider": "AutoStake 🛡️ Slash Protected"
       },
       {
         "address": "grpc.babylon.validatus.com:443",

--- a/bandchain/chain.json
+++ b/bandchain/chain.json
@@ -82,11 +82,6 @@
         "address": "seeds-bandprotocol.activenodes.io:36656"
       },
       {
-        "id": "ebc272824924ea1a27ea3183dd0b9ba713494f83",
-        "address": "bandchain-mainnet-seed.autostake.com:26666",
-        "provider": "AutoStake 🛡️ Slash Protected"
-      },
-      {
         "id": "4ded49b3a718828eb64cf35da1ed791ecb201bc1",
         "address": "seed-band-01.stakeflow.io:25017",
         "provider": "Stakeflow"
@@ -122,11 +117,6 @@
         "address": "91.99.222.87:26656"
       },
       {
-        "id": "ebc272824924ea1a27ea3183dd0b9ba713494f83",
-        "address": "bandchain-mainnet-peer.autostake.com:26666",
-        "provider": "AutoStake 🛡️ Slash Protected"
-      },
-      {
         "id": "0bfd5d7355ebf38e35af619ae0cab70aa21675a5",
         "address": "band-m.peer.stavr.tech:11026",
         "provider": "🔥STAVR🔥"
@@ -157,10 +147,6 @@
       {
         "address": "https://band.ibs.team:443/rpc",
         "provider": "Inter Blockchain Services"
-      },
-      {
-        "address": "https://bandchain-mainnet-rpc.autostake.com:443",
-        "provider": "AutoStake 🛡️ Slash Protected"
       },
       {
         "address": "https://band.rpc.m.stavr.tech:443",
@@ -217,10 +203,6 @@
         "provider": "🔥STAVR🔥"
       },
       {
-        "address": "https://bandchain-mainnet-lcd.autostake.com:443",
-        "provider": "AutoStake 🛡️ Slash Protected"
-      },
-      {
         "address": "https://api-band-01.stakeflow.io",
         "provider": "Stakeflow"
       },
@@ -250,10 +232,6 @@
       }
     ],
     "grpc": [
-      {
-        "address": "bandchain-mainnet-grpc.autostake.com:443",
-        "provider": "AutoStake 🛡️ Slash Protected"
-      },
       {
         "address": "grpc-band.cosmos-spaces.cloud:2240",
         "provider": "Cosmos Spaces"

--- a/canto/chain.json
+++ b/canto/chain.json
@@ -51,11 +51,6 @@
         "provider": "Polkachu"
       },
       {
-        "id": "ebc272824924ea1a27ea3183dd0b9ba713494f83",
-        "address": "canto-mainnet-seed.autostake.com:27156",
-        "provider": "AutoStake 🛡️ Slash Protected"
-      },
-      {
         "id": "27b6d74c8408e033e2e5a9e966a0d15782e33596",
         "address": "seeds.nethernode.xyz:15556",
         "provider": "carbonZERO🌲"
@@ -71,11 +66,6 @@
         "id": "9361d2cfb283da656b14eaf27e64d96cb86706f0",
         "address": "167.71.170.71:26656",
         "provider": "Plex"
-      },
-      {
-        "id": "ebc272824924ea1a27ea3183dd0b9ba713494f83",
-        "address": "canto-mainnet-peer.autostake.com:27156",
-        "provider": "AutoStake 🛡️ Slash Protected"
       }
     ]
   },
@@ -94,10 +84,6 @@
         "provider": "Althea"
       },
       {
-        "address": "https://canto-mainnet-rpc.autostake.com:443",
-        "provider": "AutoStake 🛡️ Slash Protected"
-      },
-      {
         "address": "https://rpc-canto.kewrnode.com",
         "provider": "Kewr Node"
       }
@@ -110,10 +96,6 @@
       {
         "address": "https://api.canto.silentvalidator.com/",
         "provider": "silent"
-      },
-      {
-        "address": "https://canto-mainnet-lcd.autostake.com:443",
-        "provider": "AutoStake 🛡️ Slash Protected"
       },
       {
         "address": "https://rest-canto.kewrnode.com",
@@ -132,10 +114,6 @@
       {
         "address": "https://canto.gravitychain.io:9090",
         "provider": "Althea"
-      },
-      {
-        "address": "canto-mainnet-grpc.autostake.com:443",
-        "provider": "AutoStake 🛡️ Slash Protected"
       }
     ],
     "evm-http-jsonrpc": [

--- a/carbon/chain.json
+++ b/carbon/chain.json
@@ -332,11 +332,6 @@
         "provider": "Lavender.Five Nodes 🐝"
       },
       {
-        "id": "ebc272824924ea1a27ea3183dd0b9ba713494f83",
-        "address": "carbon-mainnet-seed.autostake.com:27426",
-        "provider": "AutoStake 🛡️ Slash Protected"
-      },
-      {
         "id": "75efe81807f1a69d1ed5d881203e49f65afd765b",
         "address": "34.126.188.181:26656",
         "provider": "switcheo-labs"
@@ -351,13 +346,6 @@
         "address": "seed.publicnode.com:26656",
         "provider": "Allnodes ⚡️ Nodes & Staking"
       }
-    ],
-    "persistent_peers": [
-      {
-        "id": "ebc272824924ea1a27ea3183dd0b9ba713494f83",
-        "address": "carbon-mainnet-peer.autostake.com:27426",
-        "provider": "AutoStake 🛡️ Slash Protected"
-      }
     ]
   },
   "apis": {
@@ -369,10 +357,6 @@
       {
         "address": "https://rpc.lavenderfive.com:443/carbon",
         "provider": "Lavender.Five Nodes 🐝"
-      },
-      {
-        "address": "https://carbon-mainnet-rpc.autostake.com:443",
-        "provider": "AutoStake 🛡️ Slash Protected"
       },
       {
         "address": "https://rpc.carbon.blockhunters.org",
@@ -389,10 +373,6 @@
         "provider": "Lavender.Five Nodes 🐝"
       },
       {
-        "address": "https://carbon-mainnet-lcd.autostake.com:443",
-        "provider": "AutoStake 🛡️ Slash Protected"
-      },
-      {
         "address": "https://rest.carbon.blockhunters.org",
         "provider": "BlockHunters"
       }
@@ -401,10 +381,6 @@
       {
         "address": "carbon.lavenderfive.com:443",
         "provider": "Lavender.Five Nodes 🐝"
-      },
-      {
-        "address": "carbon-mainnet-grpc.autostake.com:443",
-        "provider": "AutoStake 🛡️ Slash Protected"
       }
     ]
   },

--- a/celestia/chain.json
+++ b/celestia/chain.json
@@ -81,11 +81,6 @@
         "provider": "Lunar Oasis"
       },
       {
-        "id": "ebc272824924ea1a27ea3183dd0b9ba713494f83",
-        "address": "celestia-mainnet-seed.autostake.com:27206",
-        "provider": "AutoStake | Delegate for StakeDrops"
-      },
-      {
         "id": "20e1000e88125698264454a884812746c2eb4807",
         "address": "seeds.lavenderfive.com:16656",
         "provider": "Lavender.Five Nodes 🐝"
@@ -152,11 +147,6 @@
       }
     ],
     "persistent_peers": [
-      {
-        "id": "ebc272824924ea1a27ea3183dd0b9ba713494f83",
-        "address": "celestia-mainnet-peer.autostake.com:27206",
-        "provider": "AutoStake | Delegate for StakeDrops"
-      },
       {
         "id": "24a607a217cf12be29bae5b2e8151391bde2d8c8",
         "address": "peer-celestia-01.stakeflow.io:15007",
@@ -259,10 +249,6 @@
         "provider": "AM Solutions"
       },
       {
-        "address": "https://celestia-mainnet-rpc.autostake.com:443",
-        "provider": "AutoStake | Delegate for StakeDrops"
-      },
-      {
         "address": "https://rpc.celestia.validatus.com",
         "provider": "Validatus"
       },
@@ -361,10 +347,6 @@
         "provider": "Validatus"
       },
       {
-        "address": "https://celestia-mainnet-lcd.autostake.com:443",
-        "provider": "AutoStake | Delegate for StakeDrops"
-      },
-      {
         "address": "https://celestia.api.cumulo.org.es",
         "provider": "Cumulo"
       },
@@ -401,10 +383,6 @@
       {
         "address": "https://grpc.celestia.nodestake.org",
         "provider": "NodeStake"
-      },
-      {
-        "address": "celestia-mainnet-grpc.autostake.com:443",
-        "provider": "AutoStake | Delegate for StakeDrops"
       },
       {
         "address": "celestia.lavenderfive.com:443",

--- a/chain4energy/chain.json
+++ b/chain4energy/chain.json
@@ -116,11 +116,6 @@
         "provider": "TAKESHI"
       },
       {
-        "id": "ebc272824924ea1a27ea3183dd0b9ba713494f83",
-        "address": "chain4energy-mainnet-seed.autostake.com:27276",
-        "provider": "AutoStake 🛡️ Slash Protected"
-      },
-      {
         "id": "8cb175d973c3c638a4e5d014c030d8599369419f",
         "address": "seeds.cros-nest.com:28656",
         "provider": "Crosnest"
@@ -203,11 +198,6 @@
         "provider": "Nodine.ID"
       },
       {
-        "id": "ebc272824924ea1a27ea3183dd0b9ba713494f83",
-        "address": "chain4energy-mainnet-peer.autostake.com:27276",
-        "provider": "AutoStake 🛡️ Slash Protected"
-      },
-      {
         "id": "e3d0b136495c3f4382ac801fbc89083d32625ff8",
         "address": "c4e.peer.stavr.tech:17096",
         "provider": "🔥STAVR🔥"
@@ -272,10 +262,6 @@
       {
         "address": "https://c4e.rpc.bccnodes.com",
         "provider": "BccNodes"
-      },
-      {
-        "address": "https://chain4energy-mainnet-rpc.autostake.com:443",
-        "provider": "AutoStake 🛡️ Slash Protected"
       },
       {
         "address": "https://c4e.rpc.m.stavr.tech:443",
@@ -400,10 +386,6 @@
         "provider": "BccNodes"
       },
       {
-        "address": "https://chain4energy-mainnet-lcd.autostake.com:443",
-        "provider": "AutoStake 🛡️ Slash Protected"
-      },
-      {
         "address": "https://c4e.api.m.stavr.tech",
         "provider": "🔥STAVR🔥"
       },
@@ -504,10 +486,6 @@
       {
         "address": "c4e.grpc.bccnodes.com:443",
         "provider": "BccNodes"
-      },
-      {
-        "address": "chain4energy-mainnet-grpc.autostake.com:443",
-        "provider": "AutoStake 🛡️ Slash Protected"
       },
       {
         "address": "c4e.grpc.bccnodes.com:443",

--- a/cheqd/chain.json
+++ b/cheqd/chain.json
@@ -82,11 +82,6 @@
         "provider": "cheqd"
       },
       {
-        "id": "ebc272824924ea1a27ea3183dd0b9ba713494f83",
-        "address": "cheqd-mainnet-seed.autostake.com:27326",
-        "provider": "AutoStake 🛡️ Slash Protected"
-      },
-      {
         "id": "20e1000e88125698264454a884812746c2eb4807",
         "address": "seeds.lavenderfive.com:16156",
         "provider": "Lavender.Five Nodes 🐝"
@@ -122,11 +117,6 @@
         "id": "9201b408d24941fd342e739f0814aa3eb8ab7577",
         "address": "sentry1.ap.cheqd.net:26656",
         "provider": "cheqd"
-      },
-      {
-        "id": "ebc272824924ea1a27ea3183dd0b9ba713494f83",
-        "address": "cheqd-mainnet-peer.autostake.com:27326",
-        "provider": "AutoStake 🛡️ Slash Protected"
       }
     ]
   },
@@ -151,10 +141,6 @@
       {
         "address": "https://rpc-cheqd.whispernode.com:443",
         "provider": "WhisperNode 🤐"
-      },
-      {
-        "address": "https://cheqd-mainnet-rpc.autostake.com:443",
-        "provider": "AutoStake 🛡️ Slash Protected"
       },
       {
         "address": "https://rpc-cheqd.blockval.io",
@@ -193,10 +179,6 @@
       {
         "address": "https://cheqd.api.m.stavr.tech",
         "provider": "🔥STAVR🔥"
-      },
-      {
-        "address": "https://cheqd-mainnet-lcd.autostake.com:443",
-        "provider": "AutoStake 🛡️ Slash Protected"
       },
       {
         "address": "https://api.cheqd.nodestake.org",
@@ -243,10 +225,6 @@
       {
         "address": "cheqd.lavenderfive.com:443",
         "provider": "Lavender.Five Nodes 🐝"
-      },
-      {
-        "address": "cheqd-mainnet-grpc.autostake.com:443",
-        "provider": "AutoStake 🛡️ Slash Protected"
       },
       {
         "address": "grpc.cheqd.nodestake.org:443",

--- a/chihuahua/chain.json
+++ b/chihuahua/chain.json
@@ -91,11 +91,6 @@
         "provider": "Golden Ratio Staking"
       },
       {
-        "id": "ebc272824924ea1a27ea3183dd0b9ba713494f83",
-        "address": "chihuahua-mainnet-seed.autostake.com:27186",
-        "provider": "AutoStake 🛡️ Slash Protected"
-      },
-      {
         "id": "8542cd7e6bf9d260fef543bc49e59be5a3fa9074",
         "address": "seed.publicnode.com:26656",
         "provider": "Allnodes ⚡️ Nodes & Staking"
@@ -111,11 +106,6 @@
         "id": "89b576c3eb72a4f0c66dc0899bec7c21552ea2a5",
         "address": "23.88.7.73:29538",
         "provider": "Mercury"
-      },
-      {
-        "id": "ebc272824924ea1a27ea3183dd0b9ba713494f83",
-        "address": "chihuahua-mainnet-peer.autostake.com:27186",
-        "provider": "AutoStake 🛡️ Slash Protected"
       },
       {
         "id": "637077d431f618181597706810a65c826524fd74",
@@ -153,10 +143,6 @@
       {
         "address": "https://rpc-chihuahua.pupmos.network",
         "provider": "PUPMØS"
-      },
-      {
-        "address": "https://chihuahua-mainnet-rpc.autostake.com:443",
-        "provider": "AutoStake 🛡️ Slash Protected"
       },
       {
         "address": "https://chihuahua-rpc.publicnode.com:443",
@@ -205,10 +191,6 @@
         "provider": "PUPMØS"
       },
       {
-        "address": "https://chihuahua-mainnet-lcd.autostake.com:443",
-        "provider": "AutoStake 🛡️ Slash Protected"
-      },
-      {
         "address": "https://chihuahua-rest.publicnode.com",
         "provider": "Allnodes ⚡️ Nodes & Staking"
       },
@@ -245,10 +227,6 @@
       {
         "address": "grpc-chihuahua.cosmos-spaces.cloud:2290",
         "provider": "Cosmos Spaces"
-      },
-      {
-        "address": "chihuahua-mainnet-grpc.autostake.com:443",
-        "provider": "AutoStake 🛡️ Slash Protected"
       },
       {
         "address": "chihuahua-grpc.publicnode.com:443",

--- a/comdex/chain.json
+++ b/comdex/chain.json
@@ -88,11 +88,6 @@
         "provider": "Lavender.Five Nodes 🐝"
       },
       {
-        "id": "ebc272824924ea1a27ea3183dd0b9ba713494f83",
-        "address": "comdex-mainnet-seed.autostake.com:26776",
-        "provider": "AutoStake 🛡️ Slash Protected"
-      },
-      {
         "id": "6596d143fd128b2394b27cd7846bda099ca5a193",
         "address": "seeds.goldenratiostaking.net:1621",
         "provider": "Golden Ratio Staking"
@@ -128,11 +123,6 @@
         "address": "194.163.128.55:36656"
       },
       {
-        "id": "ebc272824924ea1a27ea3183dd0b9ba713494f83",
-        "address": "comdex-mainnet-peer.autostake.com:26776",
-        "provider": "AutoStake 🛡️ Slash Protecteds"
-      },
-      {
         "id": "88ba33fbdf0279efaf27cff629f3cf72814d4069",
         "address": "peer-comdex-01.stakeflow.io:10007",
         "provider": "Stakeflow"
@@ -165,10 +155,6 @@
       {
         "address": "https://rpc-comdex.cosmos-spaces.cloud",
         "provider": "Cosmos Spaces"
-      },
-      {
-        "address": "https://comdex-mainnet-rpc.autostake.com:443",
-        "provider": "AutoStake 🛡️ Slash Protected"
       },
       {
         "address": "https://comdex-rpc.w3coins.io",
@@ -225,10 +211,6 @@
         "provider": "Cosmos Spaces"
       },
       {
-        "address": "https://comdex-mainnet-lcd.autostake.com:443",
-        "provider": "AutoStake 🛡️ Slash Protected"
-      },
-      {
         "address": "https://comdex-api.w3coins.io",
         "provider": "w3coins"
       },
@@ -277,10 +259,6 @@
       {
         "address": "comdex.lavenderfive.com:443",
         "provider": "Lavender.Five Nodes 🐝"
-      },
-      {
-        "address": "comdex-mainnet-lcd.autostake.com:443",
-        "provider": "AutoStake 🛡️ Slash Protected"
       },
       {
         "address": "comdex-grpc.w3coins.io:13190",

--- a/composable/chain.json
+++ b/composable/chain.json
@@ -68,11 +68,6 @@
   "peers": {
     "seeds": [
       {
-        "id": "ebc272824924ea1a27ea3183dd0b9ba713494f83",
-        "address": "composable-mainnet-seed.autostake.com:26976",
-        "provider": "AutoStake 🛡️ Slash Protected"
-      },
-      {
         "id": "20e1000e88125698264454a884812746c2eb4807",
         "address": "seeds.lavenderfive.com:22256",
         "provider": "Lavender.Five Nodes 🐝"
@@ -94,11 +89,6 @@
       }
     ],
     "persistent_peers": [
-      {
-        "id": "ebc272824924ea1a27ea3183dd0b9ba713494f83",
-        "address": "composable-mainnet-peer.autostake.com:26976",
-        "provider": "AutoStake 🛡️ Slash Protected"
-      },
       {
         "id": "63559b939442512ed82d2ded46d02ab1021ea29a",
         "address": "95.214.55.138:53656",
@@ -128,10 +118,6 @@
   },
   "apis": {
     "rpc": [
-      {
-        "address": "https://composable-mainnet-rpc.autostake.com:443",
-        "provider": "AutoStake 🛡️ Slash Protected"
-      },
       {
         "address": "https://rpc.lavenderfive.com:443/picasso",
         "provider": "Lavender.Five Nodes 🐝"
@@ -175,10 +161,6 @@
     ],
     "rest": [
       {
-        "address": "https://composable-mainnet-lcd.autostake.com:443",
-        "provider": "AutoStake 🛡️ Slash Protected"
-      },
-      {
         "address": "https://rest.lavenderfive.com:443/picasso",
         "provider": "Lavender.Five Nodes 🐝"
       },
@@ -219,10 +201,6 @@
       {
         "address": "grpc.composable.nodestake.top:9090",
         "provider": "NodeStake"
-      },
-      {
-        "address": "composable-mainnet-grpc.autostake.com:443",
-        "provider": "AutoStake 🛡️ Slash Protected"
       },
       {
         "address": "grpc-centauri.cosmos-spaces.cloud:1120",

--- a/crescent/chain.json
+++ b/crescent/chain.json
@@ -58,11 +58,6 @@
         "provider": "crescent"
       },
       {
-        "id": "ebc272824924ea1a27ea3183dd0b9ba713494f83",
-        "address": "crescent-mainnet-seed.autostake.com:26816",
-        "provider": "AutoStake 🛡️ Slash Protected"
-      },
-      {
         "id": "3b60a29d89cd7ef6a8d0c7ba32013d7f2051e082",
         "address": "seed-crescent-01.stakeflow.io:1406",
         "provider": "Stakeflow"
@@ -83,11 +78,6 @@
         "id": "ade4d8bc8cbe014af6ebdf3cb7b1e9ad36f412c0",
         "address": "seeds.polkachu.com:14556",
         "provider": "Polkachu"
-      },
-      {
-        "id": "ebc272824924ea1a27ea3183dd0b9ba713494f83",
-        "address": "crescent-mainnet-peer.autostake.com:26816",
-        "provider": "AutoStake 🛡️ Slash Protected"
       },
       {
         "id": "3b60a29d89cd7ef6a8d0c7ba32013d7f2051e082",
@@ -113,10 +103,6 @@
       {
         "address": "https://crescent.rpc.stakin-nodes.com",
         "provider": "Stakin"
-      },
-      {
-        "address": "https://crescent-mainnet-rpc.autostake.com:443",
-        "provider": "AutoStake 🛡️ Slash Protected"
       },
       {
         "address": "https://rpc-crescent.cosmos-spaces.cloud",
@@ -157,10 +143,6 @@
         "provider": "Cosmos Spaces"
       },
       {
-        "address": "https://crescent-mainnet-lcd.autostake.com:443",
-        "provider": "AutoStake 🛡️ Slash Protected"
-      },
-      {
         "address": "https://api-crescent-01.stakeflow.io",
         "provider": "Stakeflow"
       },
@@ -181,10 +163,6 @@
       {
         "address": "crescent.grpc.stakin-nodes.com:443",
         "provider": "Stakin"
-      },
-      {
-        "address": "crescent-mainnet-grpc.autostake.com:443",
-        "provider": "AutoStake 🛡️ Slash Protected"
       },
       {
         "address": "grpc-crescent.cosmos-spaces.cloud:2270",

--- a/cudos/chain.json
+++ b/cudos/chain.json
@@ -65,11 +65,6 @@
         "provider": "cudo"
       },
       {
-        "id": "ebc272824924ea1a27ea3183dd0b9ba713494f83",
-        "address": "cudos-mainnet-seed.autostake.com:27256",
-        "provider": "AutoStake 🛡️ Slash Protected"
-      },
-      {
         "id": "20e1000e88125698264454a884812746c2eb4807",
         "address": "seeds.lavenderfive.com:12356",
         "provider": "Lavender.Five Nodes 🐝"
@@ -105,11 +100,6 @@
         "id": "eb14f9142ad313297653f84754b1caf60efe75ac",
         "address": "mainnet-full-node-02.hosts.cudos.org:26656",
         "provider": "cudo"
-      },
-      {
-        "id": "ebc272824924ea1a27ea3183dd0b9ba713494f83",
-        "address": "cudos-mainnet-peer.autostake.com:27256",
-        "provider": "AutoStake 🛡️ Slash Protected"
       }
     ]
   },
@@ -126,10 +116,6 @@
       {
         "address": "https://cudos-rpc.kleomedes.network",
         "provider": "Kleomedes"
-      },
-      {
-        "address": "https://cudos-mainnet-rpc.autostake.com:443",
-        "provider": "AutoStake 🛡️ Slash Protected"
       },
       {
         "address": "https://rpc.lavenderfive.com:443/cudos",
@@ -154,10 +140,6 @@
         "provider": "Kleomedes"
       },
       {
-        "address": "https://cudos-mainnet-lcd.autostake.com:443",
-        "provider": "AutoStake 🛡️ Slash Protected"
-      },
-      {
         "address": "https://rest.lavenderfive.com:443/cudos",
         "provider": "Lavender.Five Nodes 🐝"
       },
@@ -170,10 +152,6 @@
       {
         "address": "mainnet-full-node-01.hosts.cudos.org:9090",
         "provider": "cudo"
-      },
-      {
-        "address": "cudos-mainnet-grpc.autostake.com:443",
-        "provider": "AutoStake 🛡️ Slash Protected"
       },
       {
         "address": "cudos.lavenderfive.com:443",

--- a/dydx/chain.json
+++ b/dydx/chain.json
@@ -127,11 +127,6 @@
         "provider": "Allnodes ⚡️ Nodes & Staking"
       },
       {
-        "id": "ebc272824924ea1a27ea3183dd0b9ba713494f83",
-        "address": "dydx-mainnet-seed.autostake.com:27366",
-        "provider": "AutoStake 🛡️ Slash Protected"
-      },
-      {
         "id": "09ba537d6563018b97c502979c3478df4decf426",
         "address": "dydxprotocol-seed.genznodes.dev:22656",
         "provider": "genznodes"
@@ -140,13 +135,6 @@
         "id": "babc3f3f7804933265ec9c40ad94f4da8e9e0017",
         "address": "seed.rhinostake.com:23856",
         "provider": "RHINO 🦏"
-      }
-    ],
-    "persistent_peers": [
-      {
-        "id": "ebc272824924ea1a27ea3183dd0b9ba713494f83",
-        "address": "dydx-mainnet-peer.autostake.com:27366",
-        "provider": "AutoStake 🛡️ Slash Protected"
       }
     ]
   },
@@ -163,10 +151,6 @@
       {
         "address": "https://rpc.lavenderfive.com:443/dydx",
         "provider": "Lavender.Five Nodes 🐝"
-      },
-      {
-        "address": "https://dydx-mainnet-rpc.autostake.com:443",
-        "provider": "AutoStake 🛡️ Slash Protected"
       },
       {
         "address": "https://dydx-rpc.publicnode.com:443",
@@ -193,10 +177,6 @@
       {
         "address": "https://rest.lavenderfive.com:443/dydx",
         "provider": "Lavender.Five Nodes 🐝"
-      },
-      {
-        "address": "https://dydx-mainnet-lcd.autostake.com:443",
-        "provider": "AutoStake 🛡️ Slash Protected"
       },
       {
         "address": "https://dydx-rest.publicnode.com",
@@ -239,10 +219,6 @@
       {
         "address": "dydx.lavenderfive.com:443",
         "provider": "Lavender.Five Nodes 🐝"
-      },
-      {
-        "address": "dydx-mainnet-grpc.autostake.com:443",
-        "provider": "AutoStake 🛡️ Slash Protected"
       },
       {
         "address": "dydx.grpc.kjnodes.com:443",

--- a/dymension/chain.json
+++ b/dymension/chain.json
@@ -61,11 +61,6 @@
         "provider": "NodeStake"
       },
       {
-        "id": "ebc272824924ea1a27ea3183dd0b9ba713494f83",
-        "address": "dymension-mainnet-seed.autostake.com:27086",
-        "provider": "AutoStake 🛡️ Slash Protected"
-      },
-      {
         "id": "20e1000e88125698264454a884812746c2eb4807",
         "address": "seeds.lavenderfive.com:20556",
         "provider": "Lavender.Five Nodes 🐝"
@@ -120,11 +115,6 @@
         "address": "45.76.38.67:26656"
       },
       {
-        "id": "ebc272824924ea1a27ea3183dd0b9ba713494f83",
-        "address": "dymension-mainnet-peer.autostake.com:27086",
-        "provider": "AutoStake 🛡️ Slash Protected"
-      },
-      {
         "id": "babe3d67aa5570e65953a5253eaf36c7ebfbbb44",
         "address": "82.223.0.229:26646",
         "provider": "Cumulo"
@@ -154,10 +144,6 @@
       {
         "address": "http://dymension.mainnet.rpc.noders.team:42657",
         "provider": "[NODERS]TEAM"
-      },
-      {
-        "address": "https://dymension-mainnet-rpc.autostake.com:443",
-        "provider": "AutoStake 🛡️ Slash Protected"
       },
       {
         "address": "https://rpc.lavenderfive.com:443/dymension",
@@ -274,10 +260,6 @@
         "provider": "[NODERS]TEAM"
       },
       {
-        "address": "https://dymension-mainnet-lcd.autostake.com:443",
-        "provider": "AutoStake 🛡️ Slash Protected"
-      },
-      {
         "address": "https://rest.lavenderfive.com:443/dymension",
         "provider": "Lavender.Five Nodes 🐝"
       },
@@ -382,10 +364,6 @@
       {
         "address": "grpc.dymension.nodestake.org:443",
         "provider": "NodeStake"
-      },
-      {
-        "address": "dymension-mainnet-grpc.autostake.com:443",
-        "provider": "AutoStake 🛡️ Slash Protected"
       },
       {
         "address": "dymension.mainnet.grpc.noders.team:42090",

--- a/elys/chain.json
+++ b/elys/chain.json
@@ -125,11 +125,6 @@
         "provider": "Inter Blockchain Services"
       },
       {
-        "id": "ebc272824924ea1a27ea3183dd0b9ba713494f83",
-        "address": "elys-mainnet-seed.autostake.com:27396",
-        "provider": "AutoStake"
-      },
-      {
         "id": "86bd5cb6e762f673f1706e5889e039d5406b4b90",
         "address": "seed.elys.node75.org:29186",
         "provider": "Pro-Nodes75"
@@ -182,11 +177,6 @@
         "provider": "Moonbridge"
       },
       {
-        "id": "ebc272824924ea1a27ea3183dd0b9ba713494f83",
-        "address": "elys-mainnet-peer.autostake.com:27396",
-        "provider": "AutoStake"
-      },
-      {
         "id": "5e2b7d7e52ad78afc80de5e34c21ba73c9576283",
         "address": "elys-peers.node39.top:12656",
         "provider": "Node39"
@@ -229,10 +219,6 @@
         "provider": "🚀 WHEN MOON 🌕 WHEN LAMBO 🔥"
       },
       {
-        "address": "https://elys-mainnet-rpc.autostake.com:443",
-        "provider": "AutoStake"
-      },
-      {
         "address": "https://elys-rpc.vnodesv.net",
         "provider": "vNodes[V] Ser[V]ices"
       }
@@ -267,10 +253,6 @@
         "provider": "🚀 WHEN MOON 🌕 WHEN LAMBO 🔥"
       },
       {
-        "address": "https://elys-mainnet-lcd.autostake.com:443",
-        "provider": "AutoStake"
-      },
-      {
         "address": "https://elys-api.vnodesv.net",
         "provider": "vNodes[V] Ser[V]ices"
       }
@@ -291,10 +273,6 @@
       {
         "address": "elys-grpc.stake-town.com:443",
         "provider": "StakeTown"
-      },
-      {
-        "address": "elys-mainnet-grpc.autostake.com:443",
-        "provider": "AutoStake"
       },
       {
         "address": "https://elys.vnodesv.net/grpc",

--- a/emoney/chain.json
+++ b/emoney/chain.json
@@ -97,21 +97,9 @@
         "provider": "Cat Boss"
       },
       {
-        "id": "ebc272824924ea1a27ea3183dd0b9ba713494f83",
-        "address": "emoney-mainnet-seed.autostake.com:26746",
-        "provider": "AutoStake 🛡️ Slash Protected"
-      },
-      {
         "id": "8542cd7e6bf9d260fef543bc49e59be5a3fa9074",
         "address": "seed.publicnode.com:26656",
         "provider": "Allnodes ⚡️ Nodes & Staking"
-      }
-    ],
-    "persistent_peers": [
-      {
-        "id": "ebc272824924ea1a27ea3183dd0b9ba713494f83",
-        "address": "emoney-mainnet-peer.autostake.com:26746",
-        "provider": "AutoStake 🛡️ Slash Protected"
       }
     ]
   },
@@ -134,12 +122,6 @@
       {
         "address": "https://api.emoney.bh.rocks",
         "provider": "BlockHunters 🎯"
-      }
-    ],
-    "grpc": [
-      {
-        "address": "emoney-mainnet-grpc.autostake.com:443",
-        "provider": "AutoStake 🛡️ Slash Protected"
       }
     ]
   },

--- a/empowerchain/chain.json
+++ b/empowerchain/chain.json
@@ -60,11 +60,6 @@
         "address": "empower-mainnet-seed.itrocket.net:14656"
       },
       {
-        "id": "ebc272824924ea1a27ea3183dd0b9ba713494f83",
-        "address": "empowerchain-mainnet-seed.autostake.com:27326",
-        "provider": "AutoStake 🛡️ Slash Protected"
-      },
-      {
         "id": "a1427b456513ab70967a2a5c618d347bc89e8848",
         "address": "seed.empowerchain.io:26656"
       },
@@ -90,11 +85,6 @@
       }
     ],
     "persistent_peers": [
-      {
-        "id": "ebc272824924ea1a27ea3183dd0b9ba713494f83",
-        "address": "empowerchain-mainnet-peer.autostake.com:27326",
-        "provider": "AutoStake 🛡️ Slash Protected"
-      },
       {
         "id": "178718a993161cc20f9d0de2bbef9a3aec5c1d3d",
         "address": "rpc.empower.indonode.net:52656",
@@ -129,10 +119,6 @@
   },
   "apis": {
     "rpc": [
-      {
-        "address": "https://empowerchain-mainnet-rpc.autostake.com:443",
-        "provider": "AutoStake 🛡️ Slash Protected"
-      },
       {
         "address": "https://empower.rpc.liveraven.net",
         "provider": "LiveRaveN"
@@ -184,10 +170,6 @@
     ],
     "rest": [
       {
-        "address": "https://empowerchain-mainnet-lcd.autostake.com:443",
-        "provider": "AutoStake 🛡️ Slash Protected"
-      },
-      {
         "address": "https://empower.api.liveraven.net",
         "provider": "LiveRaveN"
       },
@@ -233,10 +215,6 @@
       }
     ],
     "grpc": [
-      {
-        "address": "empowerchain-mainnet-grpc.autostake.com:443",
-        "provider": "AutoStake 🛡️ Slash Protected"
-      },
       {
         "address": "https://empower.grpc.liveraven.net",
         "provider": "LiveRaveN"

--- a/evmos/chain.json
+++ b/evmos/chain.json
@@ -100,11 +100,6 @@
         "provider": "Lavender.Five Nodes 🐝"
       },
       {
-        "id": "ebc272824924ea1a27ea3183dd0b9ba713494f83",
-        "address": "evmos-mainnet-seed.autostake.com:26736",
-        "provider": "AutoStake 🛡️ Slash Protected"
-      },
-      {
         "id": "40f4fac63da8b1ce8f850b0fa0f79b2699d2ce72",
         "address": "seed.evmos.jerrychong.com:26656",
         "provider": "Jerry's Pool"
@@ -140,11 +135,6 @@
         "id": "588cedb70fa1d98c14a2f2c1456bfa41e1a156a8",
         "address": "evmos-sentry.mercury-nodes.net:29539",
         "provider": "Mercury"
-      },
-      {
-        "id": "ebc272824924ea1a27ea3183dd0b9ba713494f83",
-        "address": "evmos-mainnet-peer.autostake.com:26736",
-        "provider": "AutoStake 🛡️ Slash Protected"
       },
       {
         "id": "ac009a9564d3471852795b5d703095a1d4b6a3e1",
@@ -328,10 +318,6 @@
       {
         "address": "evmos.grpc.stakin-nodes.com:443",
         "provider": "Stakin"
-      },
-      {
-        "address": "evmos-mainnet-grpc.autostake.com:443",
-        "provider": "AutoStake 🛡️ Slash Protected"
       },
       {
         "address": "evmos-grpc.publicnode.com:443",

--- a/fetchhub/chain.json
+++ b/fetchhub/chain.json
@@ -64,11 +64,6 @@
         "provider": "Polkachu"
       },
       {
-        "id": "ebc272824924ea1a27ea3183dd0b9ba713494f83",
-        "address": "fetchhub-mainnet-seed.autostake.com:27266",
-        "provider": "AutoStake 🛡️ Slash Protected"
-      },
-      {
         "id": "8542cd7e6bf9d260fef543bc49e59be5a3fa9074",
         "address": "seed.publicnode.com:26656",
         "provider": "Allnodes ⚡️ Nodes & Staking"
@@ -106,11 +101,6 @@
         "provider": "fetch.ai"
       },
       {
-        "id": "ebc272824924ea1a27ea3183dd0b9ba713494f83",
-        "address": "fetchhub-mainnet-peer.autostake.com:27266",
-        "provider": "AutoStake 🛡️ Slash Protected"
-      },
-      {
         "id": "637077d431f618181597706810a65c826524fd74",
         "address": "fetch.rpc.nodeshub.online:15256",
         "provider": "NodesHub"
@@ -138,10 +128,6 @@
       {
         "address": "https://rpc-fetch.architectnodes.com",
         "provider": "Architect Nodes"
-      },
-      {
-        "address": "https://fetchhub-mainnet-rpc.autostake.com:443",
-        "provider": "AutoStake 🛡️ Slash Protected"
       },
       {
         "address": "https://fetch.ibs.team:443/rpc",
@@ -202,10 +188,6 @@
         "provider": "Antrix"
       },
       {
-        "address": "https://fetchhub-mainnet-lcd.autostake.com:443",
-        "provider": "AutoStake 🛡️ Slash Protected"
-      },
-      {
         "address": "https://rest-fetch.architectnodes.com",
         "provider": "Architect Nodes"
       },
@@ -258,10 +240,6 @@
       {
         "address": "fetch-grpc.polkachu.com:15290",
         "provider": "Polkachu"
-      },
-      {
-        "address": "fetchhub-mainnet-grpc.autostake.com:443",
-        "provider": "AutoStake 🛡️ Slash Protected"
       },
       {
         "address": "fetch-grpc.teasel.org:443",

--- a/gitopia/chain.json
+++ b/gitopia/chain.json
@@ -79,11 +79,6 @@
         "provider": "Lavender.Five Nodes 🐝"
       },
       {
-        "id": "ebc272824924ea1a27ea3183dd0b9ba713494f83",
-        "address": "gitopia-mainnet-seed.autostake.com",
-        "provider": "autostake"
-      },
-      {
         "id": "9aa8a73ea9364aa3cf7806d4dd25b6aed88d8152",
         "address": "gitopia-seed.mzonder.com:11056",
         "provider": "MZONDER"
@@ -134,11 +129,6 @@
         "id": "be0c48bbcefb13702008d819ee4292f5afa4dc4c",
         "address": "148.251.235.130:11656",
         "provider": "Staketab"
-      },
-      {
-        "id": "ebc272824924ea1a27ea3183dd0b9ba713494f83",
-        "address": "gitopia-mainnet-peer.autostake.com",
-        "provider": "autostake"
       },
       {
         "id": "c6f7524b45ae2d9da2a272858c804fd67a29cf72",
@@ -349,10 +339,6 @@
       {
         "address": "https://gitopia-rest.staketab.org",
         "provider": "Staketab"
-      },
-      {
-        "address": "https://gitopia-mainnet-lcd.autostake.com:443",
-        "provider": "autostake"
       },
       {
         "address": "https://m-gitopia.api.utsa.tech",

--- a/humans/chain.json
+++ b/humans/chain.json
@@ -77,11 +77,6 @@
         "id": "8542cd7e6bf9d260fef543bc49e59be5a3fa9074",
         "address": "seed.publicnode.com:26656",
         "provider": "Allnodes ⚡️ Nodes & Staking"
-      },
-      {
-        "id": "ebc272824924ea1a27ea3183dd0b9ba713494f83",
-        "address": "humans-mainnet-seed.autostake.com:27536",
-        "provider": "AutoStake 🛡️ Slash Protected"
       }
     ],
     "persistent_peers": [
@@ -104,11 +99,6 @@
         "id": "9193e655f0581b4acf2e87976ac0b55795359742",
         "address": "167.235.177.226:26656",
         "provider": "[NODERS]TEAM"
-      },
-      {
-        "id": "ebc272824924ea1a27ea3183dd0b9ba713494f83",
-        "address": "humans-mainnet-peer.autostake.com:27536",
-        "provider": "AutoStake 🛡️ Slash Protected"
       }
     ]
   },
@@ -161,10 +151,6 @@
       {
         "address": "https://humans-rpc.noders.services",
         "provider": "[NODERS]TEAM"
-      },
-      {
-        "address": "https://humans-mainnet-rpc.autostake.com:443",
-        "provider": "AutoStake 🛡️ Slash Protected"
       }
     ],
     "rest": [
@@ -211,10 +197,6 @@
       {
         "address": "https://humans-api.noders.services",
         "provider": "[NODERS]TEAM"
-      },
-      {
-        "address": "https://humans-mainnet-lcd.autostake.com:443",
-        "provider": "AutoStake 🛡️ Slash Protected"
       }
     ],
     "grpc": [
@@ -253,10 +235,6 @@
       {
         "address": "humans-grpc.noders.services:21090",
         "provider": "[NODERS]TEAM"
-      },
-      {
-        "address": "humans-mainnet-grpc.autostake.com:443",
-        "provider": "AutoStake 🛡️ Slash Protected"
       }
     ],
     "evm-http-jsonrpc": [

--- a/initia/chain.json
+++ b/initia/chain.json
@@ -54,11 +54,6 @@
       {
         "id": "80e8870743458d1a28ce9f9da939e4ddcb7cedfe",
         "address": "34.142.172.124:26656"
-      },
-      {
-        "id": "ebc272824924ea1a27ea3183dd0b9ba713494f83",
-        "address": "initia-mainnet-seed.autostake.com:26686",
-        "provider": "AutoStake 🛡️ Slash Protected"
       }
     ],
     "persistent_peers": [
@@ -78,11 +73,6 @@
         "id": "a29410f6c0b6aae3386d5b7ed24a038f1e4edab4",
         "address": "91.223.3.148:16656",
         "provider": "Quasar"
-      },
-      {
-        "id": "ebc272824924ea1a27ea3183dd0b9ba713494f83",
-        "address": "initia-mainnet-peer.autostake.com:26686",
-        "provider": "AutoStake 🛡️ Slash Protected"
       }
     ]
   },
@@ -95,10 +85,6 @@
       {
         "address": "https://initia.rpc.quasarstaking.ai:443",
         "provider": "Quasar"
-      },
-      {
-        "address": "https://initia-mainnet-rpc.autostake.com:443",
-        "provider": "AutoStake 🛡️ Slash Protected"
       }
     ],
     "rest": [
@@ -109,10 +95,6 @@
       {
         "address": "https://initia.api.quasarstaking.ai:443",
         "provider": "Quasar"
-      },
-      {
-        "address": "https://initia-mainnet-lcd.autostake.com:443",
-        "provider": "AutoStake 🛡️ Slash Protected"
       }
     ],
     "grpc": [
@@ -123,10 +105,6 @@
       {
         "address": "initia.grpc.quasarstaking.ai:80",
         "provider": "Quasar"
-      },
-      {
-        "address": "initia-mainnet-grpc.autostake.com:443",
-        "provider": "AutoStake 🛡️ Slash Protected"
       }
     ]
   },

--- a/injective/chain.json
+++ b/injective/chain.json
@@ -91,11 +91,6 @@
         "provider": "polkachu.com"
       },
       {
-        "id": "ebc272824924ea1a27ea3183dd0b9ba713494f83",
-        "address": "injective-mainnet-seed.autostake.com:26726",
-        "provider": "AutoStake 🛡️ Slash Protected"
-      },
-      {
         "id": "20e1000e88125698264454a884812746c2eb4807",
         "address": "seeds.lavenderfive.com:14356",
         "provider": "Lavender.Five Nodes 🐝"
@@ -158,11 +153,6 @@
         "provider": "injectivelabs.org"
       },
       {
-        "id": "ebc272824924ea1a27ea3183dd0b9ba713494f83",
-        "address": "injective-mainnet-peer.autostake.com:26726",
-        "provider": "AutoStake 🛡️ Slash Protected"
-      },
-      {
         "id": "858c86e2590f82934b8483ed184afd88416a7b31",
         "address": "peer-injective-01.stakeflow.io:2106",
         "provider": "Stakeflow"
@@ -222,10 +212,6 @@
       {
         "address": "injective-grpc.polkachu.com:14390",
         "provider": "Polkachu"
-      },
-      {
-        "address": "injective-mainnet-grpc.autostake.com:443",
-        "provider": "AutoStake 🛡️ Slash Protected"
       },
       {
         "address": "injective-grpc.publicnode.com:443",

--- a/jackal/chain.json
+++ b/jackal/chain.json
@@ -65,11 +65,6 @@
         "provider": "Lavender.Five Nodes 🐝"
       },
       {
-        "id": "ebc272824924ea1a27ea3183dd0b9ba713494f83",
-        "address": "jackal-mainnet-seed.autostake.com:26906",
-        "provider": "AutoStake 🛡️ Slash Protected"
-      },
-      {
         "id": "ade4d8bc8cbe014af6ebdf3cb7b1e9ad36f412c0",
         "address": "seeds.polkachu.com:17556",
         "provider": "Polkachu"
@@ -94,11 +89,6 @@
       {
         "id": "0ab9ec918cd36a28be1fcf538f7f76ede2b81659",
         "address": "89.58.38.59:26656"
-      },
-      {
-        "id": "ebc272824924ea1a27ea3183dd0b9ba713494f83",
-        "address": "jackal-mainnet-peer.autostake.com:26906",
-        "provider": "AutoStake 🛡️ Slash Protected"
       },
       {
         "id": "26b6255375a592c3b0664bd474a6975f468c3785",
@@ -165,10 +155,6 @@
         "provider": "WhisperNode 🤐"
       },
       {
-        "address": "https://jackal-mainnet-rpc.autostake.com:443",
-        "provider": "AutoStake 🛡️ Slash Protected"
-      },
-      {
         "address": "https://jackal.rpc.kjnodes.com",
         "provider": "kjnodes"
       },
@@ -233,10 +219,6 @@
       {
         "address": "https://m-jackal.api.utsa.tech",
         "provider": "𝐥𝐞𝐬𝐧𝐢𝐤 | 𝐔𝐓𝐒𝐀"
-      },
-      {
-        "address": "https://jackal-mainnet-lcd.autostake.com:443",
-        "provider": "AutoStake 🛡️ Slash Protected"
       },
       {
         "address": "https://lcd-jackal.whispernode.com:443",
@@ -307,10 +289,6 @@
       {
         "address": "http://jkl.grpc.m.stavr.tech:5013",
         "provider": "🔥STAVR🔥"
-      },
-      {
-        "address": "jackal-mainnet-grpc.autostake.com:443",
-        "provider": "AutoStake 🛡️ Slash Protected"
       },
       {
         "address": "jackal.grpc.kjnodes.com:13790",

--- a/juno/chain.json
+++ b/juno/chain.json
@@ -105,11 +105,6 @@
         "provider": "Allnodes ⚡️ Nodes & Staking"
       },
       {
-        "id": "ebc272824924ea1a27ea3183dd0b9ba713494f83",
-        "address": "juno-mainnet-seed.autostake.com:27136",
-        "provider": "AutoStake 🛡️ Slash Protected"
-      },
-      {
         "id": "509f6dbae3133a9df177edea051b31e1210b117e",
         "address": "seed-juno-01.stakeflow.io:2307",
         "provider": "Stakeflow"
@@ -134,11 +129,6 @@
       {
         "id": "7f593757c0cde8972ce929381d8ac8e446837811",
         "address": "178.18.255.244:26656"
-      },
-      {
-        "id": "ebc272824924ea1a27ea3183dd0b9ba713494f83",
-        "address": "juno-mainnet-peer.autostake.com:27136",
-        "provider": "AutoStake 🛡️ Slash Protected"
       },
       {
         "id": "3ee2034cf0180e4d50f7b3ed952472add3316faf",

--- a/kava/chain.json
+++ b/kava/chain.json
@@ -54,11 +54,6 @@
         "provider": "Polkachu"
       },
       {
-        "id": "ebc272824924ea1a27ea3183dd0b9ba713494f83",
-        "address": "kava-mainnet-seed.autostake.com:26656",
-        "provider": "AutoStake 🛡️ Slash Protected"
-      },
-      {
         "id": "7ab4b78fbe5ee9e3777b21464a3162bd4cc17f57",
         "address": "seed-kava-01.stakeflow.io:1206",
         "provider": "Stakeflow"
@@ -80,11 +75,6 @@
         "address": "121.78.241.68:46656"
       },
       {
-        "id": "ebc272824924ea1a27ea3183dd0b9ba713494f83",
-        "address": "kava-mainnet-peer.autostake.com:26656",
-        "provider": "AutoStake 🛡️ Slash Protected"
-      },
-      {
         "id": "7ab4b78fbe5ee9e3777b21464a3162bd4cc17f57",
         "address": "peer-kava-01.stakeflow.io:1206",
         "provider": "Stakeflow"
@@ -100,10 +90,6 @@
       {
         "address": "https://kava-rpc.polkachu.com",
         "provider": "Polkachu"
-      },
-      {
-        "address": "https://kava-mainnet-rpc.autostake.com:443",
-        "provider": "AutoStake 🛡️ Slash Protected"
       },
       {
         "address": "https://kava-rpc.publicnode.com:443",
@@ -128,10 +114,6 @@
         "provider": "Polkachu"
       },
       {
-        "address": "https://kava-mainnet-lcd.autostake.com:443",
-        "provider": "AutoStake 🛡️ Slash Protected"
-      },
-      {
         "address": "https://kava-rest.publicnode.com",
         "provider": "Allnodes ⚡️ Nodes & Staking"
       },
@@ -152,10 +134,6 @@
       {
         "address": "kava-grpc.polkachu.com:13990",
         "provider": "Polkachu"
-      },
-      {
-        "address": "kava-mainnet-grpc.autostake.com:443",
-        "provider": "AutoStake 🛡️ Slash Protected"
       },
       {
         "address": "kava-grpc.publicnode.com:443",

--- a/kichain/chain.json
+++ b/kichain/chain.json
@@ -60,11 +60,6 @@
         "provider": "Polkachu"
       },
       {
-        "id": "ebc272824924ea1a27ea3183dd0b9ba713494f83",
-        "address": "kichain-mainnet-seed.autostake.com:27396",
-        "provider": "AutoStake 🛡️ Slash Protected"
-      },
-      {
         "id": "20e1000e88125698264454a884812746c2eb4807",
         "address": "seeds.lavenderfive.com:13556",
         "provider": "Lavender.Five Nodes 🐝"
@@ -87,11 +82,6 @@
         "provider": "cosmostation"
       },
       {
-        "id": "ebc272824924ea1a27ea3183dd0b9ba713494f83",
-        "address": "kichain-mainnet-peer.autostake.com:27396",
-        "provider": "AutoStake 🛡️ Slash Protected"
-      },
-      {
         "id": "623645c5ad5fb81197f68c48e815e40917f2d6ed",
         "address": "5.9.61.184:26656",
         "provider": "[NODERS]TEAM"
@@ -107,10 +97,6 @@
       {
         "address": "https://kichain-rpc.polkachu.com",
         "provider": "Polkachu"
-      },
-      {
-        "address": "https://kichain-mainnet-rpc.autostake.com:443",
-        "provider": "AutoStake 🛡️ Slash Protected"
       },
       {
         "address": "https://rpc.kichain.chaintools.tech/",
@@ -143,10 +129,6 @@
         "provider": "ChainTools"
       },
       {
-        "address": "https://kichain-mainnet-lcd.autostake.com:443",
-        "provider": "AutoStake 🛡️ Slash Protected"
-      },
-      {
         "address": "http://ki-chain.api.nodersteam.com:14017",
         "provider": "[NODERS]TEAM"
       },
@@ -164,10 +146,6 @@
       }
     ],
     "grpc": [
-      {
-        "address": "kichain-mainnet-grpc.autostake.com:443",
-        "provider": "AutoStake 🛡️ Slash Protected"
-      },
       {
         "address": "ki-chain.grpc.nodersteam.com:9410",
         "provider": "[NODERS]TEAM"

--- a/konstellation/chain.json
+++ b/konstellation/chain.json
@@ -54,11 +54,6 @@
         "provider": "Polkachu"
       },
       {
-        "id": "ebc272824924ea1a27ea3183dd0b9ba713494f83",
-        "address": "konstellation-mainnet-seed.autostake.com:26826",
-        "provider": "AutoStake 🛡️ Slash Protected"
-      },
-      {
         "id": "df949a46ae6529ae1e09b034b49716468d5cc7e9",
         "address": "seeds.stakerhouse.com:10856",
         "provider": "StakerHouse"
@@ -73,11 +68,6 @@
       {
         "id": "1bd4b89e05e5d7ea5d2dba89c799c2e624cb35d7",
         "address": "node1.konstellation.tech:26656"
-      },
-      {
-        "id": "ebc272824924ea1a27ea3183dd0b9ba713494f83",
-        "address": "konstellation-mainnet-peer.autostake.com:26826",
-        "provider": "AutoStake 🛡️ Slash Protected"
       },
       {
         "id": "5a10c5f0a2d981037a0a3e5ecc825901ae0d416c",
@@ -103,10 +93,6 @@
       {
         "address": "konstellation-grpc.polkachu.com:13390",
         "provider": "Polkachu"
-      },
-      {
-        "address": "konstellation-mainnet-grpc.autostake.com:443",
-        "provider": "AutoStake 🛡️ Slash Protected"
       },
       {
         "address": "konstellation-grpc.stakerhouse.com:443",

--- a/kujira/chain.json
+++ b/kujira/chain.json
@@ -189,11 +189,6 @@
         "provider": "Golden Ratio Staking"
       },
       {
-        "id": "ebc272824924ea1a27ea3183dd0b9ba713494f83",
-        "address": "kujira-mainnet-seed.autostake.com:26796",
-        "provider": "AutoStake 🛡️ Slash Protected"
-      },
-      {
         "id": "400f3d9e30b69e78a7fb891f60d76fa3c73f0ecc",
         "address": "kujira.rpc.kjnodes.com:11359",
         "provider": "kjnodes"
@@ -215,11 +210,6 @@
       }
     ],
     "persistent_peers": [
-      {
-        "id": "ebc272824924ea1a27ea3183dd0b9ba713494f83",
-        "address": "kujira-mainnet-peer.autostake.com:26796",
-        "provider": "AutoStake 🛡️ Slash Protected"
-      },
       {
         "id": "c1a740841a6dc0b56730e975b1a4aa2d8c73b204",
         "address": "peer-kujira.mms.team:29656",
@@ -260,10 +250,6 @@
       {
         "address": "https://rpc-kujira.goldenratiostaking.net",
         "provider": "Golden Ratio Staking"
-      },
-      {
-        "address": "https://kujira-mainnet-rpc.autostake.com:443",
-        "provider": "AutoStake 🛡️ Slash Protected"
       },
       {
         "address": "https://rpc.kujira.rektdao.club",
@@ -324,10 +310,6 @@
         "provider": "Kleomedes"
       },
       {
-        "address": "https://kujira-mainnet-lcd.autostake.com:443",
-        "provider": "AutoStake 🛡️ Slash Protected"
-      },
-      {
         "address": "https://api.kujira.rektdao.club",
         "provider": "rektDAO"
       },
@@ -360,10 +342,6 @@
       {
         "address": "kujira-grpc.polkachu.com:11890",
         "provider": "Polkachu"
-      },
-      {
-        "address": "kujira-mainnet-grpc.autostake.com:443",
-        "provider": "AutoStake 🛡️ Slash Protected"
       },
       {
         "address": "kujira.grpc.kjnodes.com:11390",

--- a/kyve/chain.json
+++ b/kyve/chain.json
@@ -88,11 +88,6 @@
         "id": "8542cd7e6bf9d260fef543bc49e59be5a3fa9074",
         "address": "seed.publicnode.com:26656",
         "provider": "Allnodes ⚡️ Nodes & Staking"
-      },
-      {
-        "id": "ebc272824924ea1a27ea3183dd0b9ba713494f83",
-        "address": "kyve-mainnet-seed.autostake.com:27106",
-        "provider": "AutoStake 🛡️ Slash Protected"
       }
     ],
     "persistent_peers": [
@@ -120,11 +115,6 @@
         "id": "73ef1c0f9bc77fd925decf7fa41f22a35b5dc76d",
         "address": "kyve.declab.pro:26618",
         "provider": "Decloud Nodes Lab"
-      },
-      {
-        "id": "ebc272824924ea1a27ea3183dd0b9ba713494f83",
-        "address": "kyve-mainnet-peer.autostake.com:27106",
-        "provider": "AutoStake 🛡️ Slash Protected"
       }
     ]
   },
@@ -173,10 +163,6 @@
       {
         "address": "https://kyve_mainnet_rpc.chain.whenmoonwhenlambo.money",
         "provider": "🚀 WHEN MOON 🌕 WHEN LAMBO 🔥"
-      },
-      {
-        "address": "https://kyve-mainnet-rpc.autostake.com:443",
-        "provider": "AutoStake 🛡️ Slash Protected"
       }
     ],
     "rest": [
@@ -223,10 +209,6 @@
       {
         "address": "https://kyve_mainnet_api.chain.whenmoonwhenlambo.money",
         "provider": "🚀 WHEN MOON 🌕 WHEN LAMBO 🔥"
-      },
-      {
-        "address": "https://kyve-mainnet-lcd.autostake.com:443",
-        "provider": "AutoStake 🛡️ Slash Protected"
       }
     ],
     "grpc": [
@@ -261,10 +243,6 @@
       {
         "address": "kyve-grpc.noders.services:15090",
         "provider": "[NODERS]TEAM"
-      },
-      {
-        "address": "kyve-mainnet-grpc.autostake.com:443",
-        "provider": "AutoStake 🛡️ Slash Protected"
       }
     ]
   },

--- a/lava/chain.json
+++ b/lava/chain.json
@@ -125,11 +125,6 @@
         "provider": "BlueStake 🚀"
       },
       {
-        "id": "ebc272824924ea1a27ea3183dd0b9ba713494f83",
-        "address": "lava-mainnet-seed.autostake.com:27066",
-        "provider": "AutoStake 🛡️ Slash Protected"
-      },
-      {
         "id": "6086779c98b6864aea1ae595b96a412aa11ec6c7",
         "address": "lava.seed.stakevillage.net:17760",
         "provider": "Stake Village"
@@ -146,11 +141,6 @@
       }
     ],
     "persistent_peers": [
-      {
-        "id": "ebc272824924ea1a27ea3183dd0b9ba713494f83",
-        "address": "lava-mainnet-peer.autostake.com:27066",
-        "provider": "AutoStake 🛡️ Slash Protected"
-      },
       {
         "id": "8a83d4bdd4b26ebe9893efd4609d4be6d82c3527",
         "address": "lava.peer.stakevillage.net:17756",
@@ -207,10 +197,6 @@
       {
         "address": "https://lava.rpc.liveraven.net",
         "provider": "LiveRaveN"
-      },
-      {
-        "address": "https://lava-mainnet-rpc.autostake.com:443",
-        "provider": "AutoStake 🛡️ Slash Protected"
       },
       {
         "address": "https://lava-rpc.bluestake.net:443",
@@ -287,10 +273,6 @@
         "provider": "LiveRaveN"
       },
       {
-        "address": "https://lava-mainnet-lcd.autostake.com:443",
-        "provider": "AutoStake 🛡️ Slash Protected"
-      },
-      {
         "address": "https://lava-api.bluestake.net",
         "provider": "BlueStake 🚀"
       },
@@ -343,10 +325,6 @@
       {
         "address": "lava.grpc.liveraven.net:443",
         "provider": "LiveRaveN"
-      },
-      {
-        "address": "lava-mainnet-grpc.autostake.com:443",
-        "provider": "AutoStake 🛡️ Slash Protected"
       },
       {
         "address": "lava.grpc.stakevillage.net:443",

--- a/lumnetwork/chain.json
+++ b/lumnetwork/chain.json
@@ -74,11 +74,6 @@
         "provider": "lum foundation"
       },
       {
-        "id": "ebc272824924ea1a27ea3183dd0b9ba713494f83",
-        "address": "lum-mainnet-seed.autostake.com:27416",
-        "provider": "AutoStake 🛡️ Slash Protected"
-      },
-      {
         "id": "42d79514ca40e942004e94f90557644cf36e986a",
         "address": "lum.seed.stavr.tech:31316",
         "provider": "🔥STAVR🔥"
@@ -104,11 +99,6 @@
         "id": "b47626b9d78ed7ed3c413304387026f907c70cbe",
         "address": "peer-0.mainnet.lum.network:26656",
         "provider": "lum foundation"
-      },
-      {
-        "id": "ebc272824924ea1a27ea3183dd0b9ba713494f83",
-        "address": "lum-mainnet-peer.autostake.com:27416",
-        "provider": "AutoStake 🛡️ Slash Protected"
       },
       {
         "id": "fbaeeff89ec94a4f6c4a2a61e24af7d06b3be0c8",
@@ -175,10 +165,6 @@
       {
         "address": "lum.grpc.m.stavr.tech:2277",
         "provider": "🔥STAVR🔥"
-      },
-      {
-        "address": "lum-mainnet-grpc.autostake.com:443",
-        "provider": "AutoStake 🛡️ Slash Protected"
       },
       {
         "address": "lum-grpc.stakerhouse.com:443",

--- a/mantrachain/chain.json
+++ b/mantrachain/chain.json
@@ -84,11 +84,6 @@
         "address": "seed-mantra.r93axnodes.cloud:13156"
       },
       {
-        "id": "ebc272824924ea1a27ea3183dd0b9ba713494f83",
-        "address": "mantrachain-mainnet-seed.autostake.com:27536",
-        "provider": "AutoStake 🛡️ Slash Protected"
-      },
-      {
         "id": "8542cd7e6bf9d260fef543bc49e59be5a3fa9074",
         "address": "seed.publicnode.com:26656",
         "provider": "Allnodes ⚡️ Nodes & Staking"
@@ -100,11 +95,6 @@
       }
     ],
     "persistent_peers": [
-      {
-        "id": "ebc272824924ea1a27ea3183dd0b9ba713494f83",
-        "address": "mantrachain-mainnet-peer.autostake.com:27536",
-        "provider": "AutoStake 🛡️ Slash Protected"
-      },
       {
         "id": "5cb41a850a2d41a28ff908e0e984a2a8deb7498a",
         "address": "mantra-mainnet-peer.itrocket.net:22656",

--- a/mars/chain.json
+++ b/mars/chain.json
@@ -75,11 +75,6 @@
         "provider": "Lavender.Five Nodes 🐝"
       },
       {
-        "id": "ebc272824924ea1a27ea3183dd0b9ba713494f83",
-        "address": "mars-mainnet-seed.autostake.com:27056",
-        "provider": "AutoStake 🛡️ Slash Protected"
-      },
-      {
         "id": "ade4d8bc8cbe014af6ebdf3cb7b1e9ad36f412c0",
         "address": "seeds.polkachu.com:18556",
         "provider": "Polkachu"
@@ -94,13 +89,6 @@
         "address": "mars.rpc.kjnodes.com:14559",
         "provider": "kjnodes"
       }
-    ],
-    "persistent_peers": [
-      {
-        "id": "ebc272824924ea1a27ea3183dd0b9ba713494f83",
-        "address": "mars-mainnet-peer.autostake.com:27056",
-        "provider": "AutoStake 🛡️ Slash Protected"
-      }
     ]
   },
   "apis": {
@@ -112,10 +100,6 @@
       {
         "address": "https://rpc.lavenderfive.com:443/mars",
         "provider": "Lavender.Five Nodes 🐝"
-      },
-      {
-        "address": "https://mars-mainnet-rpc.autostake.com:443",
-        "provider": "AutoStake 🛡️ Slash Protected"
       },
       {
         "address": "https://mars-rpc.polkachu.com",
@@ -150,10 +134,6 @@
       {
         "address": "https://rest.lavenderfive.com:443/mars",
         "provider": "Lavender.Five Nodes 🐝"
-      },
-      {
-        "address": "https://mars-mainnet-lcd.autostake.com:443",
-        "provider": "AutoStake 🛡️ Slash Protected"
       },
       {
         "address": "https://mars-api.polkachu.com",
@@ -192,10 +172,6 @@
       {
         "address": "mars-grpc.polkachu.com:18590",
         "provider": "Polkachu"
-      },
-      {
-        "address": "mars-mainnet-grpc.autostake.com:443",
-        "provider": "AutoStake 🛡️ Slash Protected"
       },
       {
         "address": "mars-grpc.genznodes.dev:26090",

--- a/migaloo/chain.json
+++ b/migaloo/chain.json
@@ -70,11 +70,6 @@
         "provider": "Cros-Nest"
       },
       {
-        "id": "ebc272824924ea1a27ea3183dd0b9ba713494f83",
-        "address": "whitewhale-mainnet-seed.autostake.com:27096",
-        "provider": "AutoStake 🛡️ Slash Protected"
-      },
-      {
         "id": "ade4d8bc8cbe014af6ebdf3cb7b1e9ad36f412c0",
         "address": "seeds.polkachu.com:20756",
         "provider": "Polkachu"
@@ -83,13 +78,6 @@
         "id": "8542cd7e6bf9d260fef543bc49e59be5a3fa9074",
         "address": "seed.publicnode.com:26656",
         "provider": "Allnodes ⚡️ Nodes & Staking"
-      }
-    ],
-    "persistent_peers": [
-      {
-        "id": "ebc272824924ea1a27ea3183dd0b9ba713494f83",
-        "address": "whitewhale-mainnet-peer.autostake.com:27096",
-        "provider": "AutoStake 🛡️ Slash Protected"
       }
     ]
   },
@@ -134,10 +122,6 @@
       {
         "address": "migaloo-grpc.polkachu.com:20790",
         "provider": "Polkachu"
-      },
-      {
-        "address": "whitewhale-mainnet-grpc.autostake.com:443",
-        "provider": "AutoStake 🛡️ Slash Protected"
       },
       {
         "address": "grpc-migaloo.cosmos-spaces.cloud:4810",

--- a/nillion/chain.json
+++ b/nillion/chain.json
@@ -78,11 +78,6 @@
         "address": "rpc.nodestake.org.com:666"
       },
       {
-        "id": "ebc272824924ea1a27ea3183dd0b9ba713494f83",
-        "address": "nillion-mainnet-seed.autostake.com:27076",
-        "provider": "AutoStake 🛡️ Slash Protected"
-      },
-      {
         "id": "babc3f3f7804933265ec9c40ad94f4da8e9e0017",
         "address": "seed.rhinostake.com:28156",
         "provider": "RHINO 🦏"
@@ -105,10 +100,6 @@
         "provider": "NodeStake"
       },
       {
-        "address": "https://nillion-mainnet-rpc.autostake.com:443",
-        "provider": "AutoStake 🛡️ Slash Protected"
-      },
-      {
         "address": "https://nillion-mainnet-rpc.shazoes.xyz",
         "provider": "Shazoes"
       },
@@ -127,10 +118,6 @@
         "provider": "NodeStake"
       },
       {
-        "address": "https://nillion-mainnet-lcd.autostake.com:443",
-        "provider": "AutoStake 🛡️ Slash Protected"
-      },
-      {
         "address": "https://nillion-mainnet-api.shazoes.xyz",
         "provider": "Shazoes"
       },
@@ -147,10 +134,6 @@
       {
         "address": "https://grpc.nillion.nodestake.org",
         "provider": "NodeStake"
-      },
-      {
-        "address": "nillion-mainnet-grpc.autostake.com:443",
-        "provider": "AutoStake 🛡️ Slash Protected"
       },
       {
         "address": "nillion-mainnet-grpc.shazoes.xyz:30890",

--- a/nois/chain.json
+++ b/nois/chain.json
@@ -145,10 +145,6 @@
         "provider": "SR20DE"
       },
       {
-        "address": "https://nois-mainnet-rpc.autostake.com",
-        "provider": "AutoStake"
-      },
-      {
         "address": "https://nois-rpc.polkachu.com",
         "provider": "Polkachu"
       },
@@ -205,10 +201,6 @@
       {
         "address": "https://grpc-nois.sr20de.xyz",
         "provider": "SR20DE"
-      },
-      {
-        "address": "https://nois-testnet-grpc.autostake.com",
-        "provider": "AutoStake"
       },
       {
         "address": "nois-grpc.polkachu.com:17390",

--- a/nolus/chain.json
+++ b/nolus/chain.json
@@ -116,11 +116,6 @@
         "provider": "Lavender.Five Nodes 🐝"
       },
       {
-        "id": "ebc272824924ea1a27ea3183dd0b9ba713494f83",
-        "address": "nolus-mainnet-seed.autostake.com:27016",
-        "provider": "AutoStake 🛡️ Slash Protected"
-      },
-      {
         "id": "8542cd7e6bf9d260fef543bc49e59be5a3fa9074",
         "address": "seed.publicnode.com:26656",
         "provider": "Allnodes ⚡️ Nodes & Staking"
@@ -130,13 +125,6 @@
         "address": "nolus.rpc.kjnodes.com:14359",
         "provider": "kjnodes"
       }
-    ],
-    "persistent_peers": [
-      {
-        "id": "ebc272824924ea1a27ea3183dd0b9ba713494f83",
-        "address": "nolus-mainnet-peer.autostake.com:27016",
-        "provider": "AutoStake 🛡️ Slash Protected"
-      }
     ]
   },
   "apis": {
@@ -144,10 +132,6 @@
       {
         "address": "https://rpc.nolus.network",
         "provider": "NolusProtocol"
-      },
-      {
-        "address": "https://nolus-mainnet-rpc.autostake.com:443",
-        "provider": "AutoStake 🛡️ Slash Protected"
       },
       {
         "address": "https://rpc.lavenderfive.com:443/nolus",
@@ -188,10 +172,6 @@
         "provider": "NolusProtocol"
       },
       {
-        "address": "https://nolus-mainnet-lcd.autostake.com:443",
-        "provider": "AutoStake 🛡️ Slash Protected"
-      },
-      {
         "address": "https://rest.lavenderfive.com:443/nolus",
         "provider": "Lavender.Five Nodes 🐝"
       },
@@ -228,10 +208,6 @@
       {
         "address": "grpc.nolus.network",
         "provider": "NolusProtocol"
-      },
-      {
-        "address": "nolus-mainnet-grpc.autostake.com:443",
-        "provider": "AutoStake 🛡️ Slash Protected"
       },
       {
         "address": "nolus.lavenderfive.com:443",

--- a/odin/chain.json
+++ b/odin/chain.json
@@ -68,11 +68,6 @@
         "provider": "Lavender.Five Nodes 🐝"
       },
       {
-        "id": "ebc272824924ea1a27ea3183dd0b9ba713494f83",
-        "address": "odin-mainnet-seed.autostake.com:26766",
-        "provider": "AutoStake.net"
-      },
-      {
         "id": "9a5b281c2d627cdf362f86721ced61a6228b87d1",
         "address": "odin.seed.stavr.tech:1116",
         "provider": "🔥STAVR🔥"
@@ -108,11 +103,6 @@
         "id": "0165cd0d60549a37abb00b6acc8227a54609c648",
         "address": "34.79.179.216:26656",
         "provider": "Odin Protocol"
-      },
-      {
-        "id": "ebc272824924ea1a27ea3183dd0b9ba713494f83",
-        "address": "odin-mainnet-peer.autostake.com:26766",
-        "provider": "AutoStake.net"
       }
     ]
   },
@@ -129,10 +119,6 @@
       {
         "address": "https://rpc.lavenderfive.com:443/odin",
         "provider": "Lavender.Five Nodes 🐝"
-      },
-      {
-        "address": "https://odin-mainnet-rpc.autostake.com:443",
-        "provider": "AutoStake 🛡️ Slash Protected"
       }
     ],
     "rest": [
@@ -147,10 +133,6 @@
       {
         "address": "https://rest.lavenderfive.com:443/odin",
         "provider": "Lavender.Five Nodes 🐝"
-      },
-      {
-        "address": "https://odin-mainnet-lcd.autostake.com:443",
-        "provider": "AutoStake 🛡️ Slash Protected"
       }
     ],
     "grpc": [
@@ -161,10 +143,6 @@
       {
         "address": "odin.grpc.m.stavr.tech:122",
         "provider": "🔥STAVR🔥"
-      },
-      {
-        "address": "odin-mainnet-grpc.autostake.com:443",
-        "provider": "AutoStake 🛡️ Slash Protected"
       }
     ]
   },

--- a/odin1/chain.json
+++ b/odin1/chain.json
@@ -51,11 +51,6 @@
         "id": "20e1000e88125698264454a884812746c2eb4807",
         "address": "seeds.lavenderfive.com:16856",
         "provider": "Lavender.Five Nodes 🐝"
-      },
-      {
-        "id": "ebc272824924ea1a27ea3183dd0b9ba713494f83",
-        "address": "odin-mainnet-seed.autostake.com:26766",
-        "provider": "AutoStake.net"
       }
     ],
     "persistent_peers": [
@@ -78,11 +73,6 @@
         "id": "0165cd0d60549a37abb00b6acc8227a54609c648",
         "address": "34.79.179.216:26656",
         "provider": "Odin Protocol"
-      },
-      {
-        "id": "ebc272824924ea1a27ea3183dd0b9ba713494f83",
-        "address": "odin-mainnet-peer.autostake.com:26766",
-        "provider": "AutoStake.net"
       }
     ]
   },
@@ -95,10 +85,6 @@
       {
         "address": "https://rpc.lavenderfive.com:443/odin",
         "provider": "Lavender.Five Nodes 🐝"
-      },
-      {
-        "address": "https://odin-mainnet-rpc.autostake.com:443",
-        "provider": "AutoStake 🛡️ Slash Protected"
       }
     ],
     "rest": [
@@ -109,20 +95,12 @@
       {
         "address": "https://rest.lavenderfive.com:443/odin",
         "provider": "Lavender.Five Nodes 🐝"
-      },
-      {
-        "address": "https://odin-mainnet-lcd.autostake.com:443",
-        "provider": "AutoStake 🛡️ Slash Protected"
       }
     ],
     "grpc": [
       {
         "address": "odin.lavenderfive.com:443",
         "provider": "Lavender.Five Nodes 🐝"
-      },
-      {
-        "address": "odin-mainnet-grpc.autostake.com:443",
-        "provider": "AutoStake 🛡️ Slash Protected"
       }
     ]
   },

--- a/omniflixhub/chain.json
+++ b/omniflixhub/chain.json
@@ -67,11 +67,6 @@
         "provider": "RHINO 🦏"
       },
       {
-        "id": "ebc272824924ea1a27ea3183dd0b9ba713494f83",
-        "address": "omniflixhub-mainnet-seed.autostake.com:27306",
-        "provider": "AutoStake 🛡️ Slash Protected"
-      },
-      {
         "id": "20e1000e88125698264454a884812746c2eb4807",
         "address": "seeds.lavenderfive.com:16956",
         "provider": "Lavender.Five Nodes 🐝"
@@ -96,11 +91,6 @@
       {
         "id": "574b37cc6e80663e70673cbe848147c2643ca48e",
         "address": "35.240.187.174:26656"
-      },
-      {
-        "id": "ebc272824924ea1a27ea3183dd0b9ba713494f83",
-        "address": "omniflixhub-mainnet-peer.autostake.com:27306",
-        "provider": "AutoStake 🛡️ Slash Protected"
       },
       {
         "id": "d8e371758cdb310906bc32ba0bb922642bb33536",
@@ -135,10 +125,6 @@
       {
         "address": "https://rpc.omniflix.silentvalidator.com/",
         "provider": "silent"
-      },
-      {
-        "address": "https://omniflixhub-mainnet-rpc.autostake.com:443",
-        "provider": "AutoStake 🛡️ Slash Protected"
       },
       {
         "address": "https://rpc-omniflix.architectnodes.com",
@@ -199,10 +185,6 @@
         "provider": "kingnodes 👑"
       },
       {
-        "address": "https://omniflixhub-mainnet-lcd.autostake.com:443",
-        "provider": "AutoStake 🛡️ Slash Protected"
-      },
-      {
         "address": "https://rest-omniflix.architectnodes.com",
         "provider": "Architect Nodes"
       },
@@ -251,10 +233,6 @@
       {
         "address": "grpc-omniflixhub.cosmos-spaces.cloud:2230",
         "provider": "Cosmos Spaces"
-      },
-      {
-        "address": "omniflixhub-mainnet-grpc.autostake.com:443",
-        "provider": "AutoStake 🛡️ Slash Protected"
       },
       {
         "address": "grpc-omniflix.architectnodes.com:1443",

--- a/onomy/chain.json
+++ b/onomy/chain.json
@@ -71,11 +71,6 @@
         "id": "7e0f0acd32a3c1e85aaebeea56d9b72cece12252",
         "address": "b.seed.mainnet.onomy.io:26656",
         "provider": "onomy"
-      },
-      {
-        "id": "ebc272824924ea1a27ea3183dd0b9ba713494f83",
-        "address": "onomy-mainnet-seed.autostake.com:27556",
-        "provider": "AutoStake 🛡️ Slash Protected"
       }
     ],
     "persistent_peers": [
@@ -88,11 +83,6 @@
         "id": "00ce2f84f6b91639a7cedb2239e38ffddf9e36de",
         "address": "44.195.221.88:26656",
         "provider": "cosmostation"
-      },
-      {
-        "id": "ebc272824924ea1a27ea3183dd0b9ba713494f83",
-        "address": "onomy-mainnet-peer.autostake.com:27556",
-        "provider": "AutoStake 🛡️ Slash Protected"
       }
     ]
   },
@@ -101,20 +91,12 @@
       {
         "address": "https://rpc-mainnet.onomy.io",
         "provider": "onomy"
-      },
-      {
-        "address": "https://onomy-mainnet-rpc.autostake.com:443",
-        "provider": "AutoStake 🛡️ Slash Protected"
       }
     ],
     "rest": [
       {
         "address": "https://rest-mainnet.onomy.io",
         "provider": "onomy"
-      },
-      {
-        "address": "https://onomy-mainnet-lcd.autostake.com:443",
-        "provider": "AutoStake 🛡️ Slash Protected"
       }
     ],
     "grpc": []

--- a/oraichain/chain.json
+++ b/oraichain/chain.json
@@ -76,11 +76,6 @@
         "provider": "synergynodes"
       },
       {
-        "id": "ebc272824924ea1a27ea3183dd0b9ba713494f83",
-        "address": "oraichain-mainnet-seed.autostake.com:27436",
-        "provider": "AutoStake 🛡️ Slash Protected"
-      },
-      {
         "id": "f223f1be06ef35a6dfe54995f05daeb1897d94d7",
         "address": "seed-node.mms.team:42656",
         "provider": "MMS"
@@ -128,11 +123,6 @@
         "provider": "synergynodes"
       },
       {
-        "id": "ebc272824924ea1a27ea3183dd0b9ba713494f83",
-        "address": "oraichain-mainnet-seed.autostake.com:27436",
-        "provider": "AutoStake 🛡️ Slash Protected"
-      },
-      {
         "id": "c14df7b2e097d743aa7574c7cf65397a06ea3833",
         "address": "peer-oraichain.mms.team:56103",
         "provider": "MMS"
@@ -167,10 +157,6 @@
       {
         "address": "https://rpc-orai.nodine.id/",
         "provider": "Nodine.ID"
-      },
-      {
-        "address": "https://oraichain-mainnet-rpc.autostake.com:443",
-        "provider": "AutoStake 🛡️ Slash Protected"
       },
       {
         "address": "https://rpc-oraichain.mms.team",
@@ -215,10 +201,6 @@
         "provider": "oraichain-team"
       },
       {
-        "address": "https://oraichain-mainnet-lcd.autostake.com:443",
-        "provider": "AutoStake 🛡️ Slash Protected"
-      },
-      {
         "address": "https://api-oraichain.mms.team",
         "provider": "MMS"
       },
@@ -255,10 +237,6 @@
       {
         "address": "grpc.orai.pfc.zone:443",
         "provider": "PFC"
-      },
-      {
-        "address": "oraichain-mainnet-grpc.autostake.com:443",
-        "provider": "AutoStake 🛡️ Slash Protected"
       },
       {
         "address": "grpc-orai.blockval.io:9390",

--- a/osmosis/chain.json
+++ b/osmosis/chain.json
@@ -601,11 +601,6 @@
         "provider": "Lavender.Five Nodes 🐝"
       },
       {
-        "id": "ebc272824924ea1a27ea3183dd0b9ba713494f83",
-        "address": "osmosis-mainnet-seed.autostake.com:26716",
-        "provider": "AutoStake 🛡️ Slash Protected"
-      },
-      {
         "id": "3cc024d1c760c9cd96e6413abaf3b36a8bdca58e",
         "address": "seeds.goldenratiostaking.net:1630",
         "provider": "Golden Ratio Staking"
@@ -661,11 +656,6 @@
         "id": "2f9c16151400d8516b0f58c030b3595be20b804c",
         "address": "37.120.245.167:26656",
         "provider": "syncnode"
-      },
-      {
-        "id": "ebc272824924ea1a27ea3183dd0b9ba713494f83",
-        "address": "osmosis-mainnet-peer.autostake.com:26716",
-        "provider": "AutoStake 🛡️ Slash Protected"
       },
       {
         "id": "e891d42c31064fb7e0d99839536164473c4905c2",

--- a/passage/chain.json
+++ b/passage/chain.json
@@ -83,11 +83,6 @@
         "provider": "Lavender.Five Nodes 🐝"
       },
       {
-        "id": "ebc272824924ea1a27ea3183dd0b9ba713494f83",
-        "address": "passage-mainnet-seed.autostake.com:26916",
-        "provider": "AutoStake 🛡️ Slash Protected"
-      },
-      {
         "id": "8542cd7e6bf9d260fef543bc49e59be5a3fa9074",
         "address": "seed.publicnode.com:26656",
         "provider": "Allnodes ⚡️ Nodes & Staking"
@@ -116,11 +111,6 @@
       {
         "id": "8e0b0d4f80d0d2853f853fbd6a76390113f07d72",
         "address": "65.108.127.249:26656"
-      },
-      {
-        "id": "ebc272824924ea1a27ea3183dd0b9ba713494f83",
-        "address": "passage-mainnet-peer.autostake.com:26916",
-        "provider": "AutoStake 🛡️ Slash Protected"
       },
       {
         "id": "621f75a74a95298fe16e0c2dd899c087bcba6594",
@@ -159,10 +149,6 @@
       {
         "address": "https://rpc-passage.d-stake.xyz",
         "provider": "D-stake"
-      },
-      {
-        "address": "https://passage-mainnet-rpc.autostake.com:443",
-        "provider": "AutoStake 🛡️ Slash Protected"
       },
       {
         "address": "https://passage-rpc.stakerhouse.com",
@@ -215,10 +201,6 @@
         "provider": "D-stake"
       },
       {
-        "address": "https://passage-mainnet-lcd.autostake.com:443",
-        "provider": "AutoStake 🛡️ Slash Protected"
-      },
-      {
         "address": "https://passage-rest.stakerhouse.com",
         "provider": "StakerHouse"
       },
@@ -255,10 +237,6 @@
       {
         "address": "grpc-passage.cosmos-spaces.cloud:2320",
         "provider": "Cosmos Spaces"
-      },
-      {
-        "address": "passage-mainnet-grpc.autostake.com:443",
-        "provider": "AutoStake 🛡️ Slash Protected"
       },
       {
         "address": "services.staketab.com:9023",

--- a/persistence/chain.json
+++ b/persistence/chain.json
@@ -87,11 +87,6 @@
         "address": "tenderseed.ccvalidators.com:26003"
       },
       {
-        "id": "ebc272824924ea1a27ea3183dd0b9ba713494f83",
-        "address": "persistence-mainnet-seed.autostake.com:26896",
-        "provider": "AutoStake 🛡️ Slash Protected"
-      },
-      {
         "id": "ade4d8bc8cbe014af6ebdf3cb7b1e9ad36f412c0",
         "address": "seeds.polkachu.com:15456",
         "provider": "Polkachu"
@@ -123,11 +118,6 @@
       }
     ],
     "persistent_peers": [
-      {
-        "id": "ebc272824924ea1a27ea3183dd0b9ba713494f83",
-        "address": "persistence-mainnet-peer.autostake.com:26896",
-        "provider": "AutoStake 🛡️ Slash Protected"
-      },
       {
         "id": "137818b03a705cf86622b4d97a074091f2f22589",
         "address": "185.225.233.30:26756",
@@ -192,10 +182,6 @@
       {
         "address": "https://persistence-rpc.zenscape.one",
         "provider": "Zenscape"
-      },
-      {
-        "address": "https://persistence-mainnet-rpc.autostake.com:443",
-        "provider": "AutoStake 🛡️ Slash Protected"
       },
       {
         "address": "https://persistence-rpc.stakeandrelax.net",
@@ -268,10 +254,6 @@
         "provider": "Architect Nodes"
       },
       {
-        "address": "https://persistence-mainnet-lcd.autostake.com:443",
-        "provider": "AutoStake 🛡️ Slash Protected"
-      },
-      {
         "address": "https://persistence-mainnet-rest.cosmonautstakes.com",
         "provider": "Cosmonaut Stakes"
       },
@@ -340,10 +322,6 @@
       {
         "address": "persistence-grpc.polkachu.com:15490",
         "provider": "Polkachu"
-      },
-      {
-        "address": "persistence-mainnet-grpc.autostake.com:443",
-        "provider": "AutoStake 🛡️ Slash Protected"
       },
       {
         "address": "grpc.persistence.posthuman.digital:80",

--- a/provenance/chain.json
+++ b/provenance/chain.json
@@ -79,11 +79,6 @@
         "provider": "TAKESHI"
       },
       {
-        "id": "ebc272824924ea1a27ea3183dd0b9ba713494f83",
-        "address": "provenance-mainnet-seed.autostake.com:27376",
-        "provider": "AutoStake 🛡️ Slash Protected"
-      },
-      {
         "id": "40f9493fa7ab4259159240e9a8ba12f90743079b",
         "address": "seed.provenance.io:26656",
         "provider": "Figure"
@@ -111,11 +106,6 @@
     ],
     "persistent_peers": [
       {
-        "id": "ebc272824924ea1a27ea3183dd0b9ba713494f83",
-        "address": "provenance-mainnet-peer.autostake.com:27376",
-        "provider": "AutoStake 🛡️ Slash Protected"
-      },
-      {
         "id": "aa808927715ad82be258605060c21fc5afc1cd00",
         "address": "provenance-peer.panthea.eu:34656",
         "provider": "Panthea EU"
@@ -131,10 +121,6 @@
       {
         "address": "https://rpc.provenance.io/",
         "provider": "Figure"
-      },
-      {
-        "address": "https://provenance-mainnet-rpc.autostake.com:443",
-        "provider": "AutoStake 🛡️ Slash Protected"
       },
       {
         "address": "https://provenance.ibs.team:443/rpc",
@@ -169,10 +155,6 @@
       {
         "address": "https://api-provenance.takeshi.team",
         "provider": "TAKESHI"
-      },
-      {
-        "address": "https://provenance-mainnet-lcd.autostake.com:443",
-        "provider": "AutoStake 🛡️ Slash Protected"
       },
       {
         "address": "https://api.provenance.io",
@@ -215,10 +197,6 @@
       {
         "address": "grpc-provenance.takeshi.team:443",
         "provider": "TAKESHI"
-      },
-      {
-        "address": "provenance-mainnet-grpc.autostake.com:443",
-        "provider": "AutoStake 🛡️ Slash Protected"
       },
       {
         "address": "provenance-grpc.panthea.eu:16780",

--- a/pryzm/chain.json
+++ b/pryzm/chain.json
@@ -165,18 +165,6 @@
         "id": "20e1000e88125698264454a884812746c2eb4807",
         "address": "seeds.lavenderfive.com:24856",
         "provider": "Lavender.Five Nodes 🐝"
-      },
-      {
-        "id": "ebc272824924ea1a27ea3183dd0b9ba713494f83",
-        "address": "pryzm-mainnet-seed.autostake.com:27406",
-        "provider": "AutoStake 🛡️ Slash Protected"
-      }
-    ],
-    "persistent_peers": [
-      {
-        "id": "ebc272824924ea1a27ea3183dd0b9ba713494f83",
-        "address": "pryzm-mainnet-peer.autostake.com:27406",
-        "provider": "AutoStake 🛡️ Slash Protected"
       }
     ]
   },
@@ -189,10 +177,6 @@
       {
         "address": "https://rpc.lavenderfive.com:443/pryzm",
         "provider": "Lavender.Five Nodes 🐝"
-      },
-      {
-        "address": "https://pryzm-mainnet-rpc.autostake.com:443",
-        "provider": "AutoStake 🛡️ Slash Protected"
       },
       {
         "address": "https://pryzm-rpc.chainroot.io",
@@ -209,10 +193,6 @@
         "provider": "Lavender.Five Nodes 🐝"
       },
       {
-        "address": "https://pryzm-mainnet-lcd.autostake.com:443",
-        "provider": "AutoStake 🛡️ Slash Protected"
-      },
-      {
         "address": "https://pryzm-api.chainroot.io",
         "provider": "Chainroot"
       }
@@ -225,10 +205,6 @@
       {
         "address": "pryzm.lavenderfive.com:443",
         "provider": "Lavender.Five Nodes 🐝"
-      },
-      {
-        "address": "pryzm-mainnet-grpc.autostake.com:443",
-        "provider": "AutoStake 🛡️ Slash Protected"
       },
       {
         "address": "pryzm-grpc.chainroot.io:443",

--- a/quasar/chain.json
+++ b/quasar/chain.json
@@ -100,22 +100,12 @@
         "id": "400f3d9e30b69e78a7fb891f60d76fa3c73f0ecc",
         "address": "quasar.rpc.kjnodes.com:14859",
         "provider": "kjnodes"
-      },
-      {
-        "id": "ebc272824924ea1a27ea3183dd0b9ba713494f83",
-        "address": "quasar-mainnet-seed.autostake.com:27146",
-        "provider": "AutoStake 🛡️ Slash Protected"
       }
     ],
     "persistent_peers": [
       {
         "id": "298e0e1faf8a5da43514cc2908d2908658e732a0",
         "address": "298e0e1faf8a5da43514cc2908d2908658e732a0@38.146.3.148:18256"
-      },
-      {
-        "id": "ebc272824924ea1a27ea3183dd0b9ba713494f83",
-        "address": "quasar-mainnet-peer.autostake.com:27146",
-        "provider": "AutoStake 🛡️ Slash Protected"
       },
       {
         "id": "f85f57bd852fd460bc99628444df26c45e02e95a",
@@ -141,10 +131,6 @@
       {
         "address": "https://rpc-quasar.cosmos-spaces.cloud",
         "provider": "Cosmos Spaces"
-      },
-      {
-        "address": "https://quasar-mainnet-rpc.autostake.com:443",
-        "provider": "AutoStake 🛡️ Slash Protected"
       },
       {
         "address": "https://quasar.rpc.kjnodes.com",
@@ -193,10 +179,6 @@
         "provider": "Enigma"
       },
       {
-        "address": "https://quasar-mainnet-lcd.autostake.com:443",
-        "provider": "AutoStake 🛡️ Slash Protected"
-      },
-      {
         "address": "https://quasar.api.kjnodes.com",
         "provider": "kjnodes"
       },
@@ -237,10 +219,6 @@
       {
         "address": "grpc-quasar.cosmos-spaces.cloud:12890",
         "provider": "Cosmos Spaces"
-      },
-      {
-        "address": "quasar-mainnet-grpc.autostake.com:443",
-        "provider": "AutoStake 🛡️ Slash Protected"
       },
       {
         "address": "quasar.grpc.kjnodes.com:14890",

--- a/quicksilver/chain.json
+++ b/quicksilver/chain.json
@@ -84,11 +84,6 @@
         "provider": "Lavender.Five Nodes 🐝"
       },
       {
-        "id": "ebc272824924ea1a27ea3183dd0b9ba713494f83",
-        "address": "quicksilver-mainnet-seed.autostake.com:27026",
-        "provider": "AutoStake 🛡️ Slash Protected"
-      },
-      {
         "id": "8542cd7e6bf9d260fef543bc49e59be5a3fa9074",
         "address": "seed.publicnode.com:26656",
         "provider": "Allnodes ⚡️ Nodes & Staking"
@@ -120,11 +115,6 @@
       }
     ],
     "persistent_peers": [
-      {
-        "id": "ebc272824924ea1a27ea3183dd0b9ba713494f83",
-        "address": "quicksilver-mainnet-peer.autostake.com:27026",
-        "provider": "AutoStake 🛡️ Slash Protected"
-      },
       {
         "id": "3461638afd470034067392e5dba8dcf6de49f81f",
         "address": "rpc.quicksilver.indonode.net:28656",

--- a/rebus/chain.json
+++ b/rebus/chain.json
@@ -59,11 +59,6 @@
         "provider": "Lavender.Five Nodes 🐝"
       },
       {
-        "id": "ebc272824924ea1a27ea3183dd0b9ba713494f83",
-        "address": "rebus-mainnet-seed.autostake.com:26906",
-        "provider": "AutoStake 🛡️ Slash Protected"
-      },
-      {
         "id": "8542cd7e6bf9d260fef543bc49e59be5a3fa9074",
         "address": "seed.publicnode.com:26656",
         "provider": "Allnodes ⚡️ Nodes & Staking"
@@ -74,11 +69,6 @@
         "id": "0863966356f6532377aeba663415258d44ddbd13",
         "address": "rebus.peer.stavr.tech:40106",
         "provider": "🔥STAVR🔥"
-      },
-      {
-        "id": "ebc272824924ea1a27ea3183dd0b9ba713494f83",
-        "address": "rebus-mainnet-peer.autostake.com:26906",
-        "provider": "AutoStake 🛡️ Slash Protected"
       },
       {
         "id": "9c7c067bd73bddfe8da39087cdae37c4fc5ec6e3",
@@ -112,10 +102,6 @@
       {
         "address": "https://api.mainnet.rebus.money:26657",
         "provider": "Rebuschain"
-      },
-      {
-        "address": "https://rebus-mainnet-rpc.autostake.com:443",
-        "provider": "AutoStake 🛡️ Slash Protected"
       },
       {
         "address": "https://rebus.rpc.liveraven.net",
@@ -152,10 +138,6 @@
         "provider": "Rebuschain"
       },
       {
-        "address": "https://rebus-mainnet-lcd.autostake.com:443",
-        "provider": "AutoStake 🛡️ Slash Protected"
-      },
-      {
         "address": "https://rebus.api.liveraven.net",
         "provider": "LiveRaveN"
       },
@@ -184,10 +166,6 @@
       {
         "address": "http://rebus.grpc.m.stavr.tech:3211",
         "provider": "🔥STAVR🔥"
-      },
-      {
-        "address": "rebus-mainnet-grpc.autostake.com:443",
-        "provider": "AutoStake 🛡️ Slash Protected"
       },
       {
         "address": "https://rebus.grpc.liveraven.net",

--- a/regen/chain.json
+++ b/regen/chain.json
@@ -79,22 +79,12 @@
         "id": "dc7121500d58d40c98f06f14d5a9065935a7adf6",
         "address": "regen.seed.stavr.tech:2126",
         "provider": "🔥STAVR🔥"
-      },
-      {
-        "id": "ebc272824924ea1a27ea3183dd0b9ba713494f83",
-        "address": "regen-mainnet-seed.autostake.com:27216",
-        "provider": "AutoStake 🛡️ Slash Protected"
       }
     ],
     "persistent_peers": [
       {
         "id": "d35d652b6cb3bf7d6cb8d4bd7c036ea03e7be2ab",
         "address": "116.203.182.185:26656"
-      },
-      {
-        "id": "ebc272824924ea1a27ea3183dd0b9ba713494f83",
-        "address": "regen-mainnet-peer.autostake.com:27216",
-        "provider": "AutoStake 🛡️ Slash Protected"
       }
     ]
   },
@@ -119,10 +109,6 @@
       {
         "address": "http://rpc.regen.forbole.com:80",
         "provider": "forbole"
-      },
-      {
-        "address": "https://regen-mainnet-rpc.autostake.com:443",
-        "provider": "AutoStake 🛡️ Slash Protected"
       },
       {
         "address": "https://regen-rpc.easy2stake.com",
@@ -155,10 +141,6 @@
         "provider": "🔥STAVR🔥"
       },
       {
-        "address": "https://regen-mainnet-lcd.autostake.com:443",
-        "provider": "AutoStake 🛡️ Slash Protected"
-      },
-      {
         "address": "https://rest-regen.ecostake.com",
         "provider": "ecostake"
       },
@@ -180,10 +162,6 @@
       }
     ],
     "grpc": [
-      {
-        "address": "regen-mainnet-grpc.autostake.com:443",
-        "provider": "AutoStake 🛡️ Slash Protected"
-      },
       {
         "address": "regen.grpc.m.stavr.tech:124",
         "provider": "🔥STAVR🔥"

--- a/routerchain/chain.json
+++ b/routerchain/chain.json
@@ -82,11 +82,6 @@
         "id": "fbb30fa866f318e9e1c48188711526fc69f66d18",
         "address": "188.214.133.174:26656",
         "provider": "Router"
-      },
-      {
-        "id": "ebc272824924ea1a27ea3183dd0b9ba713494f83",
-        "address": "router-mainnet-seed.autostake.com:27336",
-        "provider": "AutoStake 🛡️ Slash Protected"
       }
     ],
     "persistent_peers": [
@@ -104,11 +99,6 @@
         "id": "fbb30fa866f318e9e1c48188711526fc69f66d18",
         "address": "188.214.133.174:26656",
         "provider": "Router"
-      },
-      {
-        "id": "ebc272824924ea1a27ea3183dd0b9ba713494f83",
-        "address": "router-mainnet-seed.autostake.com:27336",
-        "provider": "AutoStake 🛡️ Slash Protected"
       }
     ]
   },
@@ -117,10 +107,6 @@
       {
         "address": "https://sentry.tm.rpc.routerprotocol.com/",
         "provider": "Router"
-      },
-      {
-        "address": "https://router-mainnet-rpc.autostake.com:443",
-        "provider": "AutoStake 🛡️ Slash Protected"
       },
       {
         "address": "https://routerchain_mainnet_rpc.chain.whenmoonwhenlambo.money",
@@ -137,10 +123,6 @@
         "provider": "Router"
       },
       {
-        "address": "https://router-mainnet-lcd.autostake.com:443",
-        "provider": "AutoStake 🛡️ Slash Protected"
-      },
-      {
         "address": "https://routerchain_mainnet_api.chain.whenmoonwhenlambo.money",
         "provider": "🚀 WHEN MOON 🌕 WHEN LAMBO 🔥"
       },
@@ -153,10 +135,6 @@
       {
         "address": "sentry.grpc.routerprotocol.com:9090",
         "provider": "Router"
-      },
-      {
-        "address": "router-mainnet-grpc.autostake.com:443",
-        "provider": "AutoStake 🛡️ Slash Protected"
       },
       {
         "address": "grpc.router.nodestake.org:443",

--- a/saga/chain.json
+++ b/saga/chain.json
@@ -73,11 +73,6 @@
   "peers": {
     "seeds": [
       {
-        "id": "ebc272824924ea1a27ea3183dd0b9ba713494f83",
-        "address": "saga-mainnet-seed.autostake.com:27426",
-        "provider": "AutoStake 🛡️ Slash Protected"
-      },
-      {
         "id": "20e1000e88125698264454a884812746c2eb4807",
         "address": "seeds.lavenderfive.com:24956",
         "provider": "Lavender.Five Nodes 🐝"
@@ -87,11 +82,6 @@
       {
         "id": "9e22163e2bf159883557ea36d1025ca3468f0d71",
         "address": "211.216.47.211:26656"
-      },
-      {
-        "id": "ebc272824924ea1a27ea3183dd0b9ba713494f83",
-        "address": "saga-mainnet-peer.autostake.com:27426",
-        "provider": "AutoStake 🛡️ Slash Protected"
       },
       {
         "id": "8542cd7e6bf9d260fef543bc49e59be5a3fa9074",
@@ -110,10 +100,6 @@
       {
         "address": "https://rpc-saga.keplr.app",
         "provider": "chainapsis"
-      },
-      {
-        "address": "https://saga-mainnet-rpc.autostake.com:443",
-        "provider": "AutoStake 🛡️ Slash Protected"
       },
       {
         "address": "https://saga-rpc.publicnode.com:443",
@@ -150,10 +136,6 @@
     ],
     "rest": [
       {
-        "address": "https://saga-mainnet-lcd.autostake.com:443",
-        "provider": "AutoStake 🛡️ Slash Protected"
-      },
-      {
         "address": "https://saga-rest.publicnode.com",
         "provider": "Allnodes ⚡️ Nodes & Staking"
       },
@@ -187,10 +169,6 @@
       }
     ],
     "grpc": [
-      {
-        "address": "saga-mainnet-grpc.autostake.com:443",
-        "provider": "AutoStake 🛡️ Slash Protected"
-      },
       {
         "address": "saga-grpc.publicnode.com:443",
         "provider": "Allnodes ⚡️ Nodes & Staking"

--- a/secretnetwork/chain.json
+++ b/secretnetwork/chain.json
@@ -81,21 +81,9 @@
         "provider": "WhisperNode 🤐"
       },
       {
-        "id": "5b0d6ef879fe1326045fa18d5bf767c5968704e6",
-        "address": "secretnetwork-mainnet-seed.autostake.com:26656",
-        "provider": "AutoStake 🛡️ Slash Protected"
-      },
-      {
         "id": "8542cd7e6bf9d260fef543bc49e59be5a3fa9074",
         "address": "seed.publicnode.com:26656",
         "provider": "Allnodes ⚡️ Nodes & Staking"
-      }
-    ],
-    "persistent_peers": [
-      {
-        "id": "5b0d6ef879fe1326045fa18d5bf767c5968704e6",
-        "address": "secretnetwork-mainnet-peer.autostake.com:26656",
-        "provider": "AutoStake 🛡️ Slash Protected"
       }
     ]
   },
@@ -138,10 +126,6 @@
         "provider": "Lavender.Five Nodes 🐝"
       },
       {
-        "address": "http://secretnetwork-mainnet-lcd.autostake.com:1317",
-        "provider": "AutoStake 🛡️ Slash Protected"
-      },
-      {
         "address": "https://1rpc.io/scrt-lcd",
         "provider": "1RPC - Automata Network"
       },
@@ -162,10 +146,6 @@
       {
         "address": "secretnetwork.lavenderfive.com:443",
         "provider": "Lavender.Five Nodes 🐝"
-      },
-      {
-        "address": "secretnetwork-mainnet-grpc.autostake.com:9090",
-        "provider": "AutoStake 🛡️ Slash Protected"
       }
     ]
   },

--- a/seda/chain.json
+++ b/seda/chain.json
@@ -99,11 +99,6 @@
         "provider": "Inter Blockchain Services"
       },
       {
-        "id": "ebc272824924ea1a27ea3183dd0b9ba713494f83",
-        "address": "seda-mainnet-seed.autostake.com:26866",
-        "provider": "AutoStake 🛡️ Slash Protected"
-      },
-      {
         "id": "c28827cb96c14c905b127b92065a3fb4cd77d7f6",
         "address": "seeds.whispernode.com:25856",
         "provider": "WhisperNode 🤐"
@@ -123,11 +118,6 @@
       {
         "id": "31f54fbcf445a9d9286426be59a17a811dd63f84",
         "address": "18.133.231.208:26656"
-      },
-      {
-        "id": "ebc272824924ea1a27ea3183dd0b9ba713494f83",
-        "address": "seda-mainnet-peer.autostake.com:26866",
-        "provider": "AutoStake 🛡️ Slash Protected"
       },
       {
         "id": "1067a3d13bc82129b14078edb053be07966c15fe",

--- a/sei/chain.json
+++ b/sei/chain.json
@@ -75,11 +75,6 @@
         "provider": "Lavender.Five Nodes 🐝"
       },
       {
-        "id": "ebc272824924ea1a27ea3183dd0b9ba713494f83",
-        "address": "sei-mainnet-seed.autostake.com:26806",
-        "provider": "AutoStake 🛡️ Slash Protected"
-      },
-      {
         "id": "c28827cb96c14c905b127b92065a3fb4cd77d7f6",
         "address": "seeds.whispernode.com:11956",
         "provider": "WhisperNode 🤐"
@@ -105,11 +100,6 @@
         "id": "20e1000e88125698264454a884812746c2eb4807",
         "address": "seeds.lavenderfive.com:11956",
         "provider": "Lavender.Five Nodes 🐝"
-      },
-      {
-        "id": "ebc272824924ea1a27ea3183dd0b9ba713494f83",
-        "address": "sei-mainnet-peer.autostake.com:26806",
-        "provider": "AutoStake 🛡️ Slash Protected"
       },
       {
         "id": "d9bfa29e0cf9c4ce0cc9c26d98e5d97228f93b0b",
@@ -203,10 +193,6 @@
       {
         "address": "https://sei-grpc.polkachu.com:11990",
         "provider": "polkachu.com"
-      },
-      {
-        "address": "sei-mainnet-grpc.autostake.com:443",
-        "provider": "AutoStake 🛡️ Slash Protected"
       },
       {
         "address": "grpc-sei.whispernode.com:443",

--- a/self/chain.json
+++ b/self/chain.json
@@ -62,11 +62,6 @@
         "id": "08bc9afd0cac4ae6cf8f1877920b0cc7e58a6f42",
         "address": "seeds.tendermint.roomit.xyz:40009",
         "provider": "Roomit"
-      },
-      {
-        "id": "ebc272824924ea1a27ea3183dd0b9ba713494f83",
-        "address": "selfchain-mainnet-seed.autostake.com:27216",
-        "provider": "AutoStake 🛡️ Slash Protected"
       }
     ],
     "persistent_peers": [
@@ -96,11 +91,6 @@
         "provider": "Stake Village"
       },
       {
-        "id": "ebc272824924ea1a27ea3183dd0b9ba713494f83",
-        "address": "selfchain-mainnet-peer.autostake.com:27216",
-        "provider": "AutoStake 🛡️ Slash Protected"
-      },
-      {
         "id": "2b3a029bbcd47863e8f3adf387f8b45aefbb0dab",
         "address": "selfchain-m.peer.stavr.tech:3056",
         "provider": "🔥STAVR🔥"
@@ -124,10 +114,6 @@
       {
         "address": "https://selfchain-mainnet.rpc.stakevillage.net:443",
         "provider": "Stake Village"
-      },
-      {
-        "address": "https://selfchain-mainnet-rpc.autostake.com:443",
-        "provider": "AutoStake 🛡️ Slash Protected"
       },
       {
         "address": "https://rpc.selfchain.nodestake.org",
@@ -160,10 +146,6 @@
         "provider": "Stake Village"
       },
       {
-        "address": "https://selfchain-mainnet-lcd.autostake.com:443",
-        "provider": "AutoStake 🛡️ Slash Protected"
-      },
-      {
         "address": "https://api.selfchain.nodestake.org",
         "provider": "NodeStake"
       }
@@ -176,10 +158,6 @@
       {
         "address": "selfchain-mainnet.grpc.stakevillage.net:443",
         "provider": "Stake Village"
-      },
-      {
-        "address": "selfchain-mainnet-grpc.autostake.com:443",
-        "provider": "AutoStake 🛡️ Slash Protected"
       },
       {
         "address": "https://grpc.selfchain.nodestake.org:443",

--- a/sentinel/chain.json
+++ b/sentinel/chain.json
@@ -49,11 +49,6 @@
   "peers": {
     "seeds": [
       {
-        "id": "ebc272824924ea1a27ea3183dd0b9ba713494f83",
-        "address": "sentinel-mainnet-seed.autostake.com:26706",
-        "provider": "AutoStake 🛡️ Slash Protected"
-      },
-      {
         "id": "8542cd7e6bf9d260fef543bc49e59be5a3fa9074",
         "address": "seed.publicnode.com:26656",
         "provider": "Allnodes ⚡️ Nodes & Staking"
@@ -87,11 +82,6 @@
       {
         "id": "a77f6a094578dad899e2f40e0626b4c6d4705311",
         "address": "3.36.165.232:26656"
-      },
-      {
-        "id": "ebc272824924ea1a27ea3183dd0b9ba713494f83",
-        "address": "sentinel-mainnet-peer.autostake.com:26706",
-        "provider": "AutoStake 🛡️ Slash Protected"
       },
       {
         "id": "01cf083bf6e4667c4c1d2bb9454a2e06d6d5e415",
@@ -394,10 +384,6 @@
       {
         "address": "sentinel.grpcui.chaintools.host:443",
         "provider": "ChainTools"
-      },
-      {
-        "address": "sentinel-mainnet-grpc.autostake.com:443",
-        "provider": "AutoStake 🛡️ Slash Protected"
       },
       {
         "address": "grpc.dvpn.roomit.xyz:8443",

--- a/sifchain/chain.json
+++ b/sifchain/chain.json
@@ -48,11 +48,6 @@
   "peers": {
     "seeds": [
       {
-        "id": "ebc272824924ea1a27ea3183dd0b9ba713494f83",
-        "address": "sifchain-mainnet-seed.autostake.com:26686",
-        "provider": "AutoStake 🛡️ Slash Protected"
-      },
-      {
         "id": "ade4d8bc8cbe014af6ebdf3cb7b1e9ad36f412c0",
         "address": "seeds.polkachu.com:13256",
         "provider": "Polkachu"
@@ -79,11 +74,6 @@
       {
         "id": "0120f0a48e7e81cc98829ef4f5b39480f11ecd5a",
         "address": "52.76.185.17:26656"
-      },
-      {
-        "id": "ebc272824924ea1a27ea3183dd0b9ba713494f83",
-        "address": "sifchain-mainnet-peer.autostake.com:26686",
-        "provider": "AutoStake 🛡️ Slash Protected"
       }
     ]
   },
@@ -92,10 +82,6 @@
       {
         "address": "https://sifchain-rpc.polkachu.com",
         "provider": "Polkachu"
-      },
-      {
-        "address": "https://sifchain-mainnet-rpc.autostake.com:443",
-        "provider": "AutoStake 🛡️ Slash Protected"
       },
       {
         "address": "https://sifchain-rpc.publicnode.com:443",
@@ -112,10 +98,6 @@
         "provider": "Polkachu"
       },
       {
-        "address": "https://sifchain-mainnet-lcd.autostake.com:443",
-        "provider": "AutoStake 🛡️ Slash Protected"
-      },
-      {
         "address": "https://sifchain-rest.publicnode.com",
         "provider": "Allnodes ⚡️ Nodes & Staking"
       },
@@ -129,10 +111,6 @@
       }
     ],
     "grpc": [
-      {
-        "address": "sifchain-mainnet-grpc.autostake.com:443",
-        "provider": "AutoStake 🛡️ Slash Protected"
-      },
       {
         "address": "sifchain-grpc.polkachu.com:13290",
         "provider": "Polkachu"

--- a/sommelier/chain.json
+++ b/sommelier/chain.json
@@ -83,11 +83,6 @@
         "provider": "Lavender.Five Nodes 🐝"
       },
       {
-        "id": "ebc272824924ea1a27ea3183dd0b9ba713494f83",
-        "address": "sommelier-mainnet-seed.autostake.com:27176",
-        "provider": "AutoStake 🛡️ Slash Protected"
-      },
-      {
         "id": "ab5a8afdc5db008c1288e129c2eb9e3e900e7fda",
         "address": "seed.sommelier.validatus.com:6000",
         "provider": "Validatus"
@@ -108,11 +103,6 @@
         "id": "6533beebc826f84376e503bbc3265b07b26b9ad5",
         "address": "sommelier.standardcryptovc.com:26656",
         "provider": "standardcrypto"
-      },
-      {
-        "id": "ebc272824924ea1a27ea3183dd0b9ba713494f83",
-        "address": "sommelier-mainnet-peer.autostake.com:27176",
-        "provider": "AutoStake 🛡️ Slash Protected"
       }
     ]
   },
@@ -133,10 +123,6 @@
       {
         "address": "https://rpc.lavenderfive.com:443/sommelier",
         "provider": "Lavender.Five Nodes 🐝"
-      },
-      {
-        "address": "https://sommelier-mainnet-rpc.autostake.com:443",
-        "provider": "AutoStake 🛡️ Slash Protected"
       },
       {
         "address": "https://somm-rpc.kleomedes.network",
@@ -165,10 +151,6 @@
         "provider": "Lavender.Five Nodes 🐝"
       },
       {
-        "address": "https://sommelier-mainnet-lcd.autostake.com:443",
-        "provider": "AutoStake 🛡️ Slash Protected"
-      },
-      {
         "address": "https://somm-api.kleomedes.network",
         "provider": "Kleomedes"
       }
@@ -185,10 +167,6 @@
       {
         "address": "sommelier.lavenderfive.com:443",
         "provider": "Lavender.Five Nodes 🐝"
-      },
-      {
-        "address": "sommelier-mainnet-grpc.autostake.com:443",
-        "provider": "AutoStake 🛡️ Slash Protected"
       },
       {
         "address": "https://grpc.sommelier.nodexcapital.com",

--- a/source/chain.json
+++ b/source/chain.json
@@ -67,11 +67,6 @@
         "provider": "BccNodes"
       },
       {
-        "id": "ebc272824924ea1a27ea3183dd0b9ba713494f83",
-        "address": "source-mainnet-seed.autostake.com:27446",
-        "provider": "AutoStake 🛡️ Slash Protected"
-      },
-      {
         "id": "738be29546d9504b3845d781b9dc35bc6f996c5f",
         "address": "rpc.source.nodestake.org:666",
         "provider": "NodeStake"
@@ -80,11 +75,6 @@
         "id": "637077d431f618181597706810a65c826524fd74",
         "address": "source.rpc.nodeshub.online:15856",
         "provider": "NodesHub"
-      },
-      {
-        "id": "ebc272824924ea1a27ea3183dd0b9ba713494f83",
-        "address": "source-mainnet-seed.autostake.com:27446",
-        "provider": "AutoStake 🛡️ Slash Protected"
       },
       {
         "id": "8fb118f995c146357b67798e9bdd650d0c4161ea",
@@ -121,11 +111,6 @@
         "id": "79adf04741f4a019684efc73e42467cb7d6d3a69",
         "address": "148.251.19.41:25656",
         "provider": "[NODERS]TEAM"
-      },
-      {
-        "id": "ebc272824924ea1a27ea3183dd0b9ba713494f83",
-        "address": "source-mainnet-peer.autostake.com:27446",
-        "provider": "AutoStake 🛡️ Slash Protected"
       },
       {
         "id": " 3c729ffe80393abd430a7c723fab2e8aa60ffa46",
@@ -185,10 +170,6 @@
       {
         "address": "https://rpc-source.nodeist.net",
         "provider": "Nodeist"
-      },
-      {
-        "address": "https://source-mainnet-rpc.autostake.com:443",
-        "provider": "AutoStake 🛡️ Slash Protected"
       },
       {
         "address": "https://source-mainnet-rpc.itrocket.net:443",
@@ -263,10 +244,6 @@
       {
         "address": "https://source-mainnet-api.itrocket.net:443",
         "provider": "ITRocket"
-      },
-      {
-        "address": "https://source-mainnet-lcd.autostake.com:443",
-        "provider": "AutoStake 🛡️ Slash Protected"
       },
       {
         "address": "https://source-api.moonbridge.org",
@@ -345,10 +322,6 @@
       {
         "address": "https://grpc-source.sr20de.xyz:443",
         "provider": "Sr20de"
-      },
-      {
-        "address": "source-mainnet-grpc.autostake.com:443",
-        "provider": "AutoStake 🛡️ Slash Protected"
       },
       {
         "address": "source-grpc.stake-town.com:443",

--- a/stargaze/chain.json
+++ b/stargaze/chain.json
@@ -86,11 +86,6 @@
         "provider": "Polkachu"
       },
       {
-        "id": "ebc272824924ea1a27ea3183dd0b9ba713494f83",
-        "address": "stargaze-mainnet-seed.autostake.com:26986",
-        "provider": "AutoStake 🛡️ Slash Protected"
-      },
-      {
         "id": "8542cd7e6bf9d260fef543bc49e59be5a3fa9074",
         "address": "seed.publicnode.com:26656",
         "provider": "Allnodes ⚡️ Nodes & Staking"
@@ -112,11 +107,6 @@
       }
     ],
     "persistent_peers": [
-      {
-        "id": "ebc272824924ea1a27ea3183dd0b9ba713494f83",
-        "address": "stargaze-mainnet-peer.autostake.com:26986",
-        "provider": "AutoStake 🛡️ Slash Protected"
-      },
       {
         "id": "344c62c700a59de6137ccd6cade56721cb1e9777",
         "address": "stargaze.ramuchi.tech:26656",
@@ -166,10 +156,6 @@
       {
         "address": "https://rpc.stargaze.silentvalidator.com/",
         "provider": "silent"
-      },
-      {
-        "address": "https://stargaze-mainnet-rpc.autostake.com:443",
-        "provider": "AutoStake 🛡️ Slash Protected"
       },
       {
         "address": "https://stargaze-rpc.ramuchi.tech",
@@ -250,10 +236,6 @@
         "provider": "silent"
       },
       {
-        "address": "https://stargaze-mainnet-lcd.autostake.com:443",
-        "provider": "AutoStake 🛡️ Slash Protected"
-      },
-      {
         "address": "https://stargaze-api.ramuchi.tech",
         "provider": "ramuchi.tech"
       },
@@ -298,10 +280,6 @@
       {
         "address": "stargaze-grpc.polkachu.com:13790",
         "provider": "Polkachu"
-      },
-      {
-        "address": "stargaze-mainnet-grpc.autostake.com:443",
-        "provider": "AutoStake 🛡️ Slash Protected"
       },
       {
         "address": "grpc-stargaze.cosmos-spaces.cloud:1150",

--- a/stride/chain.json
+++ b/stride/chain.json
@@ -175,11 +175,6 @@
         "provider": "Lavender.Five Nodes 🐝"
       },
       {
-        "id": "ebc272824924ea1a27ea3183dd0b9ba713494f83",
-        "address": "stride-mainnet-seed.autostake.com:26886",
-        "provider": "AutoStake 🛡️ Slash Protected"
-      },
-      {
         "id": "400f3d9e30b69e78a7fb891f60d76fa3c73f0ecc",
         "address": "stride.rpc.kjnodes.com:11659",
         "provider": "kjnodes"
@@ -237,11 +232,6 @@
         "provider": "Cosmostation-3"
       },
       {
-        "id": "ebc272824924ea1a27ea3183dd0b9ba713494f83",
-        "address": "stride-mainnet-peer.autostake.com:26886",
-        "provider": "AutoStake 🛡️ Slash Protected"
-      },
-      {
         "id": "ced7684f4d60399986cdbc1465ac00a420a14202",
         "address": "peer-stride-01.stakeflow.io:1807",
         "provider": "Stakeflow"
@@ -271,10 +261,6 @@
       {
         "address": "https://rpc.lavenderfive.com:443/stride",
         "provider": "Lavender.Five Nodes 🐝"
-      },
-      {
-        "address": "https://stride-mainnet-rpc.autostake.com:443",
-        "provider": "AutoStake 🛡️ Slash Protected"
       },
       {
         "address": "https://stride-rpc.publicnode.com:443",
@@ -307,10 +293,6 @@
         "provider": "Lavender.Five Nodes 🐝"
       },
       {
-        "address": "https://stride-mainnet-lcd.autostake.com:443",
-        "provider": "AutoStake 🛡️ Slash Protected"
-      },
-      {
         "address": "https://stride-rest.publicnode.com",
         "provider": "Allnodes ⚡️ Nodes & Staking"
       },
@@ -335,10 +317,6 @@
       {
         "address": "stride.lavenderfive.com:443",
         "provider": "Lavender.Five Nodes 🐝"
-      },
-      {
-        "address": "stride-mainnet-grpc.autostake.com:443",
-        "provider": "AutoStake 🛡️ Slash Protected"
       },
       {
         "address": "stride-grpc.publicnode.com:443",

--- a/synternet/chain.json
+++ b/synternet/chain.json
@@ -61,13 +61,6 @@
   },
   "description": "Synternet is the backbone of the Data Layer, a protocol serving as the customizable execution layer between all blockchains. It enables builders to See, Interpret and Act on any data from any chain, supercharging their applications.",
   "peers": {
-    "seeds": [
-      {
-        "id": "ebc272824924ea1a27ea3183dd0b9ba713494f83",
-        "address": "Synternet-mainnet-seed.autostake.com:27416",
-        "provider": "AutoStake 🛡️ Slash Protected"
-      }
-    ],
     "persistent_peers": [
       {
         "id": "2eed7e175d204680af243e008e21950f81b8d455",
@@ -93,11 +86,6 @@
         "id": "95b14ec701608044c261ebd15d0b3bd84e295acb",
         "address": "72.46.84.135:26656",
         "provider": "Restake"
-      },
-      {
-        "id": "ebc272824924ea1a27ea3183dd0b9ba713494f83",
-        "address": "Synternet-mainnet-peer.autostake.com:27416",
-        "provider": "AutoStake 🛡️ Slash Protected"
       }
     ]
   },
@@ -112,10 +100,6 @@
         "provider": "🚀 WHEN MOON 🌕 WHEN LAMBO 🔥"
       },
       {
-        "address": "https://synternet-mainnet-rpc.autostake.com:443",
-        "provider": "AutoStake 🛡️ Slash Protected"
-      },
-      {
         "address": "https://synternet-mainnet-rpc.shazoes.xyz",
         "provider": "Shazoes"
       }
@@ -128,10 +112,6 @@
       {
         "address": "https://synternet_mainnet_api.chain.whenmoonwhenlambo.money",
         "provider": "🚀 WHEN MOON 🌕 WHEN LAMBO 🔥"
-      },
-      {
-        "address": "https://synternet-mainnet-lcd.autostake.com:443",
-        "provider": "AutoStake 🛡️ Slash Protected"
       },
       {
         "address": "https://synternet-mainnet-api.shazoes.xyz",

--- a/tenet/chain.json
+++ b/tenet/chain.json
@@ -72,11 +72,6 @@
   "peers": {
     "seeds": [
       {
-        "id": "ebc272824924ea1a27ea3183dd0b9ba713494f83",
-        "address": "tenet-mainnet-seed.autostake.com:27386",
-        "provider": "AutoStake 🛡️ Slash Protected"
-      },
-      {
         "id": "8542cd7e6bf9d260fef543bc49e59be5a3fa9074",
         "address": "seed.publicnode.com:26656",
         "provider": "Allnodes ⚡️ Nodes & Staking"
@@ -87,11 +82,6 @@
         "id": "f8432cc5094870c96f34a0ebb36ffb0d38a53ad4",
         "address": "164.92.209.223:26656",
         "provider": "tenet"
-      },
-      {
-        "id": "ebc272824924ea1a27ea3183dd0b9ba713494f83",
-        "address": "tenet-mainnet-peer.autostake.com:27386",
-        "provider": "AutoStake 🛡️ Slash Protected"
       },
       {
         "id": "8542cd7e6bf9d260fef543bc49e59be5a3fa9074",
@@ -133,10 +123,6 @@
       {
         "address": "tenet-grpc.publicnode.com:443",
         "provider": "Allnodes ⚡️ Nodes & Staking"
-      },
-      {
-        "address": "kichain-mainnet-grpc.autostake.com:443",
-        "provider": "AutoStake 🛡️ Slash Protected"
       }
     ],
     "evm-http-jsonrpc": [

--- a/teritori/chain.json
+++ b/teritori/chain.json
@@ -82,11 +82,6 @@
         "provider": "Allnodes ⚡️ Nodes & Staking"
       },
       {
-        "id": "ebc272824924ea1a27ea3183dd0b9ba713494f83",
-        "address": "teritori-mainnet-seed.autostake.com:27166",
-        "provider": "AutoStake 🛡️ Slash Protected"
-      },
-      {
         "id": "38d107de6a22ca6e1a6bafd2041e38f5d50a6945",
         "address": "seed-node.mms.team:40656",
         "provider": "MMS"
@@ -112,11 +107,6 @@
         "id": "29c218fb6d31d2316b854c1178327157fbce8aa7",
         "address": "teritori.peers.stavr.tech:38026",
         "provider": "🔥STAVR🔥"
-      },
-      {
-        "id": "ebc272824924ea1a27ea3183dd0b9ba713494f83",
-        "address": "teritori-mainnet-peer.autostake.com:27166",
-        "provider": "AutoStake 🛡️ Slash Protected"
       },
       {
         "id": "669470aba9778ccccd07127115dcdc30e141d7ae",
@@ -158,10 +148,6 @@
       {
         "address": "https://rpc-teritori.pupmos.network",
         "provider": "PUPMØS"
-      },
-      {
-        "address": "https://teritori-mainnet-rpc.autostake.com:443",
-        "provider": "AutoStake 🛡️ Slash Protected"
       },
       {
         "address": "https://teritori-rpc.publicnode.com:443",
@@ -214,10 +200,6 @@
         "provider": "PUPMØS"
       },
       {
-        "address": "https://teritori-mainnet-lcd.autostake.com:443",
-        "provider": "AutoStake 🛡️ Slash Protected"
-      },
-      {
         "address": "https://teritori-rest.publicnode.com",
         "provider": "Allnodes ⚡️ Nodes & Staking"
       },
@@ -250,10 +232,6 @@
       {
         "address": "teritori.grpc.silknodes.io:443",
         "provider": "Silk Nodes"
-      },
-      {
-        "address": "teritori-mainnet-grpc.autostake.com:443",
-        "provider": "AutoStake 🛡️ Slash Protected"
       },
       {
         "address": "teritori.grpc.kjnodes.com:11990",

--- a/terra/chain.json
+++ b/terra/chain.json
@@ -203,11 +203,6 @@
   "peers": {
     "seeds": [
       {
-        "id": "ebc272824924ea1a27ea3183dd0b9ba713494f83",
-        "address": "terraclassic-mainnet-seed.autostake.com:26676",
-        "provider": "AutoStake 🛡️ Slash Protected"
-      },
-      {
         "id": "b1bdf6249fb58b4c8284aff8a9c5b2804d822261",
         "address": "seed.terra.synergynodes.com:26656",
         "provider": "www.synergynodes.com"
@@ -224,11 +219,6 @@
       }
     ],
     "persistent_peers": [
-      {
-        "id": "ebc272824924ea1a27ea3183dd0b9ba713494f83",
-        "address": "terraclassic-mainnet-peer.autostake.com:26676",
-        "provider": "AutoStake 🛡️ Slash Protected"
-      },
       {
         "id": "b1bdf6249fb58b4c8284aff8a9c5b2804d822261",
         "address": "seed.terra.synergynodes.com:26656",
@@ -273,10 +263,6 @@
       {
         "address": "https://lcd.terra-classic.hexxagon.io/",
         "provider": "Hexxagon"
-      },
-      {
-        "address": "https://terraclassic-mainnet-lcd.autostake.com:443",
-        "provider": "AutoStake 🛡️ Slash Protected"
       },
       {
         "address": "https://api-lunc-lcd.binodes.com",

--- a/terra2/chain.json
+++ b/terra2/chain.json
@@ -87,11 +87,6 @@
         "provider": "Lavender.Five Nodes 🐝"
       },
       {
-        "id": "ebc272824924ea1a27ea3183dd0b9ba713494f83",
-        "address": "terra-mainnet-seed.autostake.com:27486",
-        "provider": "AutoStake 🛡️ Slash Protected"
-      },
-      {
         "id": "8542cd7e6bf9d260fef543bc49e59be5a3fa9074",
         "address": "seed.publicnode.com:26656",
         "provider": "Allnodes ⚡️ Nodes & Staking"
@@ -114,11 +109,6 @@
       {
         "id": "f2069012aec5ced4e88e7e4311391eabe72bb5a3",
         "address": "node-phoenix.terra.lunastations.online:26656"
-      },
-      {
-        "id": "ebc272824924ea1a27ea3183dd0b9ba713494f83",
-        "address": "terra-mainnet-peer.autostake.com:27486",
-        "provider": "AutoStake 🛡️ Slash Protected"
       },
       {
         "id": "86bd5cb6e762f673f1706e5889e039d5406b4b90",
@@ -226,10 +216,6 @@
       {
         "address": "terra-grpc.polkachu.com:11790",
         "provider": "Polkachu"
-      },
-      {
-        "address": "terra-mainnet-grpc.autostake.com:443",
-        "provider": "AutoStake 🛡️ Slash Protected"
       },
       {
         "address": "terra-grpc.publicnode.com:443",

--- a/umee/chain.json
+++ b/umee/chain.json
@@ -72,11 +72,6 @@
         "provider": "Polkachu"
       },
       {
-        "id": "ebc272824924ea1a27ea3183dd0b9ba713494f83",
-        "address": "umee-mainnet-seed.autostake.com:26756",
-        "provider": "AutoStake 🛡️ Slash Protected"
-      },
-      {
         "id": "86bd5cb6e762f673f1706e5889e039d5406b4b90",
         "address": "umee.seed.node75.org:10656",
         "provider": "Pro-Nodes75"
@@ -117,11 +112,6 @@
         "id": "ade4d8bc8cbe014af6ebdf3cb7b1e9ad36f412c0",
         "address": "seeds.polkachu.com:13656",
         "provider": "Polkachu"
-      },
-      {
-        "id": "ebc272824924ea1a27ea3183dd0b9ba713494f83",
-        "address": "umee-mainnet-peer.autostake.com:26756",
-        "provider": "AutoStake 🛡️ Slash Protected"
       },
       {
         "id": "345970b5bdac916d95d8c64243d901766aff5475",
@@ -170,10 +160,6 @@
       {
         "address": "https://umee-rpc.polkachu.com",
         "provider": "Polkachu"
-      },
-      {
-        "address": "https://umee-mainnet-rpc.autostake.com:443",
-        "provider": "AutoStake 🛡️ Slash Protected"
       },
       {
         "address": "http://umee.rpc.m.stavr.tech:10457",
@@ -238,10 +224,6 @@
         "provider": "🔥STAVR🔥"
       },
       {
-        "address": "https://umee-mainnet-lcd.autostake.com:443",
-        "provider": "AutoStake 🛡️ Slash Protected"
-      },
-      {
         "address": "https://umee-api.polkachu.com",
         "provider": "Polkachu"
       },
@@ -298,10 +280,6 @@
       {
         "address": "umee-grpc.polkachu.com:13690",
         "provider": "Polkachu"
-      },
-      {
-        "address": "umee-mainnet-grpc.autostake.com:443",
-        "provider": "AutoStake 🛡️ Slash Protected"
       },
       {
         "address": "umee.grpc.m.stavr.tech:9090",

--- a/ununifi/chain.json
+++ b/ununifi/chain.json
@@ -93,11 +93,6 @@
         "provider": "CauchyE"
       },
       {
-        "id": "ebc272824924ea1a27ea3183dd0b9ba713494f83",
-        "address": "ununifi-mainnet-seed.autostake.com:26746",
-        "provider": "AutoStake 🛡️ Slash Protected"
-      },
-      {
         "id": "1357ac5cd92b215b05253b25d78cf485dd899d55",
         "address": "[2600:1f1c:534:8f02:7bf:6b31:3702:2265]:26656"
       },
@@ -169,10 +164,6 @@
       {
         "address": "b.lcd.ununifi.cauchye.net:9092",
         "provider": "CauchyE"
-      },
-      {
-        "address": "ununifi-mainnet-grpc.autostake.com:443",
-        "provider": "AutoStake 🛡️ Slash Protected"
       },
       {
         "address": "https://grpc-ununifi.nodeist.net",

--- a/xion/chain.json
+++ b/xion/chain.json
@@ -80,11 +80,6 @@
   "peers": {
     "seeds": [
       {
-        "id": "ebc272824924ea1a27ea3183dd0b9ba713494f83",
-        "address": "xion-mainnet-seed.autostake.com:27596",
-        "provider": "AutoStake 🛡️ Slash Protected"
-      },
-      {
         "id": "20e1000e88125698264454a884812746c2eb4807",
         "address": "seeds.lavenderfive.com:22356",
         "provider": "Lavender.Five Nodes 🐝"
@@ -96,11 +91,6 @@
       }
     ],
     "persistent_peers": [
-      {
-        "id": "ebc272824924ea1a27ea3183dd0b9ba713494f83",
-        "address": "xion-mainnet-peer.autostake.com:27596",
-        "provider": "AutoStake 🛡️ Slash Protected"
-      },
       {
         "id": "20e1000e88125698264454a884812746c2eb4807",
         "address": "seeds.lavenderfive.com:22356",
@@ -157,10 +147,6 @@
         "provider": "Polkachu"
       },
       {
-        "address": "https://xion-mainnet-rpc.autostake.com:443",
-        "provider": "AutoStake 🛡️ Slash Protected"
-      },
-      {
         "address": "https://rpc.xion.nodestake.org:443",
         "provider": "NodeStake"
       },
@@ -187,10 +173,6 @@
         "provider": "Polkachu"
       },
       {
-        "address": "https://xion-mainnet-lcd.autostake.com",
-        "provider": "AutoStake 🛡️ Slash Protected"
-      },
-      {
         "address": "https://api.xion.nodestake.org",
         "provider": "NodeStake"
       },
@@ -211,10 +193,6 @@
       {
         "address": "xion-grpc.polkachu.com:22390",
         "provider": "Polkachu"
-      },
-      {
-        "address": "xion-mainnet-grpc.autostake.com:443",
-        "provider": "AutoStake 🛡️ Slash Protected"
       },
       {
         "address": "grpc.xion.nodestake.org:443",


### PR DESCRIPTION
Removes all dead **AutoStake** endpoints and p2p peers registry-wide.

### Why
AutoStake's node infrastructure is decommissioned. Every registered API endpoint (`*-mainnet-{rpc,lcd,grpc}.autostake.com`) returns **HTTP 404 uniformly, registry-wide** (verified 2026-07-02 across cosmos, osmosis, juno, akash, stargaze, celestia, …). The `autostake.com` marketing site is still up, but the nodes behind it are gone.

### Removed
- **193** dead RPC / REST / gRPC endpoints across **76** chains
- **160** dead p2p peer entries (`seeds` / `persistent_peers`) across **82** chains

### On the peers
The peer hostnames (`*-mainnet-{seed,peer}.autostake.com`) resolve **only to Cloudflare** (`188.114.96/97.x`) — the same IPs as the dead HTTP endpoints — and cannot serve Tendermint p2p. They share the decommissioned infrastructure. (Note: p2p ports weren't directly probed; happy to split peers into a separate PR if you'd prefer to keep this endpoints-only.)
