### PR TITLE
lumera: remove Dungeon RPC/REST endpoints

### DIFF
--- a/lumera/chain.json
+++ b/lumera/chain.json
@@ -128,10 +128,6 @@
         "provider": "AstroStake"
       },
       {
-        "address": "https://lumera-rpc.dungeon.games",
-        "provider": "Dungeon"
-      },
-      {
         "address": "https://lumera-rpc.polkachu.com:443",
         "provider": "Polkachu"
       }
@@ -156,10 +152,6 @@
       {
         "address": "https://lumera-api.linknode.org",
         "provider": "AstroStake"
-      },
-      {
-        "address": "https://lumera-lcd.dungeon.games",
-        "provider": "Dungeon"
       },
       {
         "address": "https://lumera-api.polkachu.com",


### PR DESCRIPTION
Removing our (Dungeon) public Lumera endpoints — `lumera-rpc.dungeon.games` and `lumera-lcd.dungeon.games` — as we have discontinued our Lumera infrastructure. The endpoints are no longer serving.

🤖 Generated with [Claude Code](https://claude.com/claude-code)