### PR TITLE
fix(sync-provider-manifests): drop apostrophe breaking render step

### DIFF
--- a/.github/workflows/sync_provider_manifests.yml
+++ b/.github/workflows/sync_provider_manifests.yml
@@ -119,7 +119,7 @@ jobs:
             console.log(`\n**Added (${r.added.length})**\n${li(r.added)}`);
             console.log(`\n**Updated (${r.updated.length})**\n${li(r.updated)}`);
             console.log(`\n**Removed — absent from manifest (${r.removed.length})**\n${li(r.removed)}`);
-            console.log(`\n**Retained — failed this run's health check but kept, still in manifest (${retainedLines.length})**\n${retainedLines.length ? retainedLines.join("\n") : "- none"}`);
+            console.log(`\n**Retained — failed the health check this run but kept, still in manifest (${retainedLines.length})**\n${retainedLines.length ? retainedLines.join("\n") : "- none"}`);
             console.log(`\n**Held back — failed health check, not added (${heldExcluded.length})**\n${li(heldExcluded)}`);
             console.log(`\n**Liveness inconclusive — advisory, not treated as dead (${(r.unverified||[]).length} total: ${uvNew.length} newly added, ${uvExisting.length} already present & unchanged)**`);
             console.log(`\n_Newly added this run (${uvNew.length}):_\n${li(uvNew)}`);


### PR DESCRIPTION
## Problem

Scheduled run [29724820187](https://github.com/cosmos/chain-registry/actions/runs/29724820187) failed: every provider sync job (Cumulo, High Stakes 🇨🇭, Polkachu) errored at the **Render sync report** step with:

```
line 30: syntax error near unexpected token `('
Process completed with exit code 2.
```

## Root cause

The step runs a `node -e '…'` script wrapped in **single quotes**. Line 122 contained an apostrophe:

> `**Retained — failed this run's health check but kept …**`

The `'` in `run's` closed the bash single-quoted string 27 lines early; bash then parsed the remaining JS as shell, hit `console.log(`, and aborted. All jobs share the step, so all failed identically.

## Why CI didn't catch it

`sync_provider_manifests.yml` is `schedule`/`dispatch`-only, so PR CI never executes the render step. Green PR checks ≠ this step ran — the bug surfaced only on the scheduled run.

## Impact — no data risk

The **apply manifest** step succeeded; the crash was in the **reporting** step, which then skipped *Commit and push* and *Open PR*. So no incorrect data was merged — the pipeline simply halted and opened no `[AUTO]` PRs until fixed.

## Fix

One-line reword to drop the apostrophe (`this run's health check` → `the health check this run`). Verified:
- single-quote count in the `node -e` block is balanced again (2),
- a local repro reproduced the exact `syntax error near unexpected token '('`, and the reworded version passes `bash -n` and runs clean.

## Follow-up (not in this PR)

Convert the render step from `node -e '…'` to a quoted heredoc (`node <<'JS' … JS`) so any future apostrophe in a label can't break bash quoting.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
