### PR TITLE
chore(umee): mark chain status as killed

### DIFF
--- a/umee/chain.json
+++ b/umee/chain.json
@@ -1,7 +1,7 @@
 {
   "$schema": "../chain.schema.json",
   "chain_name": "umee",
-  "status": "live",
+  "status": "killed",
   "network_type": "mainnet",
   "website": "https://www.ux.xyz",
   "pretty_name": "UX Chain",


### PR DESCRIPTION
## Summary
UX Chain (`umee`, chain_id `umee-1`) has halted. This marks its `status` as `killed`, mirroring the recent evmos change (#7710).

## Evidence the chain has stopped producing blocks
- **All registered endpoints unreachable** — every RPC/REST provider in `umee/chain.json` returns connection-refused or `404`, and `rpc.cosmos.directory/umee` returns `502`.
- **Counterparty IBC light client stalled** — Osmosis's client tracking `umee-1` (`07-tendermint-1805`) last relayed a umee header at height **24,109,344**, timestamp **2026-07-10T12:32:18Z**, with no consensus-state updates since. The client is not frozen; the source chain simply stopped.

Net: umee-1 halted around **2026-07-10**.

## Change
`umee/chain.json`: `"status": "live"` → `"status": "killed"` (single-line change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)