### PR TITLE
Add QUAD public RPC/REST endpoint (dYdX)

### DIFF
--- a/dydx/chain.json
+++ b/dydx/chain.json
@@ -179,6 +179,10 @@
       {
         "address": "https://dydx-rpc.noders.services",
         "provider": "[NODERS]TEAM"
+      },
+      {
+        "address": "https://dydx.rpc.uquad.org:443",
+        "provider": "QUAD"
       }
     ],
     "rest": [
@@ -209,6 +213,10 @@
       {
         "address": "https://dydx-api.noders.services",
         "provider": "[NODERS]TEAM"
+      },
+      {
+        "address": "https://dydx.rpc.uquad.org:443",
+        "provider": "QUAD"
       }
     ],
     "grpc": [

--- a/neutron/chain.json
+++ b/neutron/chain.json
@@ -180,10 +180,6 @@
       {
         "address": "https://neutron.drpc.org",
         "provider": "dRPC"
-      },
-      {
-        "address": "https://neutron.rpc.uquad.org:443",
-        "provider": "QUAD"
       }
     ],
     "rest": [
@@ -235,10 +231,6 @@
       {
         "address": "https://api.neutron.quokkastake.io",
         "provider": "🐹 Quokka Stake"
-      },
-      {
-        "address": "https://neutron.rpc.uquad.org:443",
-        "provider": "QUAD"
       }
     ],
     "grpc": [

--- a/neutron/chain.json
+++ b/neutron/chain.json
@@ -180,6 +180,10 @@
       {
         "address": "https://neutron.drpc.org",
         "provider": "dRPC"
+      },
+      {
+        "address": "https://neutron.rpc.uquad.org:443",
+        "provider": "QUAD"
       }
     ],
     "rest": [
@@ -231,6 +235,10 @@
       {
         "address": "https://api.neutron.quokkastake.io",
         "provider": "🐹 Quokka Stake"
+      },
+      {
+        "address": "https://neutron.rpc.uquad.org:443",
+        "provider": "QUAD"
       }
     ],
     "grpc": [


### PR DESCRIPTION
Follow-up to #7762 (merged) and #7782. Adds live public nodes we operate:

- `dydx.rpc.uquad.org` (dydx-mainnet-1)
- `neutron.rpc.uquad.org` (neutron-1)

Both serve keyless, rate-limited RPC + REST at current height. Each gateway is a single path-routed host: Tendermint RPC at the root, LCD/REST on its standard `/cosmos/...` paths on the same host (same pattern as our merged #7762 entries).

Verify:
```
curl https://dydx.rpc.uquad.org/status
curl https://dydx.rpc.uquad.org/cosmos/base/tendermint/v1beta1/blocks/latest
curl https://neutron.rpc.uquad.org/status
curl https://neutron.rpc.uquad.org/cosmos/base/tendermint/v1beta1/blocks/latest
```