### PR TITLE
ritbit: rename display name to Rubin, add codebase metadata

### DIFF
--- a/ritbit/chain.json
+++ b/ritbit/chain.json
@@ -4,10 +4,15 @@
   "status": "live",
   "website": "https://rubin.trade/",
   "network_type": "mainnet",
-  "pretty_name": "RITBIT",
+  "pretty_name": "Rubin",
   "chain_type": "cosmos",
   "chain_id": "ritbit-mainnet",
   "bech32_prefix": "rit",
+  "daemon_name": "ritbitd",
+  "node_home": "$HOME/.ritbit",
+  "key_algos": [
+    "secp256k1"
+  ],
   "slip44": 118,
   "fees": {
     "fee_tokens": [
@@ -34,10 +39,28 @@
       }
     ]
   },
+  "codebase": {
+    "recommended_version": "v27.3",
+    "compatible_versions": [
+      "v27.3"
+    ],
+    "consensus": {
+      "type": "cometbft",
+      "version": "v0.39.3"
+    },
+    "sdk": {
+      "type": "cosmos",
+      "version": "v0.54.3"
+    },
+    "ibc": {
+      "type": "go",
+      "version": "v11.2.0"
+    }
+  },
   "logo_URIs": {
     "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/ritbit/images/ritbit.png"
   },
-  "description": "RITBIT is the network that powers Rubin Trade — a self-custody decentralized exchange for crypto perpetual futures and spot trading.",
+  "description": "Rubin is a self-custody decentralized exchange for crypto perpetual futures and spot trading.",
   "apis": {
     "rpc": [
       {

--- a/ritbit/chain.json
+++ b/ritbit/chain.json
@@ -18,10 +18,10 @@
     "fee_tokens": [
       {
         "denom": "urit",
-        "fixed_min_gas_price": 12500000000,
-        "low_gas_price": 12500000000,
-        "average_gas_price": 12500000000,
-        "high_gas_price": 20000000000
+        "fixed_min_gas_price": 25000000000,
+        "low_gas_price": 25000000000,
+        "average_gas_price": 25000000000,
+        "high_gas_price": 40000000000
       },
       {
         "denom": "uusdc",

--- a/ritbit/chain.json
+++ b/ritbit/chain.json
@@ -40,9 +40,9 @@
     ]
   },
   "codebase": {
-    "recommended_version": "v27.5",
+    "recommended_version": "v27.6",
     "compatible_versions": [
-      "v27.5"
+      "v27.6"
     ],
     "consensus": {
       "type": "cometbft",
@@ -55,6 +55,12 @@
     "ibc": {
       "type": "go",
       "version": "v11.2.0"
+    },
+    "genesis": {
+      "genesis_url": "https://cdn.rubin.trade/scripts/genesis.json"
+    },
+    "binaries": {
+      "linux/amd64": "https://storage.yandexcloud.net/ritbit-upgrade/v27.6/ritbitd-v27.6-linux-amd64.tar.gz?checksum=sha256:9f6134e883fc52e44033b2ba52a90edf705c99799a7b4e885a8dce15938a6502"
     }
   },
   "logo_URIs": {
@@ -93,5 +99,15 @@
     {
       "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/ritbit/images/ritbit.png"
     }
-  ]
+  ],
+  "peers": {
+    "seeds": [],
+    "persistent_peers": [
+      {
+        "id": "f907537d0ea47759e369f7bac5cb2c22be5e3c93",
+        "address": "213.165.223.41:26656",
+        "provider": "Rubin Lab"
+      }
+    ]
+  }
 }

--- a/ritbit/chain.json
+++ b/ritbit/chain.json
@@ -40,9 +40,9 @@
     ]
   },
   "codebase": {
-    "recommended_version": "v27.3",
+    "recommended_version": "v27.5",
     "compatible_versions": [
-      "v27.3"
+      "v27.5"
     ],
     "consensus": {
       "type": "cometbft",


### PR DESCRIPTION
The network is publicly branded **Rubin** (https://rubin.trade). This PR aligns the display name and fills in previously missing metadata.

### Display name

- `pretty_name`: `RITBIT` → `Rubin`
- `description` reworded accordingly

`chain_name`, `chain_id` (`ritbit-mainnet`) and `bech32_prefix` (`rit`) are intentionally left unchanged — the chain id cannot be altered without a network restart, so the mismatch between the display name and the identifiers is expected and permanent.

### Added metadata

- `daemon_name`: `ritbitd`
- `node_home`: `$HOME/.ritbit`
- `key_algos`: `["secp256k1"]`
- `codebase`: `recommended_version` `v27.3`, plus consensus / sdk / ibc versions

Values are taken from the running mainnet (`/cosmos/base/tendermint/v1beta1/node_info` reports app `27.3`, Cosmos SDK `v0.54.3`) and from the node binary defaults.

`codebase.git_repo` is omitted because the source repository is not public.

### Endpoints

All endpoints already listed in the entry were verified while preparing this change:

- `https://rpc.mainnet.rubin.trade` — HTTP 200
- `https://rest.mainnet.rubin.trade` — HTTP 200
- `grpc.mainnet.rubin.trade:443` — responds to `cosmos.base.tendermint.v1beta1.Service/GetNodeInfo`