### PR TITLE
feat: onboard Kleomedes provider manifest

### DIFF
--- a/_providers/provider-allowlist.json
+++ b/_providers/provider-allowlist.json
@@ -18,6 +18,12 @@
       "manifest_url": "https://cumulo.pro/files/.well-known/cosmos-registry.json",
       "status": "active",
       "added_by_pr": 7822
+    },
+    {
+      "name": "Kleomedes",
+      "manifest_url": "https://api.kleomedes.network/.well-known/cosmos-registry.json",
+      "status": "active",
+      "added_by_pr": 0
     }
   ]
 }

--- a/_providers/provider-allowlist.json
+++ b/_providers/provider-allowlist.json
@@ -23,7 +23,7 @@
       "name": "Kleomedes",
       "manifest_url": "https://api.kleomedes.network/.well-known/cosmos-registry.json",
       "status": "active",
-      "added_by_pr": 0
+      "added_by_pr": 7843
     }
   ]
 }


### PR DESCRIPTION
## Summary

Onboard Kleomedes in the provider-manifest allowlist.

* Provider: `Kleomedes`
* Manifest: `https://api.kleomedes.network/.well-known/cosmos-registry.json`
* Status: `active`

The manifest is hosted at the required well-known HTTPS path, is below the 512 KiB limit, and is validated in the source repository against the current `provider-manifest.schema.json`.

It publishes Kleomedes-operated RPC, REST and gRPC endpoints, together with the snapshot services currently offered by Kleomedes.

Provider contact: `marco@kleomed.es`.

This PR establishes `Kleomedes` as the canonical provider name for entries managed through the manifest.
