### PR TITLE
Add BitBadges<->Injective IBC connection

### DIFF
--- a/_IBC/bitbadges-injective.json
+++ b/_IBC/bitbadges-injective.json
@@ -1,0 +1,33 @@
+{
+  "$schema": "../ibc_data.schema.json",
+  "chain_1": {
+    "chain_name": "bitbadges",
+    "chain_id": "bitbadges-1",
+    "client_id": "07-tendermint-39",
+    "connection_id": "connection-89"
+  },
+  "chain_2": {
+    "chain_name": "injective",
+    "chain_id": "injective-1",
+    "client_id": "07-tendermint-340",
+    "connection_id": "connection-343"
+  },
+  "channels": [
+    {
+      "chain_1": {
+        "channel_id": "channel-40",
+        "port_id": "transfer"
+      },
+      "chain_2": {
+        "channel_id": "channel-464",
+        "port_id": "transfer"
+      },
+      "ordering": "unordered",
+      "version": "ics20-1",
+      "tags": {
+        "preferred": true,
+        "status": "ACTIVE"
+      }
+    }
+  ]
+}


### PR DESCRIPTION
Adds the IBC path between **BitBadges** (`bitbadges-1`) and **Injective** (`injective-1`).

The channel was established via a standard permissionless handshake and both ends are `STATE_OPEN`, actively relayed (Hermes).

| Side | chain_id | client | connection | channel | port |
|------|----------|--------|-----------|---------|------|
| bitbadges | bitbadges-1 | `07-tendermint-39` | `connection-89` | `channel-40` | transfer |
| injective | injective-1 | `07-tendermint-340` | `connection-343` | `channel-464` | transfer |

Version `ics20-1`, unordered.

### Verification
- BitBadges: `https://lcd.bitbadges.io/ibc/core/channel/v1/channels/channel-40/ports/transfer` → `STATE_OPEN`, counterparty `channel-464`
- Injective: `https://injective-rest.publicnode.com/ibc/core/channel/v1/channels/channel-464/ports/transfer` → `STATE_OPEN`, counterparty `channel-40`

Follows the schema of the existing `_IBC/bitbadges-osmosis.json`, `bitbadges-noble.json`, and `bitbadges-cosmoshub.json` files.