### PR TITLE
chore(provider-manifests): require /.well-known/cosmos-registry.json manifest path

### DIFF
--- a/_guides/provider-manifests.md
+++ b/_guides/provider-manifests.md
@@ -69,7 +69,7 @@ npx ajv-cli validate --spec=draft7 -c ajv-formats \
   -s provider-manifest.schema.json -d your-manifest.json
 ```
 
-3. **Host it over HTTPS on a domain you control.** The recommended path is `/.well-known/cosmos-registry.json`, but any stable HTTPS URL on your domain works. Keep it under 512 KB; the bot does not follow redirects off your domain.
+3. **Host it over HTTPS at `/.well-known/cosmos-registry.json` on a domain you control.** The manifest **must** be served at a `/.well-known/cosmos-registry.json` path — i.e. the URL ends with `/.well-known/cosmos-registry.json` (e.g. `https://your-domain/.well-known/cosmos-registry.json`) — so every provider's manifest lives at one predictable, standardized location. Keep it under 512 KB; the bot does not follow redirects off your domain.
 
 4. **Open one onboarding PR** adding yourself to [`_providers/provider-allowlist.json`](../_providers/provider-allowlist.json):
 

--- a/provider-allowlist.schema.json
+++ b/provider-allowlist.schema.json
@@ -33,8 +33,8 @@
           "manifest_url": {
             "type": "string",
             "format": "uri",
-            "pattern": "^https://[^\\s/]+\\.[^\\s/]+(/\\S*)?$",
-            "description": "HTTPS URL of the provider's self-hosted manifest. Must be served from a domain that verifiably belongs to the provider (checked by the reviewing maintainer at onboarding). The bot does not follow redirects off this domain."
+            "pattern": "^https://[^\\s/]+\\.[^\\s/]+/(\\S*/)?\\.well-known/cosmos-registry\\.json$",
+            "description": "HTTPS URL of the provider's self-hosted manifest. MUST be served at a `/.well-known/cosmos-registry.json` path (the URL must end with `/.well-known/cosmos-registry.json`) so every provider's manifest lives at one predictable location. Must be on a domain that verifiably belongs to the provider (checked by the reviewing maintainer at onboarding). The bot does not follow redirects off this domain."
           },
           "status": {
             "type": "string",


### PR DESCRIPTION
Standardizes where provider manifests are hosted so every provider's manifest lives at one predictable, discoverable location.

## Changes
- **`_guides/provider-manifests.md`** (step 3): "recommended path … but any stable HTTPS URL works" → the manifest **must** be served at a `/.well-known/cosmos-registry.json` path (the URL must end with `/.well-known/cosmos-registry.json`).
- **`provider-allowlist.schema.json`** (`manifest_url`): tightened the pattern from `^https://[^\s/]+\.[^\s/]+(/\S*)?$` to `^https://[^\s/]+\.[^\s/]+/(\S*/)?\.well-known/cosmos-registry\.json$`, plus an updated description. This makes the requirement **CI-enforced** by the existing `validate_provider_allowlist` check, not just documented.

## Compatibility — existing providers unaffected
Verified against the current allowlist:
- `Polkachu` → `https://polkachu.com/.well-known/cosmos-registry.json` ✅
- `High Stakes 🇨🇭` → `https://tools.highstakes.ch/files/.well-known/cosmos-registry.json` ✅ (subpath still ends with the required suffix)

A non-conforming URL (e.g. `https://…/manifests/foo.json`) now fails AJV validation at `manifest_url` with keyword `pattern`. Tested: 11 URL cases + full-allowlist AJV validation against the live master allowlist.