### PR TITLE
Add MuCoin chain and Osmosis IBC metadata

### DIFF
--- a/_IBC/mucoin-osmosis.json
+++ b/_IBC/mucoin-osmosis.json
@@ -1,0 +1,27 @@
+{
+  "$schema": "../ibc_data.schema.json",
+  "chain_1": {
+    "chain_name": "mucoin",
+    "client_id": "07-tendermint-1",
+    "connection_id": "connection-0"
+  },
+  "chain_2": {
+    "chain_name": "osmosis",
+    "client_id": "07-tendermint-3721",
+    "connection_id": "connection-11076"
+  },
+  "channels": [
+    {
+      "chain_1": {
+        "channel_id": "channel-0",
+        "port_id": "transfer"
+      },
+      "chain_2": {
+        "channel_id": "channel-110510",
+        "port_id": "transfer"
+      },
+      "ordering": "unordered",
+      "version": "ics20-1"
+    }
+  ]
+}

--- a/mucoin/assetlist.json
+++ b/mucoin/assetlist.json
@@ -1,0 +1,41 @@
+{
+  "$schema": "../assetlist.schema.json",
+  "chain_name": "mucoin",
+  "assets": [
+    {
+      "description": "MuCoin is the native asset of the MuCoin mainnet, created for MU Online server communities.",
+      "denom_units": [
+        {
+          "denom": "umuc",
+          "exponent": 0
+        },
+        {
+          "denom": "MUC",
+          "exponent": 6
+        }
+      ],
+      "base": "umuc",
+      "name": "MuCoin",
+      "display": "MUC",
+      "symbol": "MUC",
+      "logo_URIs": {
+        "png": "https://mucoin.org/assets/muc-chain-256.png"
+      },
+      "images": [
+        {
+          "png": "https://mucoin.org/assets/muc-chain-256.png",
+          "theme": {
+            "primary_color_hex": "#00d9ff"
+          }
+        }
+      ],
+      "type_asset": "sdk.coin",
+      "keywords": [
+        "gaming",
+        "mu-online",
+        "cosmos-sdk",
+        "ibc"
+      ]
+    }
+  ]
+}

--- a/mucoin/chain.json
+++ b/mucoin/chain.json
@@ -1,0 +1,77 @@
+{
+  "$schema": "../chain.schema.json",
+  "chain_name": "mucoin",
+  "status": "live",
+  "network_type": "mainnet",
+  "website": "https://mucoin.org",
+  "pretty_name": "MuCoin",
+  "chain_type": "cosmos",
+  "chain_id": "mucoin",
+  "bech32_prefix": "muc",
+  "daemon_name": "mucoind",
+  "node_home": ".mucoin",
+  "slip44": 118,
+  "fees": {
+    "fee_tokens": [
+      {
+        "denom": "umuc",
+        "low_gas_price": 0.001,
+        "average_gas_price": 0.0025,
+        "high_gas_price": 0.005
+      }
+    ]
+  },
+  "staking": {
+    "staking_tokens": [
+      {
+        "denom": "umuc"
+      }
+    ]
+  },
+  "peers": {
+    "seeds": [
+      {
+        "id": "d5650769369520da0ef1414682811acc2558c0c2",
+        "address": "seed.mucoin.org:26656",
+        "provider": "MuCoin"
+      }
+    ]
+  },
+  "apis": {
+    "rpc": [
+      {
+        "address": "https://rpc.mucoin.org",
+        "provider": "MuCoin"
+      }
+    ],
+    "rest": [
+      {
+        "address": "https://api.mucoin.org",
+        "provider": "MuCoin"
+      }
+    ]
+  },
+  "explorers": [
+    {
+      "kind": "mucoin",
+      "url": "https://mucoin.org/explorer",
+      "tx_page": "https://mucoin.org/explorer/tx/${txHash}",
+      "account_page": "https://mucoin.org/explorer/address/${accountAddress}",
+      "block_page": "https://mucoin.org/explorer/block/${blockHeight}"
+    }
+  ],
+  "images": [
+    {
+      "png": "https://mucoin.org/assets/muc-chain-256.png",
+      "theme": {
+        "primary_color_hex": "#00d9ff"
+      }
+    }
+  ],
+  "keywords": [
+    "gaming",
+    "mu-online",
+    "cosmos-sdk",
+    "ibc"
+  ]
+}


### PR DESCRIPTION
This PR adds MuCoin chain metadata, native MUC asset metadata, and the IBC connection between MuCoin and Osmosis.

MuCoin is a Cosmos SDK/Ignite-based blockchain created for MU Online server communities.

Included files:

* `mucoin/chain.json`
* `mucoin/assetlist.json`
* `_IBC/mucoin-osmosis.json`

Official references:

* Website: https://mucoin.org/
* Explorer: https://mucoin.org/explorer
* Registry: https://mucoin.org/registry
* IBC information: https://mucoin.org/ibc
* RPC: https://rpc.mucoin.org/
* REST: https://api.mucoin.org/

IBC details:

* MuCoin chain ID: `mucoin`
* Osmosis chain ID: `osmosis-1`
* MuCoin channel: `channel-0`
* Osmosis channel: `channel-110510`
* MuCoin connection: `connection-0`
* Osmosis connection: `connection-11076`
* Denom trace on Osmosis: `transfer/channel-110510/umuc`
* IBC denom on Osmosis: `ibc/D376154A5E2B07560D93BE6EAB8DD5BC0775E175AA4BA658FAA3B23178270778`

Notes:

* MuCoin is early-stage on Osmosis.
* No public Osmosis liquidity pool is claimed in this PR.
* No USD price tracking, CoinGecko listing, or CoinMarketCap listing is claimed.