### PR TITLE
fix: remove dead Cosmos Spaces provider endpoints registry-wide (15 chains)

### DIFF
--- a/bandchain/chain.json
+++ b/bandchain/chain.json
@@ -176,10 +176,6 @@
         "provider": "Stakeflow"
       },
       {
-        "address": "https://rpc-band.cosmos-spaces.cloud",
-        "provider": "Cosmos Spaces"
-      },
-      {
         "address": "https://band-rpc.w3coins.io",
         "provider": "w3coins"
       },
@@ -216,10 +212,6 @@
       {
         "address": "https://band.ibs.team:443/api",
         "provider": "Inter Blockchain Services"
-      },
-      {
-        "address": "https://api-band.cosmos-spaces.cloud",
-        "provider": "Cosmos Spaces"
       },
       {
         "address": "https://band.api.m.stavr.tech",
@@ -266,10 +258,6 @@
       {
         "address": "bandchain-mainnet-grpc.autostake.com:443",
         "provider": "AutoStake 🛡️ Slash Protected"
-      },
-      {
-        "address": "grpc-band.cosmos-spaces.cloud:2240",
-        "provider": "Cosmos Spaces"
       },
       {
         "address": "grpc-band-01.stakeflow.io:2502",

--- a/comdex/chain.json
+++ b/comdex/chain.json
@@ -163,10 +163,6 @@
         "provider": "Lavender.Five Nodes 🐝"
       },
       {
-        "address": "https://rpc-comdex.cosmos-spaces.cloud",
-        "provider": "Cosmos Spaces"
-      },
-      {
         "address": "https://comdex-mainnet-rpc.autostake.com:443",
         "provider": "AutoStake 🛡️ Slash Protected"
       },
@@ -221,10 +217,6 @@
         "provider": "Lavender.Five Nodes 🐝"
       },
       {
-        "address": "https://api-comdex.cosmos-spaces.cloud",
-        "provider": "Cosmos Spaces"
-      },
-      {
         "address": "https://comdex-mainnet-lcd.autostake.com:443",
         "provider": "AutoStake 🛡️ Slash Protected"
       },
@@ -269,10 +261,6 @@
       {
         "address": "comdex.grpc.m.stavr.tech:104",
         "provider": "🔥STAVR🔥"
-      },
-      {
-        "address": "grpc-comdex.cosmos-spaces.cloud:2300",
-        "provider": "Cosmos Spaces"
       },
       {
         "address": "comdex.lavenderfive.com:443",

--- a/composable/chain.json
+++ b/composable/chain.json
@@ -238,10 +238,6 @@
         "provider": "AutoStake 🛡️ Slash Protected"
       },
       {
-        "address": "grpc-centauri.cosmos-spaces.cloud:1120",
-        "provider": "Cosmos Spaces"
-      },
-      {
         "address": "picasso.lavenderfive.com:443",
         "provider": "Lavender.Five Nodes 🐝"
       },

--- a/crescent/chain.json
+++ b/crescent/chain.json
@@ -115,10 +115,6 @@
         "provider": "AutoStake 🛡️ Slash Protected"
       },
       {
-        "address": "https://rpc-crescent.cosmos-spaces.cloud",
-        "provider": "Cosmos Spaces"
-      },
-      {
         "address": "https://rpc-crescent-01.stakeflow.io",
         "provider": "Stakeflow"
       },
@@ -153,10 +149,6 @@
         "provider": "Stakin"
       },
       {
-        "address": "https://api-crescent.cosmos-spaces.cloud",
-        "provider": "Cosmos Spaces"
-      },
-      {
         "address": "https://crescent-mainnet-lcd.autostake.com:443",
         "provider": "AutoStake 🛡️ Slash Protected"
       },
@@ -185,10 +177,6 @@
       {
         "address": "crescent-mainnet-grpc.autostake.com:443",
         "provider": "AutoStake 🛡️ Slash Protected"
-      },
-      {
-        "address": "grpc-crescent.cosmos-spaces.cloud:2270",
-        "provider": "Cosmos Spaces"
       },
       {
         "address": "grpc-crescent-01.stakeflow.io:1402",

--- a/cryptoorgchain/chain.json
+++ b/cryptoorgchain/chain.json
@@ -113,10 +113,6 @@
         "provider": "w3coins"
       },
       {
-        "address": "https://rpc-cryptoorg.cosmos-spaces.cloud",
-        "provider": "Cosmos Spaces"
-      },
-      {
         "address": "https://cro-chain-rpc.publicnode.com:443",
         "provider": "Allnodes ⚡️ Nodes & Staking"
       },
@@ -143,10 +139,6 @@
         "provider": "w3coins"
       },
       {
-        "address": "https://api-cryptoorg.cosmos-spaces.cloud",
-        "provider": "Cosmos Spaces"
-      },
-      {
         "address": "https://cro-chain-rest.publicnode.com",
         "provider": "Allnodes ⚡️ Nodes & Staking"
       }
@@ -163,10 +155,6 @@
       {
         "address": "cryptocom-grpc.w3coins.io:20290",
         "provider": "w3coins"
-      },
-      {
-        "address": "grpc-cryptoorg.cosmos-spaces.cloud:1160",
-        "provider": "Cosmos Spaces"
       },
       {
         "address": "cro-chain-grpc.publicnode.com:443",

--- a/evmos/chain.json
+++ b/evmos/chain.json
@@ -318,10 +318,6 @@
         "provider": "Lavender.Five Nodes 🐝"
       },
       {
-        "address": "grpc-evmos.cosmos-spaces.cloud:1190",
-        "provider": "Cosmos Spaces"
-      },
-      {
         "address": "evmos-grpc.polkachu.com:13490",
         "provider": "Polkachu"
       },

--- a/humans/chain.json
+++ b/humans/chain.json
@@ -260,10 +260,6 @@
         "provider": "PPNV Service"
       },
       {
-        "address": "https://grpc-humans.cosmos-spaces.cloud:1190",
-        "provider": "StakePool"
-      },
-      {
         "address": "humans-grpc.noders.services:21090",
         "provider": "[NODERS]TEAM"
       },

--- a/migaloo/chain.json
+++ b/migaloo/chain.json
@@ -100,10 +100,6 @@
         "provider": "Polkachu"
       },
       {
-        "address": "https://rpc-migaloo.cosmos-spaces.cloud",
-        "provider": "Cosmos Spaces"
-      },
-      {
         "address": "https://migaloo-rpc.kleomedes.network:443",
         "provider": "Kleomedes"
       },
@@ -116,10 +112,6 @@
       {
         "address": "https://migaloo-api.polkachu.com:443",
         "provider": "Polkachu"
-      },
-      {
-        "address": "https://api-migaloo.cosmos-spaces.cloud",
-        "provider": "Cosmos Spaces"
       },
       {
         "address": "https://migaloo-api.kleomedes.network:443",
@@ -138,10 +130,6 @@
       {
         "address": "whitewhale-mainnet-grpc.autostake.com:443",
         "provider": "AutoStake 🛡️ Slash Protected"
-      },
-      {
-        "address": "grpc-migaloo.cosmos-spaces.cloud:4810",
-        "provider": "Cosmos Spaces"
       },
       {
         "address": "migaloo-grpc.publicnode.com:443",

--- a/nolus/chain.json
+++ b/nolus/chain.json
@@ -179,10 +179,6 @@
         "provider": "w3coins"
       },
       {
-        "address": "https://rpc-nolus.cosmos-spaces.cloud",
-        "provider": "Cosmos Spaces"
-      },
-      {
         "address": "https://nolus-rpc.publicnode.com:443",
         "provider": "Allnodes ⚡️ Nodes & Staking"
       },
@@ -203,10 +199,6 @@
       {
         "address": "https://rest.lavenderfive.com:443/nolus",
         "provider": "Lavender.Five Nodes 🐝"
-      },
-      {
-        "address": "https://api-nolus.cosmos-spaces.cloud",
-        "provider": "Cosmos Spaces"
       },
       {
         "address": "https://nolus.api.liveraven.net",
@@ -257,10 +249,6 @@
       {
         "address": "grpc-nolus.architectnodes.com:1443",
         "provider": "Architect Nodes"
-      },
-      {
-        "address": "grpc-nolus.cosmos-spaces.cloud:1190",
-        "provider": "Cosmos Spaces"
       },
       {
         "address": "nolus.grpc.kjnodes.com:14390",

--- a/omniflixhub/chain.json
+++ b/omniflixhub/chain.json
@@ -149,10 +149,6 @@
         "provider": "Staketab"
       },
       {
-        "address": "https://rpc-omniflixhub.cosmos-spaces.cloud",
-        "provider": "Cosmos Spaces"
-      },
-      {
         "address": "https://omniflix-rpc.dakshavalidator.in",
         "provider": "Daksha Validator"
       },
@@ -185,10 +181,6 @@
       {
         "address": "https://rest.lavenderfive.com:443/omniflixhub",
         "provider": "Lavender.Five Nodes 🐝"
-      },
-      {
-        "address": "https://api-omniflixhub.cosmos-spaces.cloud",
-        "provider": "Cosmos Spaces"
       },
       {
         "address": "https://api.omniflix.silentvalidator.com/",
@@ -247,10 +239,6 @@
       {
         "address": "omniflixhub.lavenderfive.com:443",
         "provider": "Lavender.Five Nodes 🐝"
-      },
-      {
-        "address": "grpc-omniflixhub.cosmos-spaces.cloud:2230",
-        "provider": "Cosmos Spaces"
       },
       {
         "address": "omniflixhub-mainnet-grpc.autostake.com:443",

--- a/passage/chain.json
+++ b/passage/chain.json
@@ -149,10 +149,6 @@
         "provider": "Lavender.Five Nodes 🐝"
       },
       {
-        "address": "https://rpc-passage.cosmos-spaces.cloud",
-        "provider": "Cosmos Spaces"
-      },
-      {
         "address": "https://rpc-passage.d-stake.xyz",
         "provider": "D-stake"
       },
@@ -203,10 +199,6 @@
         "provider": "Lavender.Five Nodes 🐝"
       },
       {
-        "address": "https://api-passage.cosmos-spaces.cloud",
-        "provider": "Cosmos Spaces"
-      },
-      {
         "address": "https://passage-api.polkachu.com",
         "provider": "Polkachu"
       },
@@ -251,10 +243,6 @@
       {
         "address": "passage-grpc.polkachu.com:15690",
         "provider": "Polkachu"
-      },
-      {
-        "address": "grpc-passage.cosmos-spaces.cloud:2320",
-        "provider": "Cosmos Spaces"
       },
       {
         "address": "passage-mainnet-grpc.autostake.com:443",

--- a/persistence/chain.json
+++ b/persistence/chain.json
@@ -174,10 +174,6 @@
         "provider": "Architect Nodes"
       },
       {
-        "address": "https://rpc-persistence.cosmos-spaces.cloud",
-        "provider": "Cosmos Spaces"
-      },
-      {
         "address": "https://persistence-mainnet-rpc.cosmonautstakes.com",
         "provider": "Cosmonaut Stakes"
       },
@@ -254,10 +250,6 @@
       {
         "address": "https://persistence-api.polkachu.com",
         "provider": "Polkachu"
-      },
-      {
-        "address": "https://api-persistence.cosmos-spaces.cloud",
-        "provider": "Cosmos Spaces"
       },
       {
         "address": "https://persistence-api.kleomedes.network",
@@ -348,10 +340,6 @@
       {
         "address": "grpc.persistence.posthuman.digital:80",
         "provider": "POSTHUMAN∞DVS"
-      },
-      {
-        "address": "grpc-persistence.cosmos-spaces.cloud:1180",
-        "provider": "Cosmos Spaces"
       },
       {
         "address": "141.95.33.97:9090",

--- a/quasar/chain.json
+++ b/quasar/chain.json
@@ -139,10 +139,6 @@
         "provider": "Enigma"
       },
       {
-        "address": "https://rpc-quasar.cosmos-spaces.cloud",
-        "provider": "Cosmos Spaces"
-      },
-      {
         "address": "https://quasar-mainnet-rpc.autostake.com:443",
         "provider": "AutoStake 🛡️ Slash Protected"
       },
@@ -183,10 +179,6 @@
       {
         "address": "https://quasar-api.polkachu.com",
         "provider": "Polkachu"
-      },
-      {
-        "address": "https://api-quasar.cosmos-spaces.cloud",
-        "provider": "Cosmos Spaces"
       },
       {
         "address": "https://quasar-lcd.enigma-validator.com",
@@ -233,10 +225,6 @@
       {
         "address": "quasar-grpc.polkachu.com:18290",
         "provider": "Polkachu"
-      },
-      {
-        "address": "grpc-quasar.cosmos-spaces.cloud:12890",
-        "provider": "Cosmos Spaces"
       },
       {
         "address": "quasar-mainnet-grpc.autostake.com:443",

--- a/stargaze/chain.json
+++ b/stargaze/chain.json
@@ -152,10 +152,6 @@
         "provider": "c29r3"
       },
       {
-        "address": "https://rpc-stargaze.cosmos-spaces.cloud",
-        "provider": "Cosmos Spaces"
-      },
-      {
         "address": "https://stargaze.ibs.team:443/rpc",
         "provider": "Inter Blockchain Services"
       },
@@ -242,10 +238,6 @@
         "provider": "D-stake"
       },
       {
-        "address": "https://api-stargaze.cosmos-spaces.cloud",
-        "provider": "Cosmos Spaces"
-      },
-      {
         "address": "https://api.stargaze.silentvalidator.com/",
         "provider": "silent"
       },
@@ -302,10 +294,6 @@
       {
         "address": "stargaze-mainnet-grpc.autostake.com:443",
         "provider": "AutoStake 🛡️ Slash Protected"
-      },
-      {
-        "address": "grpc-stargaze.cosmos-spaces.cloud:1150",
-        "provider": "Cosmos Spaces"
       },
       {
         "address": "https://stargaze-grpc.ramuchi.tech:9090",

--- a/terra2/chain.json
+++ b/terra2/chain.json
@@ -156,10 +156,6 @@
         "provider": "Stakeflow"
       },
       {
-        "address": "https://rpc-terra.cosmos-spaces.cloud",
-        "provider": "Cosmos Spaces"
-      },
-      {
         "address": "https://terra-phoenix-rpc.highstakes.ch",
         "provider": "High Stakes 🇨🇭"
       },
@@ -246,10 +242,6 @@
       {
         "address": "grpc-archive-terra.r93axnodes.cloud:443",
         "provider": "r93AX Nodes"
-      },
-      {
-        "address": "grpc-terra.cosmos-spaces.cloud:2690",
-        "provider": "Cosmos Spaces"
       },
       {
         "address": "grpc-terra-01.stakeflow.io:1102",


### PR DESCRIPTION
Removes **38 dead RPC/REST/gRPC endpoints** for the **Cosmos Spaces** provider across **15 chains**.

### Why
The entire `cosmos-spaces.cloud` domain is gone. Verified 2026-07-21 via Google's public DNS resolver — **NXDOMAIN (Status 3)** on the root domain `cosmos-spaces.cloud` **and all 38 hosts** (confirmed locally too). Nothing under this domain resolves anywhere.

### Scope (per chain: rpc / rest / grpc removed)
| Chain | Removed | Chain | Removed |
|---|---|---|---|
| bandchain | 3 | omniflixhub | 3 |
| comdex | 3 | passage | 3 |
| composable | 1 (grpc) | persistence | 3 |
| crescent | 3 | quasar | 3 |
| cryptoorgchain | 3 | stargaze | 3 |
| evmos | 1 (grpc) | terra2 | 2 (rpc, grpc) |
| humans | 1 (grpc)* | migaloo | 3 |
| nolus | 3 | | |

\* `humans/chain.json` carried a `cosmos-spaces.cloud` gRPC host mislabeled under provider `"StakePool"` — matched and removed by **hostname**, not label.

### Notes
- No chain is left without endpoints — every affected `rpc`/`rest`/`grpc` array retains multiple live providers after removal.
- **chihuahua** also had a Cosmos Spaces gRPC endpoint; it's handled separately in #7841 and excluded here to avoid overlap.
- Diff is deletions-only (−152 / +0).