### PR TITLE
neutron: add QUAD (uquad.org) public RPC + REST endpoint

### DIFF
--- a/neutron/chain.json
+++ b/neutron/chain.json
@@ -180,6 +180,10 @@
       {
         "address": "https://neutron.drpc.org",
         "provider": "dRPC"
+      },
+      {
+        "address": "https://neutron.rpc.uquad.org:443",
+        "provider": "QUAD"
       }
     ],
     "rest": [
@@ -231,6 +235,10 @@
       {
         "address": "https://api.neutron.quokkastake.io",
         "provider": "🐹 Quokka Stake"
+      },
+      {
+        "address": "https://neutron.rpc.uquad.org:443",
+        "provider": "QUAD"
       }
     ],
     "grpc": [


### PR DESCRIPTION
Adds `neutron.rpc.uquad.org` to `neutron/chain.json` under `apis.rpc` and `apis.rest`.

- Free, rate-limited public Tendermint RPC + REST, no API key required.
- Self-hosted `neutron-1` full node, verified serving at tip (`catching_up=false`) at the time of this PR.
- Provider: QUAD (same operator as the merged Cosmos Hub entry #7762 and the Osmosis/dYdX endpoint PRs).

Quick check:
```
curl -s https://neutron.rpc.uquad.org/status | jq .result.sync_info
curl -s https://neutron.rpc.uquad.org/cosmos/base/tendermint/v1beta1/blocks/latest | jq .block.header.height
```