### PR TITLE
feat: add POSTHUMAN provider manifest

### DIFF
--- a/_providers/provider-allowlist.json
+++ b/_providers/provider-allowlist.json
@@ -6,6 +6,12 @@
       "manifest_url": "https://polkachu.com/.well-known/cosmos-registry.json",
       "status": "active",
       "added_by_pr": 7798
+    },
+    {
+      "name": "POSTHUMAN",
+      "manifest_url": "https://nodes.posthuman.digital/.well-known/cosmos-registry.json",
+      "status": "active",
+      "added_by_pr": 1
     }
   ]
 }

--- a/_providers/provider-allowlist.json
+++ b/_providers/provider-allowlist.json
@@ -11,7 +11,7 @@
       "name": "POSTHUMAN",
       "manifest_url": "https://nodes.posthuman.digital/.well-known/cosmos-registry.json",
       "status": "active",
-      "added_by_pr": 1
+      "added_by_pr": 7819
     }
   ]
 }

--- a/humans/chain.json
+++ b/humans/chain.json
@@ -161,7 +161,7 @@
       },
       {
         "address": "https://rpc.humans.posthuman.digital",
-        "provider": "posthuman"
+        "provider": "POSTHUMAN"
       },
       {
         "address": "https://humans-rpc.noders.services",
@@ -215,7 +215,7 @@
       },
       {
         "address": "https://rest.humans.posthuman.digital",
-        "provider": "posthuman"
+        "provider": "POSTHUMAN"
       },
       {
         "address": "https://humans-api.noders.services",
@@ -299,7 +299,7 @@
       },
       {
         "address": "https://evm.humans.posthuman.digital",
-        "provider": "posthuman"
+        "provider": "POSTHUMAN"
       },
       {
         "address": "https://humans-jsonrpc.noders.services",


### PR DESCRIPTION
## Summary

- allowlist the canonical provider name `POSTHUMAN`
- use the hosted manifest at
  `https://nodes.posthuman.digital/.well-known/cosmos-registry.json`
- normalize existing Humans.ai entries to the canonical provider spelling so
  the provider-scoped sync can reconcile that lane

The hosted manifest currently covers 10 chain IDs and 34 provider-owned API,
peer, and snapshot entries. It intentionally omits unavailable endpoints and
retired services.

`added_by_pr` is set to this onboarding PR number (`7819`).

## Validation

- provider manifest schema validation: passed
- live upstream provider sync simulation: 33 additions, 2 provider-scoped
  removals, 0 held back, 0 conflicts, 0 skipped chains
- provider allowlist schema validation: passed
- `@chain-registry/cli@1.47.0 validate`: 2228 tests passed
- public diff preflight: passed
