### PR TITLE
ci(providers): validate provider-allowlist.json against its schema on PRs

### DIFF
--- a/.github/workflows/utility/validate_provider_allowlist.mjs
+++ b/.github/workflows/utility/validate_provider_allowlist.mjs
@@ -1,0 +1,70 @@
+// validate_provider_allowlist.mjs
+// PR-time schema validation for _providers/provider-allowlist.json.
+//
+// The onboarding path — a human PR adding a provider to the allowlist — had no
+// automated schema check. sync_provider_manifests runs only on dispatch/
+// schedule, validate_provider_scope skips non-sync branches, and
+// @chain-registry/cli does not know about _providers/. So an invalid entry
+// (e.g. added_by_pr written as a string, a malformed manifest_url, an unknown
+// status, an extra property) could land on master with green CI. This closes
+// that gap: such a file now fails the "Validate Provider Allowlist" check.
+//
+// Invocation (from .github/workflows/utility): node validate_provider_allowlist.mjs
+
+import Ajv from 'ajv';
+import addFormats from 'ajv-formats';
+import { readFileSync } from 'fs';
+import * as path from 'path';
+import { fileURLToPath } from 'url';
+
+// Anchor paths to this script's own location, not process.cwd(), so the repo
+// root resolves correctly no matter which directory the script is invoked from
+// (CI sets working-directory; local runs may not).
+const ROOT = path.join(path.dirname(fileURLToPath(import.meta.url)), '..', '..', '..');
+const ALLOWLIST = path.join(ROOT, '_providers', 'provider-allowlist.json');
+const SCHEMA = path.join(ROOT, 'provider-allowlist.schema.json');
+
+const fail = (msg) => { console.error(`❌ ${msg}`); process.exit(1); };
+
+let allowlist, schema;
+try { allowlist = JSON.parse(readFileSync(ALLOWLIST, 'utf8')); }
+catch (e) { fail(`cannot read/parse _providers/provider-allowlist.json: ${e.message}`); }
+try { schema = JSON.parse(readFileSync(SCHEMA, 'utf8')); }
+catch (e) { fail(`cannot read/parse provider-allowlist.schema.json: ${e.message}`); }
+
+// The schema intentionally omits a $schema meta-key, so AJV validates it as
+// draft-07 by default. Its $id is a URL; drop it so AJV never attempts a
+// remote fetch to resolve the schema against itself.
+delete schema.$id;
+
+const ajv = new Ajv({ allErrors: true, strict: false });
+addFormats(ajv);
+// The schema currently omits a $schema meta-key (AJV then uses draft-07 by
+// default). If it ever declares one, the repo convention is the URI
+// "https://json-schema.org/draft-07/schema" (https, no #), which AJV does not
+// know by that spelling and would throw on compile. Alias it to the built-in
+// draft-07 meta so this stays robust — same guard as sync_provider_manifests.mjs.
+ajv.addMetaSchema(ajv.getSchema('http://json-schema.org/draft-07/schema#').schema,
+                  'https://json-schema.org/draft-07/schema');
+const validate = ajv.compile(schema);
+
+if (!validate(allowlist)) {
+  console.error(`❌ ${validate.errors.length} schema violation(s) in _providers/provider-allowlist.json:`);
+  for (const e of validate.errors)
+    console.error(`   - ${e.instancePath || '(root)'} ${e.message}${e.params ? ' ' + JSON.stringify(e.params) : ''}`);
+  process.exit(1);
+}
+
+// JSON Schema cannot express uniqueness across array items. Enforce it here:
+// the sync bot keys every injected registry entry off the exact provider name,
+// so two allowlist entries sharing a name would be ambiguous.
+const names = (allowlist.providers ?? []).map(p => p.name);
+const dupNames = [...new Set(names.filter((n, i) => names.indexOf(n) !== i))];
+if (dupNames.length) fail(`duplicate provider name(s): ${dupNames.join(', ')}`);
+
+// Two entries pointing at the same manifest_url is almost certainly a mistake.
+const urls = (allowlist.providers ?? []).map(p => p.manifest_url);
+const dupUrls = [...new Set(urls.filter((u, i) => urls.indexOf(u) !== i))];
+if (dupUrls.length) fail(`duplicate manifest_url(s): ${dupUrls.join(', ')}`);
+
+console.log(`✅ provider-allowlist.json is valid (${(allowlist.providers ?? []).length} provider(s)).`);

--- a/.github/workflows/validate_provider_allowlist.yml
+++ b/.github/workflows/validate_provider_allowlist.yml
@@ -1,0 +1,42 @@
+name: Validate Provider Allowlist
+
+# Schema-validates _providers/provider-allowlist.json on every PR that touches
+# it (or the schema / this workflow's own files). The onboarding path had no
+# PR-time validation of the allowlist file: sync_provider_manifests runs only
+# on dispatch/schedule, validate_provider_scope skips non-sync branches, and
+# @chain-registry/cli does not know about _providers/. This is a targeted,
+# non-required check — a PR that does not touch these paths never runs it.
+
+on:
+  pull_request:
+    branches: [master]
+    paths:
+      - '_providers/provider-allowlist.json'
+      - 'provider-allowlist.schema.json'
+      - '.github/workflows/validate_provider_allowlist.yml'
+      - '.github/workflows/utility/validate_provider_allowlist.mjs'
+
+permissions:
+  contents: read
+
+jobs:
+  allowlist:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      # ajv/ajv-formats are the validator's only imports — same versions the
+      # sync bot pins. --no-save/--no-package-lock so no dependency files are
+      # written into the checkout.
+      - name: Install validator dependencies
+        working-directory: ./.github/workflows/utility
+        run: npm install --no-save --no-package-lock ajv@8 ajv-formats@3
+
+      - name: Validate allowlist against schema
+        working-directory: ./.github/workflows/utility
+        run: node validate_provider_allowlist.mjs


### PR DESCRIPTION
## What

Adds a targeted **Validate Provider Allowlist** check that AJV-validates `_providers/provider-allowlist.json` against `provider-allowlist.schema.json` on any PR touching the allowlist (or its schema / this workflow's own files).

## Why

The provider-manifest onboarding path (a human PR adding a provider to the allowlist, per #7790/#7791) had **no PR-time schema validation** of the allowlist file:

- `sync_provider_manifests` runs only on `workflow_dispatch`/`schedule`, not `pull_request`;
- `validate_provider_scope` runs on PRs but skips any branch that isn't `auto/provider-manifest/*`;
- `@chain-registry/cli` (the `Validate Data` / `validate-schema` jobs) doesn't know about `_providers/`.

So a malformed entry could land on `master` with fully green CI — e.g. `added_by_pr` written as the string `"7798"` instead of the integer `7798` the schema requires. This closes that gap.

## How

- New workflow `.github/workflows/validate_provider_allowlist.yml` — `pull_request` trigger, **path-filtered** to the allowlist file, the schema, and this workflow's own files. Non-required: PRs that don't touch those paths never run it.
- New script `.github/workflows/utility/validate_provider_allowlist.mjs` — compiles the schema as draft-07 with `ajv`@8 + `ajv-formats`@3 (the versions the sync bot already pins), reports every violation, and additionally rejects **duplicate provider names / manifest_urls** (uniqueness the schema can't express; the sync bot keys every injected entry off the exact provider name).

## Testing

Ran the validator locally against four cases:

| Case | Result |
|---|---|
| current `master` allowlist (empty `providers`) | ✅ pass |
| entry with `added_by_pr: "7798"` (string) | ❌ fail — `/providers/0/added_by_pr must be integer` |
| same entry with `added_by_pr: 7798` (integer) | ✅ pass |
| two entries sharing a `name` | ❌ fail — `duplicate provider name(s)` |

No dependency files are written into the checkout (`npm install --no-save --no-package-lock`; `node_modules` is gitignored).

🤖 Generated with [Claude Code](https://claude.com/claude-code)