### PR TITLE
chore(cosmoshub): add ATOM reddit social

### DIFF
--- a/cosmoshub/assetlist.json
+++ b/cosmoshub/assetlist.json
@@ -34,7 +34,8 @@
         "website": "https://cosmos.network",
         "x": "https://x.com/cosmoshub",
         "telegram": "https://t.me/CosmosOG",
-        "discord": "https://discord.com/invite/interchain"
+        "discord": "https://discord.com/invite/interchain",
+        "reddit": "https://www.reddit.com/r/cosmosnetwork/"
       },
       "type_asset": "sdk.coin"
     },


### PR DESCRIPTION
Adds a Reddit link to the ATOM asset's `socials` object in `cosmoshub/assetlist.json`.

- `reddit`: https://www.reddit.com/r/cosmosnetwork/

Valid per `assetlist.schema.json` (`socials` permits website, x, telegram, discord, github, medium, reddit). Existing entries unchanged.