### PR TITLE
feat(zigchain)(zigchaintestnet): update chain registry to v4.1.0

### DIFF
--- a/testnets/zigchaintestnet/chain.json
+++ b/testnets/zigchaintestnet/chain.json
@@ -94,21 +94,21 @@
   },
   "codebase": {
     "git_repo": "https://github.com/ZIGChain/zigchain",
-    "recommended_version": "2.0.0",
+    "recommended_version": "4.1.0",
     "compatible_versions": [
-      "2.0.0"
+      "4.1.0"
     ],
     "consensus": {
       "type": "cometbft",
-      "version": "0.38.19"
+      "version": "0.38.21"
     },
     "sdk": {
       "type": "cosmos",
-      "version": "0.53.4"
+      "version": "0.53.5"
     },
     "ibc": {
       "type": "go",
-      "version": "10.1.0"
+      "version": "10.1.1"
     },
     "cosmwasm": {
       "version": "0.55.1",
@@ -118,14 +118,14 @@
       "genesis_url": "https://github.com/ZIGChain/networks/raw/main/zig-test-2/genesis.json"
     },
     "binaries": {
-      "linux/amd64": "https://github.com/ZIGChain/networks/raw/refs/heads/main/zig-test-2/binaries/zigchaind-v2.0.0-linux-amd64.tar.gz?checksum=sha256:8f2a4a51fa2d73b7bc61c33d30332fb61e76ed0be4a381a37d27aa17115a9040",
-      "darwin/amd64": "https://github.com/ZIGChain/networks/raw/refs/heads/main/zig-test-2/binaries/zigchaind-v2.0.0-darwin-amd64.tar.gz?checksum=sha256:6269882ccb1caf0af7600f2d24f5aeae7710290aba299d0d4ed607c6e63da803",
-      "darwin/arm64": "https://github.com/ZIGChain/networks/raw/refs/heads/main/zig-test-2/binaries/zigchaind-v2.0.0-darwin-arm64.tar.gz?checksum=sha256:07f59514973d67e0d09c27b1be50da78f3b824518f1ee4735c09322ec1bd3789"
+      "linux/amd64": "https://github.com/ZIGChain/networks/raw/refs/heads/main/binaries/zigchaind-v4.1.0-linux-amd64.tar.gz?checksum=sha256:1a64152e48fb25c990bfcf52c0578171137470b78a79859e3c861714e099cd5e",
+      "darwin/amd64": "https://github.com/ZIGChain/networks/raw/refs/heads/main/binaries/zigchaind-v4.1.0-darwin-amd64.tar.gz?checksum=sha256:adb639e7e1496ec30de54f7dbcd8a8110548b95ca3b3b1d20ca65ec4ad2bfaa0",
+      "darwin/arm64": "https://github.com/ZIGChain/networks/raw/refs/heads/main/binaries/zigchaind-v4.1.0-darwin-arm64.tar.gz?checksum=sha256:a27cb748c8b4c90724378109e518fd730f8471d9e28fbea56bb963b3757fd6da"
     },
-    "tag": "v2.0.0",
+    "tag": "v4.1.0",
     "language": {
       "type": "go",
-      "version": "1.25.4"
+      "version": "1.25.9"
     }
   },
   "peers": {

--- a/testnets/zigchaintestnet/versions.json
+++ b/testnets/zigchaintestnet/versions.json
@@ -161,6 +161,148 @@
         "darwin/arm64": "https://github.com/ZIGChain/networks/raw/refs/heads/main/zig-test-2/binaries/zigchaind-v2.0.0-darwin-arm64.tar.gz?checksum=sha256:07f59514973d67e0d09c27b1be50da78f3b824518f1ee4735c09322ec1bd3789"
       },
       "previous_version_name": "1.2.2",
+      "next_version_name": "v2.0.1"
+    },
+    {
+      "name": "v2.0.1",
+      "tag": "v2.0.1",
+      "recommended_version": "2.0.1",
+      "compatible_versions": [
+        "2.0.1"
+      ],
+      "consensus": {
+        "type": "cometbft",
+        "version": "0.38.19"
+      },
+      "cosmwasm": {
+        "version": "0.55.1",
+        "enabled": true
+      },
+      "sdk": {
+        "type": "cosmos",
+        "version": "0.53.4"
+      },
+      "ibc": {
+        "type": "go",
+        "version": "10.1.0"
+      },
+      "language": {
+        "type": "go",
+        "version": "1.25.4"
+      },
+      "binaries": {
+        "linux/amd64": "https://github.com/ZIGChain/networks/raw/refs/heads/main/binaries/archive/zigchaind-v2.0.1-linux-amd64.tar.gz?checksum=sha256:3f534611a1a07b5aea1b393703e5d05ee903ceebdf0fc09a80a0352e1c54c619",
+        "darwin/amd64": "https://github.com/ZIGChain/networks/raw/refs/heads/main/binaries/archive/zigchaind-v2.0.1-darwin-amd64.tar.gz?checksum=sha256:b00fed37405605a271ae7a7b924111edf4a7f208321b268110f2d9e291e5c5f9",
+        "darwin/arm64": "https://github.com/ZIGChain/networks/raw/refs/heads/main/binaries/archive/zigchaind-v2.0.1-darwin-arm64.tar.gz?checksum=sha256:948f91b481bf88a259ff93164ac710b32d19dbdfc7f670ac06b352dd589dc2a0"
+      },
+      "previous_version_name": "v2",
+      "next_version_name": "v3"
+    },
+    {
+      "name": "v3",
+      "tag": "v3.0.0",
+      "recommended_version": "3.0.0",
+      "compatible_versions": [
+        "3.0.0"
+      ],
+      "consensus": {
+        "type": "cometbft",
+        "version": "0.38.21"
+      },
+      "cosmwasm": {
+        "version": "0.55.1",
+        "enabled": true
+      },
+      "sdk": {
+        "type": "cosmos",
+        "version": "0.53.4"
+      },
+      "ibc": {
+        "type": "go",
+        "version": "10.1.0"
+      },
+      "language": {
+        "type": "go",
+        "version": "1.25.5"
+      },
+      "binaries": {
+        "linux/amd64": "https://github.com/ZIGChain/networks/raw/refs/heads/main/binaries/archive/zigchaind-v3.0.0-linux-amd64.tar.gz?checksum=sha256:9ed9c97a9f2edf86404b9d0b47b6bf6bc72c04de6293f193775fd93b123d336d",
+        "darwin/amd64": "https://github.com/ZIGChain/networks/raw/refs/heads/main/binaries/archive/zigchaind-v3.0.0-darwin-amd64.tar.gz?checksum=sha256:0710ad5f9b9db0731c3e498acbdb476c0b8610a88770b617a3c28026edb55e28",
+        "darwin/arm64": "https://github.com/ZIGChain/networks/raw/refs/heads/main/binaries/archive/zigchaind-v3.0.0-darwin-arm64.tar.gz?checksum=sha256:14a735463fd946f36a783e5e72f56d1303e0165493b178168fba7739bbe6a9f0"
+      },
+      "previous_version_name": "v2.0.1",
+      "next_version_name": "v4"
+    },
+    {
+      "name": "v4",
+      "tag": "v4.0.0",
+      "recommended_version": "4.0.0",
+      "compatible_versions": [
+        "4.0.0"
+      ],
+      "consensus": {
+        "type": "cometbft",
+        "version": "0.38.21"
+      },
+      "cosmwasm": {
+        "version": "0.55.1",
+        "enabled": true
+      },
+      "sdk": {
+        "type": "cosmos",
+        "version": "0.53.5"
+      },
+      "ibc": {
+        "type": "go",
+        "version": "10.1.0"
+      },
+      "language": {
+        "type": "go",
+        "version": "1.25.9"
+      },
+      "binaries": {
+        "linux/amd64": "https://github.com/ZIGChain/networks/raw/refs/heads/main/binaries/archive/zigchaind-v4.0.0-linux-amd64.tar.gz?checksum=sha256:afc9f73f4c4e006363c4d7468d1d59483babef11129e1f2d4bddf6b0a4ca5807",
+        "darwin/amd64": "https://github.com/ZIGChain/networks/raw/refs/heads/main/binaries/archive/zigchaind-v4.0.0-darwin-amd64.tar.gz?checksum=sha256:06d36ba8fa32236140478b8633215e5c585570dccbef508c5ec84fc79dddaa10",
+        "darwin/arm64": "https://github.com/ZIGChain/networks/raw/refs/heads/main/binaries/archive/zigchaind-v4.0.0-darwin-arm64.tar.gz?checksum=sha256:21b31af4213cb51a05de3190fb2c4b2cf9710e5aef568aaf1c1361f95088f023"
+      },
+      "previous_version_name": "v3",
+      "next_version_name": "v4.1"
+    },
+    {
+      "name": "v4.1",
+      "tag": "v4.1.0",
+      "height": 6684000,
+      "proposal": 99,
+      "recommended_version": "4.1.0",
+      "compatible_versions": [
+        "4.1.0"
+      ],
+      "consensus": {
+        "type": "cometbft",
+        "version": "0.38.21"
+      },
+      "cosmwasm": {
+        "version": "0.55.1",
+        "enabled": true
+      },
+      "sdk": {
+        "type": "cosmos",
+        "version": "0.53.5"
+      },
+      "ibc": {
+        "type": "go",
+        "version": "10.1.1"
+      },
+      "language": {
+        "type": "go",
+        "version": "1.25.9"
+      },
+      "binaries": {
+        "linux/amd64": "https://github.com/ZIGChain/networks/raw/refs/heads/main/binaries/zigchaind-v4.1.0-linux-amd64.tar.gz?checksum=sha256:1a64152e48fb25c990bfcf52c0578171137470b78a79859e3c861714e099cd5e",
+        "darwin/amd64": "https://github.com/ZIGChain/networks/raw/refs/heads/main/binaries/zigchaind-v4.1.0-darwin-amd64.tar.gz?checksum=sha256:adb639e7e1496ec30de54f7dbcd8a8110548b95ca3b3b1d20ca65ec4ad2bfaa0",
+        "darwin/arm64": "https://github.com/ZIGChain/networks/raw/refs/heads/main/binaries/zigchaind-v4.1.0-darwin-arm64.tar.gz?checksum=sha256:a27cb748c8b4c90724378109e518fd730f8471d9e28fbea56bb963b3757fd6da"
+      },
+      "previous_version_name": "v4",
       "next_version_name": ""
     }
   ]

--- a/zigchain/chain.json
+++ b/zigchain/chain.json
@@ -38,21 +38,21 @@
   },
   "codebase": {
     "git_repo": "https://github.com/ZIGChain/zigchain",
-    "recommended_version": "2.0.0",
+    "recommended_version": "4.1.0",
     "compatible_versions": [
-      "2.0.0"
+      "4.1.0"
     ],
     "consensus": {
       "type": "cometbft",
-      "version": "0.38.19"
+      "version": "0.38.21"
     },
     "sdk": {
       "type": "cosmos",
-      "version": "0.53.4"
+      "version": "0.53.5"
     },
     "ibc": {
       "type": "go",
-      "version": "10.1.0"
+      "version": "10.1.1"
     },
     "cosmwasm": {
       "version": "0.55.1",
@@ -62,14 +62,14 @@
       "genesis_url": "https://github.com/ZIGChain/networks/raw/main/zigchain-1/genesis.json"
     },
     "binaries": {
-      "linux/amd64": "https://github.com/ZIGChain/networks/raw/refs/heads/main/zig-test-2/binaries/zigchaind-v2.0.0-linux-amd64.tar.gz?checksum=sha256:8f2a4a51fa2d73b7bc61c33d30332fb61e76ed0be4a381a37d27aa17115a9040",
-      "darwin/amd64": "https://github.com/ZIGChain/networks/raw/refs/heads/main/zig-test-2/binaries/zigchaind-v2.0.0-darwin-amd64.tar.gz?checksum=sha256:6269882ccb1caf0af7600f2d24f5aeae7710290aba299d0d4ed607c6e63da803",
-      "darwin/arm64": "https://github.com/ZIGChain/networks/raw/refs/heads/main/zig-test-2/binaries/zigchaind-v2.0.0-darwin-arm64.tar.gz?checksum=sha256:07f59514973d67e0d09c27b1be50da78f3b824518f1ee4735c09322ec1bd3789"
+      "linux/amd64": "https://github.com/ZIGChain/networks/raw/refs/heads/main/binaries/zigchaind-v4.1.0-linux-amd64.tar.gz?checksum=sha256:1a64152e48fb25c990bfcf52c0578171137470b78a79859e3c861714e099cd5e",
+      "darwin/amd64": "https://github.com/ZIGChain/networks/raw/refs/heads/main/binaries/zigchaind-v4.1.0-darwin-amd64.tar.gz?checksum=sha256:adb639e7e1496ec30de54f7dbcd8a8110548b95ca3b3b1d20ca65ec4ad2bfaa0",
+      "darwin/arm64": "https://github.com/ZIGChain/networks/raw/refs/heads/main/binaries/zigchaind-v4.1.0-darwin-arm64.tar.gz?checksum=sha256:a27cb748c8b4c90724378109e518fd730f8471d9e28fbea56bb963b3757fd6da"
     },
-    "tag": "v2.0.0",
+    "tag": "v4.1.0",
     "language": {
       "type": "go",
-      "version": "1.25.4"
+      "version": "1.25.9"
     }
   },
   "logo_URIs": {

--- a/zigchain/versions.json
+++ b/zigchain/versions.json
@@ -68,6 +68,149 @@
         "darwin/arm64": "https://github.com/ZIGChain/networks/raw/refs/heads/main/zig-test-2/binaries/zigchaind-v2.0.0-darwin-arm64.tar.gz?checksum=sha256:07f59514973d67e0d09c27b1be50da78f3b824518f1ee4735c09322ec1bd3789"
       },
       "previous_version_name": "1.2.0",
+      "next_version_name": "v2.0.1"
+    },
+    {
+      "name": "v2.0.1",
+      "tag": "v2.0.1",
+      "recommended_version": "2.0.1",
+      "compatible_versions": [
+        "2.0.1"
+      ],
+      "consensus": {
+        "type": "cometbft",
+        "version": "0.38.19"
+      },
+      "cosmwasm": {
+        "version": "0.55.1",
+        "enabled": true
+      },
+      "sdk": {
+        "type": "cosmos",
+        "version": "0.53.4"
+      },
+      "ibc": {
+        "type": "go",
+        "version": "10.1.0"
+      },
+      "language": {
+        "type": "go",
+        "version": "1.25.4"
+      },
+      "binaries": {
+        "linux/amd64": "https://github.com/ZIGChain/networks/raw/refs/heads/main/binaries/archive/zigchaind-v2.0.1-linux-amd64.tar.gz?checksum=sha256:3f534611a1a07b5aea1b393703e5d05ee903ceebdf0fc09a80a0352e1c54c619",
+        "darwin/amd64": "https://github.com/ZIGChain/networks/raw/refs/heads/main/binaries/archive/zigchaind-v2.0.1-darwin-amd64.tar.gz?checksum=sha256:b00fed37405605a271ae7a7b924111edf4a7f208321b268110f2d9e291e5c5f9",
+        "darwin/arm64": "https://github.com/ZIGChain/networks/raw/refs/heads/main/binaries/archive/zigchaind-v2.0.1-darwin-arm64.tar.gz?checksum=sha256:948f91b481bf88a259ff93164ac710b32d19dbdfc7f670ac06b352dd589dc2a0"
+      },
+      "previous_version_name": "v2",
+      "next_version_name": "v3"
+    },
+    {
+      "name": "v3",
+      "tag": "v3.0.0",
+      "recommended_version": "3.0.0",
+      "compatible_versions": [
+        "3.0.0"
+      ],
+      "consensus": {
+        "type": "cometbft",
+        "version": "0.38.21"
+      },
+      "cosmwasm": {
+        "version": "0.55.1",
+        "enabled": true
+      },
+      "sdk": {
+        "type": "cosmos",
+        "version": "0.53.4"
+      },
+      "ibc": {
+        "type": "go",
+        "version": "10.1.0"
+      },
+      "language": {
+        "type": "go",
+        "version": "1.25.5"
+      },
+      "binaries": {
+        "linux/amd64": "https://github.com/ZIGChain/networks/raw/refs/heads/main/binaries/archive/zigchaind-v3.0.0-linux-amd64.tar.gz?checksum=sha256:9ed9c97a9f2edf86404b9d0b47b6bf6bc72c04de6293f193775fd93b123d336d",
+        "darwin/amd64": "https://github.com/ZIGChain/networks/raw/refs/heads/main/binaries/archive/zigchaind-v3.0.0-darwin-amd64.tar.gz?checksum=sha256:0710ad5f9b9db0731c3e498acbdb476c0b8610a88770b617a3c28026edb55e28",
+        "darwin/arm64": "https://github.com/ZIGChain/networks/raw/refs/heads/main/binaries/archive/zigchaind-v3.0.0-darwin-arm64.tar.gz?checksum=sha256:14a735463fd946f36a783e5e72f56d1303e0165493b178168fba7739bbe6a9f0"
+      },
+      "previous_version_name": "v2.0.1",
+      "next_version_name": "v4"
+    },
+    {
+      "name": "v4",
+      "tag": "v4.0.0",
+      "height": 8370000,
+      "recommended_version": "4.0.0",
+      "compatible_versions": [
+        "4.0.0"
+      ],
+      "consensus": {
+        "type": "cometbft",
+        "version": "0.38.21"
+      },
+      "cosmwasm": {
+        "version": "0.55.1",
+        "enabled": true
+      },
+      "sdk": {
+        "type": "cosmos",
+        "version": "0.53.5"
+      },
+      "ibc": {
+        "type": "go",
+        "version": "10.1.0"
+      },
+      "language": {
+        "type": "go",
+        "version": "1.25.9"
+      },
+      "binaries": {
+        "linux/amd64": "https://github.com/ZIGChain/networks/raw/refs/heads/main/binaries/archive/zigchaind-v4.0.0-linux-amd64.tar.gz?checksum=sha256:afc9f73f4c4e006363c4d7468d1d59483babef11129e1f2d4bddf6b0a4ca5807",
+        "darwin/amd64": "https://github.com/ZIGChain/networks/raw/refs/heads/main/binaries/archive/zigchaind-v4.0.0-darwin-amd64.tar.gz?checksum=sha256:06d36ba8fa32236140478b8633215e5c585570dccbef508c5ec84fc79dddaa10",
+        "darwin/arm64": "https://github.com/ZIGChain/networks/raw/refs/heads/main/binaries/archive/zigchaind-v4.0.0-darwin-arm64.tar.gz?checksum=sha256:21b31af4213cb51a05de3190fb2c4b2cf9710e5aef568aaf1c1361f95088f023"
+      },
+      "previous_version_name": "v3",
+      "next_version_name": "v4.1"
+    },
+    {
+      "name": "v4.1",
+      "tag": "v4.1.0",
+      "height": 10264000,
+      "proposal": 32,
+      "recommended_version": "4.1.0",
+      "compatible_versions": [
+        "4.1.0"
+      ],
+      "consensus": {
+        "type": "cometbft",
+        "version": "0.38.21"
+      },
+      "cosmwasm": {
+        "version": "0.55.1",
+        "enabled": true
+      },
+      "sdk": {
+        "type": "cosmos",
+        "version": "0.53.5"
+      },
+      "ibc": {
+        "type": "go",
+        "version": "10.1.1"
+      },
+      "language": {
+        "type": "go",
+        "version": "1.25.9"
+      },
+      "binaries": {
+        "linux/amd64": "https://github.com/ZIGChain/networks/raw/refs/heads/main/binaries/zigchaind-v4.1.0-linux-amd64.tar.gz?checksum=sha256:1a64152e48fb25c990bfcf52c0578171137470b78a79859e3c861714e099cd5e",
+        "darwin/amd64": "https://github.com/ZIGChain/networks/raw/refs/heads/main/binaries/zigchaind-v4.1.0-darwin-amd64.tar.gz?checksum=sha256:adb639e7e1496ec30de54f7dbcd8a8110548b95ca3b3b1d20ca65ec4ad2bfaa0",
+        "darwin/arm64": "https://github.com/ZIGChain/networks/raw/refs/heads/main/binaries/zigchaind-v4.1.0-darwin-arm64.tar.gz?checksum=sha256:a27cb748c8b4c90724378109e518fd730f8471d9e28fbea56bb963b3757fd6da"
+      },
+      "previous_version_name": "v4",
       "next_version_name": ""
     }
   ]


### PR DESCRIPTION
Bring mainnet and testnet version metadata up to date with the live v4.1.0 release and backfill halt/archive history for v2.0.1, v3.0.0, and v4.0.0.