### PR TITLE
chore(injective): add INJ telegram, discord, and reddit socials

### DIFF
--- a/injective/assetlist.json
+++ b/injective/assetlist.json
@@ -32,7 +32,10 @@
       ],
       "socials": {
         "website": "https://injective.com/",
-        "x": "https://x.com/Injective_"
+        "x": "https://x.com/Injective_",
+        "telegram": "https://t.me/joininjective",
+        "discord": "https://discord.com/invite/injective",
+        "reddit": "https://www.reddit.com/r/injective/"
       },
       "type_asset": "sdk.coin"
     },


### PR DESCRIPTION
Adds Telegram, Discord, and Reddit links to the INJ asset's `socials` object in `injective/assetlist.json`.

- `telegram`: https://t.me/joininjective
- `discord`: https://discord.com/invite/injective
- `reddit`: https://www.reddit.com/r/injective/

All keys are valid per `assetlist.schema.json` (`socials` permits website, x, telegram, discord, github, medium, reddit). Existing `website` and `x` entries are unchanged.