### PR TITLE
Add QUAD public RPC/REST endpoints (Osmosis, Injective)

### DIFF
--- a/injective/chain.json
+++ b/injective/chain.json
@@ -190,6 +190,10 @@
       {
         "address": "https://public.stakewolle.com/cosmos/injective/rpc",
         "provider": "Stakewolle"
+      },
+      {
+        "address": "https://injective.rpc.uquad.org:443",
+        "provider": "QUAD"
       }
     ],
     "rest": [
@@ -212,6 +216,10 @@
       {
         "address": "https://public.stakewolle.com/cosmos/injective/rest",
         "provider": "Stakewolle"
+      },
+      {
+        "address": "https://injective.rpc.uquad.org:443",
+        "provider": "QUAD"
       }
     ],
     "grpc": [

--- a/osmosis/chain.json
+++ b/osmosis/chain.json
@@ -769,6 +769,10 @@
       {
         "address": "https://osmosis.api.pocket.network",
         "provider": "Pocket Network"
+      },
+      {
+        "address": "https://osmosis.rpc.uquad.org:443",
+        "provider": "QUAD"
       }
     ],
     "rest": [
@@ -831,6 +835,10 @@
       {
         "address": "https://osmosis.api.pocket.network",
         "provider": "Pocket Network"
+      },
+      {
+        "address": "https://osmosis.rpc.uquad.org:443",
+        "provider": "QUAD"
       }
     ],
     "grpc": [


### PR DESCRIPTION
Follow-up to #7762, which added QUAD public endpoints for Cosmos Hub, Akash, Celestia, and Stride.

This adds RPC + REST for two more chains we run public nodes for:

| Chain | Endpoint |
|---|---|
| Osmosis (`osmosis-1`) | https://osmosis.rpc.uquad.org:443 |
| Injective (`injective-1`) | https://injective.rpc.uquad.org:443 |

Both serve keyless, rate-limited RPC (`/status`, `/abci_info`) and REST (`/cosmos/base/tendermint/...`) and are currently synced to tip.
