### PR TITLE
chore(elys): mark chain killed (elys-1 has halted)

### DIFF
--- a/elys/chain.json
+++ b/elys/chain.json
@@ -1,7 +1,7 @@
 {
   "$schema": "../chain.schema.json",
   "chain_name": "elys",
-  "status": "live",
+  "status": "killed",
   "network_type": "mainnet",
   "pretty_name": "Elys Network",
   "chain_type": "cosmos",


### PR DESCRIPTION
## Summary

Set `elys` `status` to `killed`. The Elys Network mainnet (`elys-1`) has stopped producing blocks following its governance-approved sunset.

## Evidence

- **Last committed block:** `13381279` at `2026-07-07T07:14:57Z`.
- As of `2026-07-13` the chain has been frozen at that block for over 6 days (~149 hours) with no further blocks.
- Two independent public RPCs (`rpc.elys.network`, `elys-rpc.publicnode.com`) report the identical frozen height and timestamp, and the node returns `height 13381280 must be less than or equal to the current blockchain height 13381279` when queried for the next block. This rules out a single lagging endpoint.
- The chain had been running on a small equal-weight validator committee. Signing power fell below the two-thirds CometBFT liveness threshold, so consensus can no longer commit.
- Governance proposal 103 ("Elys Network blockchain Sunset", passed) authorized ceasing operations. The chain has now halted, completing the sunset.

## Change

`elys/chain.json`: `status` `live` -> `killed`. No other fields changed.

Verified `killed` is the correct schema value (`chain.schema.json` allows `live | upcoming | killed`), consistent with how other retired chains are marked.
