### PR TITLE
fix(injective): correct INJ x (twitter) social URL

### DIFF
--- a/injective/assetlist.json
+++ b/injective/assetlist.json
@@ -32,7 +32,7 @@
       ],
       "socials": {
         "website": "https://injective.com/",
-        "x": "https://x.com/Injective_",
+        "x": "https://x.com/Injective",
         "telegram": "https://t.me/joininjective",
         "discord": "https://discord.com/invite/injective",
         "reddit": "https://www.reddit.com/r/injective/"


### PR DESCRIPTION
Corrects the INJ asset's `x` social link in `injective/assetlist.json`.

- Before: https://x.com/Injective_
- After: https://x.com/Injective

The trailing underscore was incorrect; the official Injective X handle is `@Injective`. No other fields changed.