### PR TITLE
Add limonatatestnet-osmosistestnet IBC connection

### DIFF
--- a/testnets/_IBC/limonatatestnet-osmosistestnet.json
+++ b/testnets/_IBC/limonatatestnet-osmosistestnet.json
@@ -1,0 +1,33 @@
+{
+  "$schema": "../../ibc_data.schema.json",
+  "chain_1": {
+    "chain_name": "limonatatestnet",
+    "chain_id": "limonata_10777-1",
+    "client_id": "07-tendermint-0",
+    "connection_id": "connection-0"
+  },
+  "chain_2": {
+    "chain_name": "osmosistestnet",
+    "chain_id": "osmo-test-5",
+    "client_id": "07-tendermint-5256",
+    "connection_id": "connection-4584"
+  },
+  "channels": [
+    {
+      "chain_1": {
+        "channel_id": "channel-0",
+        "port_id": "transfer"
+      },
+      "chain_2": {
+        "channel_id": "channel-11808",
+        "port_id": "transfer"
+      },
+      "ordering": "unordered",
+      "version": "ics20-1",
+      "tags": {
+        "preferred": true,
+        "status": "ACTIVE"
+      }
+    }
+  ]
+}


### PR DESCRIPTION
Registers the live IBC connection between the Limonata testnet (`limonatatestnet`, `limonata_10777-1`) and the Osmosis testnet (`osmosistestnet`, `osmo-test-5`).

All IDs verified against live state on both chains (channel `OPEN` on both ends):

| | limonatatestnet | osmosistestnet |
|---|---|---|
| client | `07-tendermint-0` | `07-tendermint-5256` |
| connection | `connection-0` | `connection-4584` |
| channel (transfer) | `channel-0` | `channel-11808` |

Verification:
- Denom trace live on osmo-test-5: `transfer/channel-11808/aLIMO` = `ibc/63FA8DC3426FEDEA61E47FB273E0D68FCC5201B9E3A99EBD42BE120E105583D9` ([LCD](https://lcd.testnet.osmosis.zone/ibc/apps/transfer/v1/denom_traces/63FA8DC3426FEDEA61E47FB273E0D68FCC5201B9E3A99EBD42BE120E105583D9))
- Transfers flowing both directions (LIMO/OSMO pool #1350 exists on osmo-test-5)
- Channel relayed by a Hermes v1.13.3 instance run by the Limonata team

The `limonatatestnet` chain + assetlist are already registered (#7766, #7774).
