### PR TITLE
gonka: add GNKScan explorer

### DIFF
--- a/gonka/chain.json
+++ b/gonka/chain.json
@@ -216,6 +216,14 @@
       "url": "https://node2.gonka.ai:8443/dashboard",
       "tx_page": "https://node2.gonka.ai:8443/dashboard/gonka/txs/${txHash}",
       "account_page": "https://node2.gonka.ai:8443/dashboard/gonka/account/${accountAddress}"
+    },
+    {
+      "kind": "gnkscan",
+      "url": "https://www.gnkscan.com",
+      "tx_page": "https://www.gnkscan.com/tx/${txHash}",
+      "account_page": "https://www.gnkscan.com/address/${accountAddress}",
+      "block_page": "https://www.gnkscan.com/blocks/${blockHeight}",
+      "proposal_page": "https://www.gnkscan.com/proposals/${proposalId}"
     }
   ],
   "keywords": [


### PR DESCRIPTION
## Summary
Adds [GNKScan](https://www.gnkscan.com) to `gonka/chain.json`'s `explorers` array.

GNKScan is a block explorer for the Gonka network with a self-hosted indexer (live blocks/transactions/participants), block detail, transaction detail, address pages, and per-proposal governance pages.

## Fields added
- `url`, `tx_page`, `account_page` (following the existing entries' pattern)
- `block_page` — per-height block detail page
- `proposal_page` — per-id governance proposal page

No other content in the file was changed.