### PR TITLE
fix(chihuahua): remove dead RPC/REST/gRPC endpoints (7 providers)

### DIFF
--- a/chihuahua/chain.json
+++ b/chihuahua/chain.json
@@ -131,24 +131,8 @@
         "provider": "Chihuahua"
       },
       {
-        "address": "https://chihua.rpc.m.stavr.tech",
-        "provider": "🔥STAVR🔥"
-      },
-      {
-        "address": "https://rpc.lavenderfive.com:443/chihuahua",
-        "provider": "Lavender.Five Nodes 🐝"
-      },
-      {
-        "address": "https://rpc.huahua.bh.rocks",
-        "provider": "BlockHunters 🎯"
-      },
-      {
         "address": "https://chihuahua-rpc.kleomedes.network",
         "provider": "Kleomedes"
-      },
-      {
-        "address": "https://rpc-chihuahua.pupmos.network",
-        "provider": "PUPMØS"
       },
       {
         "address": "https://chihuahua-mainnet-rpc.autostake.com:443",
@@ -161,14 +145,6 @@
       {
         "address": "https://rpc.chihuahua.validatus.com",
         "provider": "Validatus"
-      },
-      {
-        "address": "https://chihuahua.rpc.nodeshub.online:443",
-        "provider": "NodesHub"
-      },
-      {
-        "address": "https://chihuahua-rpc.chainroot.io",
-        "provider": "Chainroot"
       },
       {
         "address": "https://chihuahua.api.pocket.network",
@@ -185,24 +161,12 @@
         "provider": "Chihuahua"
       },
       {
-        "address": "https://chihua.api.m.stavr.tech",
-        "provider": "🔥STAVR🔥"
-      },
-      {
         "address": "https://chihuahua-api.polkachu.com",
         "provider": "Polkachu"
       },
       {
-        "address": "https://rest.lavenderfive.com:443/chihuahua",
-        "provider": "Lavender.Five Nodes 🐝"
-      },
-      {
         "address": "https://chihuahua-api.kleomedes.network",
         "provider": "Kleomedes"
-      },
-      {
-        "address": "https://api-chihuahua.pupmos.network",
-        "provider": "PUPMØS"
       },
       {
         "address": "https://chihuahua-mainnet-lcd.autostake.com:443",
@@ -215,14 +179,6 @@
       {
         "address": "https://api.chihuahua.validatus.com",
         "provider": "Validatus"
-      },
-      {
-        "address": "https://chihuahua.api.nodeshub.online:443",
-        "provider": "NodesHub"
-      },
-      {
-        "address": "https://chihuahua-api.chainroot.io",
-        "provider": "Chainroot"
       },
       {
         "address": "https://chihuahua.api.pocket.network",
@@ -239,14 +195,6 @@
         "provider": "Lavender.Five Nodes 🐝"
       },
       {
-        "address": "chihua.grpc.m.stavr.tech:108",
-        "provider": "🔥STAVR🔥"
-      },
-      {
-        "address": "grpc-chihuahua.cosmos-spaces.cloud:2290",
-        "provider": "Cosmos Spaces"
-      },
-      {
         "address": "chihuahua-mainnet-grpc.autostake.com:443",
         "provider": "AutoStake 🛡️ Slash Protected"
       },
@@ -257,14 +205,6 @@
       {
         "address": "grpc.chihuahua.validatus.com:443",
         "provider": "Validatus"
-      },
-      {
-        "address": "chihuahua.grpc.nodeshub.online",
-        "provider": "Nodes Hub"
-      },
-      {
-        "address": "chihuahua-grpc.chainroot.io:443",
-        "provider": "Chainroot"
       }
     ]
   },


### PR DESCRIPTION
Removes **15 unreachable endpoints** (7 providers) from `chihuahua/chain.json`, verified 2026-07-21. RPC 13→7, REST 12→7, gRPC 9→5.

### DNS-dead (NXDOMAIN — confirmed via Google public resolver, Status 3)
| Provider | Removed |
|---|---|
| PUPMØS | rpc, rest |
| Chainroot | rpc, rest, grpc |
| NodesHub | rpc, rest, grpc |
| 🔥STAVR🔥 | grpc |
| Cosmos Spaces | grpc |

### Chain-specific persistent failures
- **Lavender.Five** (rpc, rest) — persistent HTTP 503 on both retries, while their cosmoshub/osmosis endpoints return 200 → chihuahua node down (not infra-wide).
- **🔥STAVR🔥** (rpc, rest) — persistent HTTP 502 on both retries.
- **BlockHunters** (rpc) — the entire `bh.rocks` DNS zone returns SERVFAIL (unreachable by any resolver).

### Kept (verified alive / non-removal-grade)
Chihuahua official, Kleomedes, Validatus, Polkachu (all 200), Pocket (rpc 200), Allnodes/publicnode (HTTP 403 = bot-protection, not dead). All remaining gRPC hosts TCP-reachable.

**Note:** AutoStake endpoints (rpc/rest/grpc) were intentionally left in place — they 404 registry-wide, better addressed in a separate registry-wide sweep than a single-chain PR.