### PR TITLE
chore: mark moo (MilkyWay Interwoven rollup) as killed

### DIFF
--- a/moo/chain.json
+++ b/moo/chain.json
@@ -4,7 +4,7 @@
   "chain_type": "cosmos",
   "chain_id": "moo-1",
   "pretty_name": "MilkyWay",
-  "status": "live",
+  "status": "killed",
   "network_type": "mainnet",
   "website": "https://www.milkyway.zone",
   "bech32_prefix": "init",


### PR DESCRIPTION
Marks `moo` (chain_id `moo-1`, MilkyWay's Interwoven rollup on Initia) as `status: killed`.

MilkyWay publicly announced the permanent wind-down of its chains, with a final upgrade returning assets to their origin chains: https://x.com/milky_way_zone/status/2011770175566332325. The MilkyWay L1 (`milkyway`) was marked killed in #7744; this completes the pair. The moo-1 rollup hosted MilkyWay's liquid-staking tokens (milkINIT) and shut down with it.

Both endpoints registered in this repo (`rpc-moo-1.anvil.asia-southeast.initia.xyz`, `rest-moo-1.anvil.asia-southeast.initia.xyz`) are unreachable (verified 13 July 2026, no endpoint returns a current block).

Status-only change; no other fields touched.