### PR TITLE
feat(providers): make snapshot liveness check advisory, not gating

### DIFF
--- a/.github/workflows/sync_provider_manifests.yml
+++ b/.github/workflows/sync_provider_manifests.yml
@@ -101,6 +101,7 @@ jobs:
             console.log(`\n**Removed — absent from manifest (${r.removed.length})**\n${li(r.removed)}`);
             console.log(`\n**Retained despite failed check (${(r.retained||[]).length})**\n${li(r.retained||[])}`);
             console.log(`\n**Held back — failed health check, not added (${r.held_back.length})**\n${li(r.held_back)}`);
+            console.log(`\n**Unverified — synced, but liveness check inconclusive (${(r.unverified||[]).length})**\n${li(r.unverified||[])}`);
             console.log(`\n**Conflicts — address already registered to another provider, not added (${(r.conflicts||[]).length})**\n${li(r.conflicts||[])}`);
             if (r.skipped_chains.length) console.log(`\n**Skipped unknown chain_ids:** ${r.skipped_chains.join(", ")}`);
           ' "$F")

--- a/.github/workflows/utility/sync_provider_manifests.mjs
+++ b/.github/workflows/utility/sync_provider_manifests.mjs
@@ -31,7 +31,7 @@ if (!providerName) { console.error('PROVIDER_NAME env var required'); process.ex
 
 const report = { provider: providerName, fetched_at: new Date().toISOString(),
                  manifest_url: null, manifest_sha256: null,
-                 added: [], updated: [], removed: [], retained: [], held_back: [], conflicts: [], skipped_chains: [] };
+                 added: [], updated: [], removed: [], retained: [], held_back: [], unverified: [], conflicts: [], skipped_chains: [] };
 
 // ---------- 1. Allowlist lookup ----------
 const allowlist = JSON.parse(fs.readFileSync(ALLOWLIST, 'utf8'));
@@ -150,11 +150,42 @@ const checks = {
   async wss() { return 'not probed (reachability only in v1)'; },
   async 'grpc-web'() { return 'not probed'; },
 };
-async function checkSnapshot(s) {
+// Advisory snapshot probe. A snapshot is best-effort, provider-owned infra, and
+// a liveness check cannot verify its contents — so the probe INFORMS rather than
+// gates. Verdicts:
+//   verified   - got a 2xx; reachable.
+//   dead       - definitively gone (404/410) or host unreachable (only network
+//                errors / timeouts, never an HTTP response) -> held back.
+//   unverified - reachable but non-2xx (e.g. a WAF returning 403/405/429, or a
+//                5xx) -> still synced, flagged, because that is not proof of
+//                absence. Tries HEAD then GET (some hosts block HEAD) with a
+//                browser-like UA (some WAFs reject default agents), and never
+//                downloads the payload.
+const SNAPSHOT_UA = 'Mozilla/5.0 (compatible; cosmos-chain-registry-sync/1.0; +https://github.com/cosmos/chain-registry)';
+async function probeSnapshot(s) {
   const url = s.latest_url ?? s.url;
-  const res = await fetch(url, { method: 'HEAD', signal: AbortSignal.timeout(HEALTH_TIMEOUT_MS), redirect: 'follow' });
-  if (!res.ok) throw new Error(`HEAD ${url} -> HTTP ${res.status}`);
-  return `exists${res.headers.get('content-length') ? ', ' + res.headers.get('content-length') + 'B' : ''}`;
+  let blockedStatus = null;   // an HTTP status that is reachable-but-not-2xx (403/405/429/5xx)
+  let netError = null;        // a network/timeout/DNS error (no HTTP response at all)
+  for (const method of ['HEAD', 'GET']) {
+    try {
+      const res = await fetch(url, { method, redirect: 'follow',
+        headers: { 'user-agent': SNAPSHOT_UA }, signal: AbortSignal.timeout(HEALTH_TIMEOUT_MS) });
+      if (method === 'GET') { try { await res.body?.cancel(); } catch { /* never download the payload */ } }
+      if (res.ok) {
+        const len = res.headers.get('content-length');
+        return { verdict: 'verified', note: `reachable${len ? `, ${len}B` : ''}` };
+      }
+      if (res.status === 404 || res.status === 410) return { verdict: 'dead', note: `HTTP ${res.status}` };
+      blockedStatus = res.status;
+    } catch (err) {
+      netError = err.message;
+    }
+  }
+  // No 2xx and no definitive 404/410. A reachable-but-blocked status wins over a
+  // network error (a server that answered 403 is present, not dead).
+  if (blockedStatus !== null)
+    return { verdict: 'unverified', note: `HTTP ${blockedStatus} (check inconclusive; not confirmed dead)` };
+  return { verdict: 'dead', note: netError || 'unreachable' };
 }
 
 // ---------- 7. Provider-scoped merge ----------
@@ -232,10 +263,18 @@ for (const chain of manifest.chains) {
   }
   for (const [peerType, entries] of Object.entries(chain.peers ?? {})) desired.peers[peerType] = entries;
   for (const s of chain.snapshots ?? []) {
-    try { await checkSnapshot(s); desired.snapshots.push(s); }
-    catch (err) {
-      report.held_back.push({ chain: chain.chain_id, type: 'snapshot', address: s.url, reason: err.message });
+    const { verdict, note } = await probeSnapshot(s);
+    // `address` stays s.url — the snapshot's identity key, matching the merge
+    // and the added/removed lines. When a different latest_url was the URL
+    // actually probed, name it in the note so a maintainer can reproduce.
+    const reason = s.latest_url && s.latest_url !== s.url ? `${note} [probed ${s.latest_url}]` : note;
+    if (verdict === 'dead') {
+      report.held_back.push({ chain: chain.chain_id, type: 'snapshot', address: s.url, reason });
       markHeld('snapshots', s.url);
+    } else {
+      desired.snapshots.push(s);   // verified or unverified: snapshots are advisory, so sync them
+      if (verdict === 'unverified')
+        report.unverified.push({ chain: chain.chain_id, type: 'snapshot', address: s.url, reason });
     }
   }
 


### PR DESCRIPTION
## What

Changes the provider-manifest sync bot's **snapshot** liveness check from a hard gate into an **advisory** signal. Endpoint (rpc/rest) checks are untouched and still gate strictly.

## Why

A snapshot is best-effort, provider-owned infrastructure, and a HEAD/GET probe can only tell us "does a URL respond" — it cannot verify the snapshot's contents. So gating snapshot *inclusion* on that probe is low value, and it produces false negatives.

This surfaced in the **Polkachu pilot**: their snapshot URLs (e.g. `https://polkachu.com/tendermint_snapshots/cosmos`) sit behind a WAF that returns **403 to non-browser requests** (verified: 403 on both HEAD and GET). The old check treated 403 as failure and **silently held back every snapshot**, even though the URLs are perfectly fine in a browser.

## How

`probeSnapshot` now classifies each snapshot instead of throwing:

| Verdict | Trigger | Action |
|---|---|---|
| `verified` | 2xx | synced |
| `unverified` | reachable but non-2xx (403/405/429/5xx) | **synced, flagged** in the report |
| `dead` | 404 / 410, or unreachable host (only network/timeout errors, never an HTTP response) | held back (as before) |

- Tries **HEAD then GET** (some hosts block HEAD) with a **browser-like User-Agent** (some WAFs reject default agents), and never downloads the payload (`res.body.cancel()`).
- A reachable-but-blocked status wins over a later network error (a server that answered 403 is present, not dead).
- Adds an **"Unverified — synced, but liveness check inconclusive"** section to the `[AUTO]` PR body / job summary, so maintainers see exactly which snapshots weren't confirmed.

## Testing

- **Probe classification** against real URLs: Polkachu 403 → `unverified` ✅ · a 2xx URL → `verified` ✅ · a 404 → `dead` ✅ · a non-resolving host → `dead` ✅.
- **End-to-end** (real bot, 3 live Polkachu chains via a local manifest): before = 3 snapshots held back; after = **0 held back, 3 synced and listed under `unverified`**. Endpoint health checks still pass with live block heights.
- **Validation gate intact**: a manifest with a malformed `chain_id` still hard-rejects the whole file (this change is downstream of schema validation).
- `node --check` clean; YAML parses.

## Scope

Snapshots only. Endpoint/peer behavior, schema validation, the conflict guard, and the scope guard are all unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)