### PR TITLE
fix(sync-provider-manifests): key snapshots by stable identity, not churning latest_url

### DIFF
--- a/.github/workflows/utility/sync_provider_manifests.mjs
+++ b/.github/workflows/utility/sync_provider_manifests.mjs
@@ -235,12 +235,16 @@ async function probeSnapshot(s) {
 const keyOf = {
   endpoint: e => e.address,
   peer: p => `${p.id}@${p.address}`,
-  // A provider may publish several snapshots at one browse `url` that differ
-  // only by artifact (e.g. goleveldb `x.tar.gz` vs pebbledb `x_pebbledb.tar.gz`).
-  // Keying by `url` alone collapsed them into one — every variant but the last
-  // was dropped and the drop mis-reported as "absent from manifest". Key by the
-  // downloadable artifact (`latest_url`), falling back to `url` when absent.
-  snapshot: s => s.latest_url ?? s.url,
+  // A provider may publish several snapshots at one browse `url` differing only
+  // by variant (e.g. goleveldb `x.tar.gz` vs pebbledb `x_pebbledb.tar.gz`) — the
+  // key must keep those DISTINCT. But `latest_url` CHURNS (artifacts get renamed
+  // / re-dated), and keying by it makes a churn read as remove-old + add-new: if
+  // the new artifact blips (e.g. 404 mid-rotation) the live existing entry is
+  // dropped AND its replacement held back = data loss, because the retain-on-blip
+  // guard can't match a key that just changed. Key by STABLE identity — browse
+  // `url` + `type` + `db_backend` — so variants stay distinct while a latest_url
+  // change is an in-place update (and a blip retains the existing entry).
+  snapshot: s => [s.url ?? s.latest_url ?? '', s.type ?? '', s.db_backend ?? ''].join(' | '),
 };
 
 // order-insensitive structural compare: `{...d, provider}` re-orders keys, which
@@ -318,11 +322,13 @@ for (const chain of manifest.chains) {
   for (const [peerType, entries] of Object.entries(chain.peers ?? {})) desired.peers[peerType] = entries;
   for (const s of chain.snapshots ?? []) {
     const { verdict, note } = await probeSnapshot(s);
-    // identity = keyOf.snapshot (latest_url ?? url) so held/unverified lines
-    // reconcile against the merge's added/removed/retained keys. Name the browse
-    // page in the note when it differs so a maintainer can still locate it.
+    // identity = keyOf.snapshot (stable: url|type|db_backend) so held/unverified
+    // lines reconcile against the merge's added/removed/retained keys. The probed
+    // artifact (latest_url) is NOT in the key, so name it in the note when it
+    // differs, letting a maintainer see exactly which file the probe hit.
     const sk = keyOf.snapshot(s);
-    const reason = s.url && s.url !== sk ? `${note} [snapshot page ${s.url}]` : note;
+    const probed = s.latest_url ?? s.url;
+    const reason = probed && probed !== sk ? `${note} [artifact ${probed}]` : note;
     if (verdict === 'dead') {
       report.held_back.push({ chain: chain.chain_id, type: 'snapshot', address: sk, reason });
       markHeld('snapshots', sk);


### PR DESCRIPTION
## Problem

Reviewing [AUTO] sync **#7831** (High Stakes 🇨🇭) surfaced a **data-loss regression** — a *live* snapshot removed while still advertised by the provider.

My previous fix #7829 keyed snapshots by `latest_url ?? url` so a provider's goleveldb/pebbledb variants (published at the *same* browse `url`) stop collapsing into one key. That fixed injective — but `latest_url` **churns**, and keying identity on a churning field is the bug here.

High Stakes changed provenance's snapshot artifact in their manifest:

| | URL | HTTP |
|---|---|---|
| on master (goleveldb) | `.../files/provenance_goleveldb.tar.gz` | **206 (live)** |
| new, in manifest | `.../files/provenance.tar.gz` | **404** |

Because the key changed, the sync treated it as **remove-old + add-new**:
- new artifact health-fails (404) → **held back** (not added)
- old artifact key now "absent from manifest" → **removed**

Net: the live goleveldb snapshot is dropped. The retain-on-blip guard (which exists to keep an already-registered entry that blips this run) **couldn't fire** — it matches on key, and the key had just changed.

## Fix

Key snapshots by **stable identity** `url | type | db_backend` instead of the churning `latest_url`:

```js
snapshot: s => [s.url ?? s.latest_url ?? "", s.type ?? "", s.db_backend ?? ""].join(" | "),
```

- **Variants stay distinct** — injective goleveldb vs pebbledb differ in `db_backend` (same `url`) → still two keys → both kept (preserves #7829).
- **A latest_url change is now an in-place update**, not remove+add.
- **A blip on the new artifact retains the existing entry** — provenance keeps its live goleveldb snapshot until the new one is reachable.

The probed artifact (`latest_url`) is no longer part of the key, so it is named in the held/unverified note (`[artifact <url>]`) so a maintainer can still see exactly which file the probe hit. Render-step reconciliation is unchanged (held/retained still key off `keyOf.snapshot`, so no `.yml` change).

## Verification

Standalone merge+health-gate test on the **real injective + provenance data**:

| scenario | old key (master) | new key (this PR) |
|---|---|---|
| provenance (new artifact 404) | removed 1 (**data loss**) | **retained 1**, removed 0 |
| injective (2 variants, both live) | both kept | both kept |
| provenance recovery (new artifact live) | — | **updated 1** in place, removed 0 |

`node --check` passes. Diff is comments + one key line + one note line only.

## Follow-ups (separate, not this PR)

- **Provider-side:** High Stakes's manifest points provenance `latest_url` at `provenance.tar.gz` which currently 404s (the live artifact is `provenance_goleveldb.tar.gz`). With this fix the sync degrades gracefully (retains the live one), but they should repoint or publish the new file.
- **[AUTO] #7831** carries the pre-fix removal — close it (do not merge); a fresh dispatch after this merges produces a clean PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)