### PR TITLE
chore(cosmoshub): add ATOM telegram and discord socials

### DIFF
--- a/cosmoshub/assetlist.json
+++ b/cosmoshub/assetlist.json
@@ -32,7 +32,9 @@
       ],
       "socials": {
         "website": "https://cosmos.network",
-        "x": "https://x.com/cosmoshub"
+        "x": "https://x.com/cosmoshub",
+        "telegram": "https://t.me/CosmosOG",
+        "discord": "https://discord.com/invite/interchain"
       },
       "type_asset": "sdk.coin"
     },


### PR DESCRIPTION
Adds Telegram and Discord links to the ATOM asset's `socials` object in `cosmoshub/assetlist.json`.

- `telegram`: https://t.me/CosmosOG
- `discord`: https://discord.com/invite/interchain

Both keys are valid per `assetlist.schema.json` (`socials` permits website, x, telegram, discord, github, medium, reddit). The existing `website` and `x` entries are unchanged.