### PR TITLE
feat(dungeon): add PASG IBC asset + dungeon<->passage channel

### DIFF
--- a/_IBC/dungeon-passage.json
+++ b/_IBC/dungeon-passage.json
@@ -1,0 +1,33 @@
+{
+  "$schema": "../ibc_data.schema.json",
+  "chain_1": {
+    "chain_name": "dungeon",
+    "chain_id": "dungeon-1",
+    "client_id": "07-tendermint-37",
+    "connection_id": "connection-8639"
+  },
+  "chain_2": {
+    "chain_name": "passage",
+    "chain_id": "passage-2",
+    "client_id": "07-tendermint-22",
+    "connection_id": "connection-18"
+  },
+  "channels": [
+    {
+      "chain_1": {
+        "channel_id": "channel-5318",
+        "port_id": "transfer"
+      },
+      "chain_2": {
+        "channel_id": "channel-13",
+        "port_id": "transfer"
+      },
+      "ordering": "unordered",
+      "version": "ics20-1",
+      "tags": {
+        "status": "ACTIVE",
+        "preferred": true
+      }
+    }
+  ]
+}

--- a/dungeon/assetlist.json
+++ b/dungeon/assetlist.json
@@ -289,6 +289,55 @@
         "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/_non-cosmos/ethereum/images/usdc.svg"
       },
       "coingecko_id": "usd-coin"
+    },
+    {
+      "description": "Passage (PASG) transferred to Dungeon Chain over IBC.",
+      "denom_units": [
+        {
+          "denom": "ibc/73E558C82602DE116482AD0EFC351A375E7FF7048ED6A2C45F86A0BFE670CD5F",
+          "exponent": 0,
+          "aliases": [
+            "upasg"
+          ]
+        },
+        {
+          "denom": "pasg",
+          "exponent": 6,
+          "aliases": []
+        }
+      ],
+      "type_asset": "ics20",
+      "base": "ibc/73E558C82602DE116482AD0EFC351A375E7FF7048ED6A2C45F86A0BFE670CD5F",
+      "name": "Passage",
+      "display": "pasg",
+      "symbol": "PASG",
+      "coingecko_id": "passage",
+      "traces": [
+        {
+          "type": "ibc",
+          "counterparty": {
+            "chain_name": "passage",
+            "base_denom": "upasg",
+            "channel_id": "channel-13"
+          },
+          "chain": {
+            "channel_id": "channel-5318",
+            "path": "transfer/channel-5318/upasg"
+          }
+        }
+      ],
+      "images": [
+        {
+          "image_sync": {
+            "chain_name": "passage",
+            "base_denom": "upasg"
+          },
+          "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/passage/images/pasg.png"
+        }
+      ],
+      "logo_URIs": {
+        "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/passage/images/pasg.png"
+      }
     }
   ]
 }


### PR DESCRIPTION
Adds the Passage (PASG) IBC asset on Dungeon Chain and the `_IBC/dungeon-passage.json` connection record for a newly opened transfer channel.

**Channel (opened 2026-07-10, live + relayed):**
- dungeon-1 `channel-5318` ↔ passage-2 `channel-13` (transfer / ics20-1 / unordered)
- PASG on dungeon-1: `ibc/73E558C82602DE116482AD0EFC351A375E7FF7048ED6A2C45F86A0BFE670CD5F` = sha256("transfer/channel-5318/upasg")

Asset metadata mirrors the canonical `passage` entry (image synced from `passage/images/pasg.png`, coingecko `passage`). Smoke-tested end-to-end (packet received + acked).