### PR TITLE
chore(providers): canonicalize Polkachu provider name across chain.json (43 entries)

### DIFF
--- a/dydx/chain.json
+++ b/dydx/chain.json
@@ -222,23 +222,23 @@
     "grpc": [
       {
         "address": "dydx-dao-grpc-1.polkachu.com:23890",
-        "provider": "Polkachu (1)"
+        "provider": "Polkachu"
       },
       {
         "address": "dydx-dao-grpc-2.polkachu.com:23890",
-        "provider": "Polkachu (2)"
+        "provider": "Polkachu"
       },
       {
         "address": "dydx-dao-grpc-3.polkachu.com:23890",
-        "provider": "Polkachu (3)"
+        "provider": "Polkachu"
       },
       {
         "address": "dydx-dao-grpc-4.polkachu.com:23890",
-        "provider": "Polkachu (4)"
+        "provider": "Polkachu"
       },
       {
         "address": "dydx-dao-grpc-5.polkachu.com:23890",
-        "provider": "Polkachu (5)"
+        "provider": "Polkachu"
       },
       {
         "address": "https://dydx-grpc.kingnodes.com:443",

--- a/gitopia/chain.json
+++ b/gitopia/chain.json
@@ -71,7 +71,7 @@
       {
         "id": "ade4d8bc8cbe014af6ebdf3cb7b1e9ad36f412c0",
         "address": "seeds.polkachu.com:11356",
-        "provider": "polkachu"
+        "provider": "Polkachu"
       },
       {
         "id": "20e1000e88125698264454a884812746c2eb4807",
@@ -226,7 +226,7 @@
     "rpc": [
       {
         "address": "https://gitopia-rpc.polkachu.com:443",
-        "provider": "polkachu"
+        "provider": "Polkachu"
       },
       {
         "address": "https://rpc.lavenderfive.com:443/gitopia",
@@ -340,7 +340,7 @@
     "rest": [
       {
         "address": "https://gitopia-api.polkachu.com:443",
-        "provider": "polkachu"
+        "provider": "Polkachu"
       },
       {
         "address": "https://rest.lavenderfive.com:443/gitopia",
@@ -466,7 +466,7 @@
       },
       {
         "address": "gitopia-grpc.polkachu.com:11390",
-        "provider": "polkachu"
+        "provider": "Polkachu"
       },
       {
         "address": "services.staketab.com:9410",

--- a/injective/chain.json
+++ b/injective/chain.json
@@ -88,7 +88,7 @@
       {
         "id": "ade4d8bc8cbe014af6ebdf3cb7b1e9ad36f412c0",
         "address": "seeds.polkachu.com:14356",
-        "provider": "polkachu.com"
+        "provider": "Polkachu"
       },
       {
         "id": "ebc272824924ea1a27ea3183dd0b9ba713494f83",

--- a/kujira/chain.json
+++ b/kujira/chain.json
@@ -235,7 +235,7 @@
       },
       {
         "address": "https://kujira-rpc.polkachu.com",
-        "provider": "polkachu"
+        "provider": "Polkachu"
       },
       {
         "address": "https://rpc.lavenderfive.com:443/kujira",
@@ -301,7 +301,7 @@
       },
       {
         "address": "https://kujira-api.polkachu.com/",
-        "provider": "polkachu"
+        "provider": "Polkachu"
       },
       {
         "address": "https://kujira-lcd.wildsage.io/",

--- a/noble/chain.json
+++ b/noble/chain.json
@@ -87,7 +87,7 @@
     "rpc": [
       {
         "address": "https://noble-rpc.polkachu.com",
-        "provider": "polkachu"
+        "provider": "Polkachu"
       },
       {
         "address": "https://rpc.lavenderfive.com:443/noble",
@@ -101,7 +101,7 @@
     "rest": [
       {
         "address": "https://noble-api.polkachu.com",
-        "provider": "polkachu"
+        "provider": "Polkachu"
       },
       {
         "address": "https://rest.lavenderfive.com:443/noble",
@@ -115,7 +115,7 @@
     "grpc": [
       {
         "address": "noble-grpc.polkachu.com:21590",
-        "provider": "polkachu"
+        "provider": "Polkachu"
       },
       {
         "address": "noble.lavenderfive.com:443",

--- a/quasar/chain.json
+++ b/quasar/chain.json
@@ -132,7 +132,7 @@
       },
       {
         "address": "https://quasar-rpc.polkachu.com",
-        "provider": "polkachu"
+        "provider": "Polkachu"
       },
       {
         "address": "https://quasar-rpc.enigma-validator.com",
@@ -182,7 +182,7 @@
       },
       {
         "address": "https://quasar-api.polkachu.com",
-        "provider": "polkachu"
+        "provider": "Polkachu"
       },
       {
         "address": "https://api-quasar.cosmos-spaces.cloud",
@@ -232,7 +232,7 @@
       },
       {
         "address": "quasar-grpc.polkachu.com:18290",
-        "provider": "polkachu"
+        "provider": "Polkachu"
       },
       {
         "address": "grpc-quasar.cosmos-spaces.cloud:12890",

--- a/sei/chain.json
+++ b/sei/chain.json
@@ -130,7 +130,7 @@
       },
       {
         "address": "https://sei-rpc.polkachu.com",
-        "provider": "polkachu.com"
+        "provider": "Polkachu"
       },
       {
         "address": "https://rpc-sei.stingray.plus",
@@ -168,7 +168,7 @@
       },
       {
         "address": "https://sei-api.polkachu.com",
-        "provider": "polkachu.com"
+        "provider": "Polkachu"
       },
       {
         "address": "https://api-sei.stingray.plus",
@@ -202,7 +202,7 @@
       },
       {
         "address": "https://sei-grpc.polkachu.com:11990",
-        "provider": "polkachu.com"
+        "provider": "Polkachu"
       },
       {
         "address": "sei-mainnet-grpc.autostake.com:443",

--- a/stride/chain.json
+++ b/stride/chain.json
@@ -219,7 +219,7 @@
       {
         "id": "df3f533e6b9776c11f08da804edcb810cbdd2080",
         "address": "65.108.234.23:12256",
-        "provider": "Polkachu-2"
+        "provider": "Polkachu"
       },
       {
         "id": "e821acdaf0c7a3c60ea3cd4eb4a98a62dad06f58",

--- a/terra2/chain.json
+++ b/terra2/chain.json
@@ -145,7 +145,7 @@
       },
       {
         "address": "https://terra-rpc.polkachu.com",
-        "provider": "polkachu"
+        "provider": "Polkachu"
       },
       {
         "address": "https://terra-rpc.stakely.io:443/",

--- a/testnets/alloratestnet/chain.json
+++ b/testnets/alloratestnet/chain.json
@@ -123,7 +123,7 @@
       },
       {
         "address": "https://allora-testnet-rpc.polkachu.com",
-        "provider": "polkachu"
+        "provider": "Polkachu"
       },
       {
         "address": "https://allora-rpc.sh.moonlet.cloud/public",
@@ -137,7 +137,7 @@
       },
       {
         "address": "https://allora-testnet-api.polkachu.com",
-        "provider": "polkachu"
+        "provider": "Polkachu"
       },
       {
         "address": "https://testnet-allora-api.lavenderfive.com",
@@ -155,7 +155,7 @@
       },
       {
         "address": "allora-testnet-grpc.polkachu.com:26790",
-        "provider": "polkachu"
+        "provider": "Polkachu"
       }
     ]
   },

--- a/testnets/injectivetestnet/chain.json
+++ b/testnets/injectivetestnet/chain.json
@@ -51,7 +51,7 @@
       {
         "id": "ade4d8bc8cbe014af6ebdf3cb7b1e9ad36f412c0",
         "address": "testnet-seeds.polkachu.com:14356",
-        "provider": "polkachu"
+        "provider": "Polkachu"
       },
       {
         "id": "8542cd7e6bf9d260fef543bc49e59be5a3fa9074",

--- a/testnets/kujiratestnet/chain.json
+++ b/testnets/kujiratestnet/chain.json
@@ -35,13 +35,13 @@
     "rpc": [
       {
         "address": "https://kujira-testnet-rpc.polkachu.com",
-        "provider": "polkachu"
+        "provider": "Polkachu"
       }
     ],
     "rest": [
       {
         "address": "https://kujira-testnet-api.polkachu.com/",
-        "provider": "polkachu"
+        "provider": "Polkachu"
       }
     ]
   },

--- a/testnets/nilliontestnet/chain.json
+++ b/testnets/nilliontestnet/chain.json
@@ -75,7 +75,7 @@
     "rpc": [
       {
         "address": "https://nillion-testnet-rpc.polkachu.com/",
-        "provider": "polkachu"
+        "provider": "Polkachu"
       },
       {
         "address": "https://testnet-nillion-rpc.lavenderfive.com",
@@ -93,7 +93,7 @@
     "rest": [
       {
         "address": "https://nillion-testnet-api.polkachu.com/",
-        "provider": "polkachu"
+        "provider": "Polkachu"
       },
       {
         "address": "https://testnet-nillion-api.lavenderfive.com",

--- a/testnets/nobletestnet/chain.json
+++ b/testnets/nobletestnet/chain.json
@@ -100,7 +100,7 @@
     "rpc": [
       {
         "address": "https://noble-testnet-rpc.polkachu.com",
-        "provider": "polkachu"
+        "provider": "Polkachu"
       },
       {
         "address": "https://rpc.testnet.noble.strange.love:443",
@@ -110,7 +110,7 @@
     "rest": [
       {
         "address": "https://noble-testnet-api.polkachu.com",
-        "provider": "polkachu"
+        "provider": "Polkachu"
       },
       {
         "address": "https://api.testnet.noble.strange.love",
@@ -120,7 +120,7 @@
     "grpc": [
       {
         "address": "noble-testnet-grpc.polkachu.com:21590",
-        "provider": "polkachu"
+        "provider": "Polkachu"
       }
     ]
   },

--- a/testnets/quicksilvertestnet/chain.json
+++ b/testnets/quicksilvertestnet/chain.json
@@ -94,7 +94,7 @@
       },
       {
         "address": "https://quicksilver-testnet-rpc.polkachu.com/",
-        "provider": "polkachu"
+        "provider": "Polkachu"
       }
     ],
     "rest": [
@@ -104,7 +104,7 @@
       },
       {
         "address": "https://quicksilver-testnet-api.polkachu.com/",
-        "provider": "polkachu"
+        "provider": "Polkachu"
       }
     ],
     "grpc": [
@@ -114,7 +114,7 @@
       },
       {
         "address": "quicksilver-testnet-grpc.polkachu.com:11190",
-        "provider": "polkachu"
+        "provider": "Polkachu"
       }
     ]
   },

--- a/testnets/quicksilvertestnet2/chain.json
+++ b/testnets/quicksilvertestnet2/chain.json
@@ -94,7 +94,7 @@
       },
       {
         "address": "https://quicksilver-testnet-rpc.polkachu.com/",
-        "provider": "polkachu"
+        "provider": "Polkachu"
       }
     ],
     "rest": [
@@ -104,7 +104,7 @@
       },
       {
         "address": "https://quicksilver-testnet-api.polkachu.com/",
-        "provider": "polkachu"
+        "provider": "Polkachu"
       }
     ],
     "grpc": [
@@ -114,7 +114,7 @@
       },
       {
         "address": "quicksilver-testnet-grpc.polkachu.com:11190",
-        "provider": "polkachu"
+        "provider": "Polkachu"
       }
     ]
   },

--- a/testnets/soarchaintestnet/chain.json
+++ b/testnets/soarchaintestnet/chain.json
@@ -77,7 +77,7 @@
       {
         "id": "994c5252f55d6b809f0c19956530187009451c89",
         "address": "167.235.178.134:25256",
-        "provider": "polkachu"
+        "provider": "Polkachu"
       },
       {
         "id": "5687031cd6f0de4506bdc768118873f7608bbdf8",

--- a/testnets/xrplevmtestnet/chain.json
+++ b/testnets/xrplevmtestnet/chain.json
@@ -89,7 +89,7 @@
       {
         "id": "ade4d8bc8cbe014af6ebdf3cb7b1e9ad36f412c0",
         "address": "testnet-seeds.polkachu.com:30056",
-        "provider": "POLKACHU"
+        "provider": "Polkachu"
       },
       {
         "id": "d8106774d544591c0dd5b073ac0fd2e481669cf0",
@@ -131,7 +131,7 @@
       {
         "id": "ade4d8bc8cbe014af6ebdf3cb7b1e9ad36f412c0",
         "address": "testnet-seeds.polkachu.com:30056",
-        "provider": "POLKACHU"
+        "provider": "Polkachu"
       },
       {
         "id": "d8106774d544591c0dd5b073ac0fd2e481669cf0",


### PR DESCRIPTION
## What

Renames all **43 non-canonical `provider` string variants** of Polkachu to the canonical **`Polkachu`**, across **18 `chain.json` files**. Only `provider` field *values* change — no endpoints, peers, IDs, or other data are modified.

## Why

The registry currently attributes Polkachu's infrastructure under **10 distinct provider strings**:

| Provider string | Entries |
|---|---|
| `Polkachu` (canonical) | 289 |
| `polkachu` | 31 |
| `polkachu.com` | 4 |
| `POLKACHU` | 2 |
| `Polkachu (1)`…`(5)` | 5 |
| `Polkachu-2` | 1 |

This is provider-name fragmentation, and it's a **prerequisite for the provider-manifest sync** (#7790 / #7791): the sync bot keys attribution off the *exact* provider string, so without canonicalizing first, Polkachu's first manifest sync would read each variant as a *different* provider — reporting ~43 conflicts and adding nothing. It's also an independent registry-quality improvement regardless of the pilot.

## Scope / safety

Surgical, value-only rename — verified:
- Diff is **+43 / −43**, and **every changed line is a `"provider"` line** (no address/id/other line touched).
- All 18 files still **validate as JSON**; each file's set of endpoint/peer **addresses and node IDs is byte-identical** before and after.
- **Zero residual** non-canonical Polkachu variants remain after the rename.
- All 43 variant entries were confirmed to belong to Polkachu (41 on `polkachu.com` domains; the 2 IP-based peer entries — soarchain seed, stride persistent_peer — were already self-attributed to Polkachu and are on Polkachu's Hetzner infra).

## Files

`dydx`, `gitopia`, `injective`, `kujira`, `noble`, `quasar`, `sei`, `stride`, `terra2`, and testnets: `alloratestnet`, `injectivetestnet`, `kujiratestnet`, `nilliontestnet`, `nobletestnet`, `quicksilvertestnet`, `quicksilvertestnet2`, `soarchaintestnet`, `xrplevmtestnet`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)