### PR TITLE
Add Zerone mainnet metadata

### DIFF
--- a/zerone/assetlist.json
+++ b/zerone/assetlist.json
@@ -1,0 +1,52 @@
+{
+  "$schema": "../assetlist.schema.json",
+  "chain_name": "zerone",
+  "assets": [
+    {
+      "description": "The native staking and governance token of Zerone",
+      "denom_units": [
+        {
+          "denom": "uzrn",
+          "exponent": 0,
+          "aliases": [
+            "microzrn"
+          ]
+        },
+        {
+          "denom": "mzrn",
+          "exponent": 3,
+          "aliases": [
+            "millizrn"
+          ]
+        },
+        {
+          "denom": "zrn",
+          "exponent": 6
+        }
+      ],
+      "type_asset": "sdk.coin",
+      "base": "uzrn",
+      "name": "Zerone",
+      "display": "zrn",
+      "symbol": "ZRN",
+      "images": [
+        {
+          "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/zerone/images/zrn.svg",
+          "theme": {
+            "circle": false
+          }
+        }
+      ],
+      "keywords": [
+        "ai",
+        "agents",
+        "knowledge",
+        "provenance"
+      ],
+      "socials": {
+        "website": "https://zerone.ai/",
+        "github": "https://github.com/cambridgetcg/zerone-core"
+      }
+    }
+  ]
+}

--- a/zerone/chain.json
+++ b/zerone/chain.json
@@ -1,0 +1,109 @@
+{
+  "$schema": "../chain.schema.json",
+  "chain_name": "zerone",
+  "status": "live",
+  "network_type": "mainnet",
+  "website": "https://zerone.ai/",
+  "pretty_name": "Zerone",
+  "chain_type": "cosmos",
+  "chain_id": "zerone-1",
+  "bech32_prefix": "zrn",
+  "bech32_config": {
+    "bech32PrefixAccAddr": "zrn",
+    "bech32PrefixAccPub": "zrnpub",
+    "bech32PrefixValAddr": "zrnvaloper",
+    "bech32PrefixValPub": "zrnvaloperpub",
+    "bech32PrefixConsAddr": "zrnvalcons",
+    "bech32PrefixConsPub": "zrnvalconspub"
+  },
+  "daemon_name": "zeroned",
+  "node_home": "$HOME/.zeroned",
+  "key_algos": [
+    "secp256k1"
+  ],
+  "slip44": 118,
+  "fees": {
+    "fee_tokens": [
+      {
+        "denom": "uzrn",
+        "fixed_min_gas_price": 0.025,
+        "low_gas_price": 0.025,
+        "average_gas_price": 1,
+        "high_gas_price": 1.2,
+        "gas_costs": {
+          "cosmos_send": 200000
+        }
+      }
+    ]
+  },
+  "staking": {
+    "staking_tokens": [
+      {
+        "denom": "uzrn"
+      }
+    ],
+    "lock_duration": {
+      "time": "1814400s"
+    }
+  },
+  "codebase": {
+    "git_repo": "https://github.com/cambridgetcg/zerone-core",
+    "language": {
+      "type": "go",
+      "version": "1.24.0"
+    },
+    "sdk": {
+      "type": "cosmos",
+      "version": "v0.50.15",
+      "repo": "https://github.com/cosmos/cosmos-sdk"
+    },
+    "consensus": {
+      "type": "cometbft",
+      "version": "v0.38.20",
+      "repo": "https://github.com/cometbft/cometbft"
+    },
+    "genesis": {
+      "name": "zerone-1",
+      "genesis_url": "https://raw.githubusercontent.com/cambridgetcg/zerone-core/main/deploy/mainnet/artifacts/genesis.json"
+    }
+  },
+  "images": [
+    {
+      "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/zerone/images/zrn.svg",
+      "theme": {
+        "circle": false
+      }
+    }
+  ],
+  "description": "Zerone is a Cosmos SDK blockchain that records challenged agent work, knowledge, and provenance. ZRN is its native staking, governance, and fee token.",
+  "peers": {
+    "seeds": [
+      {
+        "id": "ed8c8d49dc23f3478b2f3eddb49b8f8087828b6e",
+        "address": "169.155.55.44:26656",
+        "provider": "Zerone"
+      }
+    ]
+  },
+  "apis": {
+    "rpc": [
+      {
+        "address": "http://169.155.55.44:26657",
+        "provider": "Zerone"
+      }
+    ]
+  },
+  "explorers": [
+    {
+      "kind": "Zerone Dashboard",
+      "url": "https://zerone.ai/"
+    }
+  ],
+  "keywords": [
+    "ai",
+    "agents",
+    "knowledge",
+    "provenance",
+    "proof-of-truth"
+  ]
+}

--- a/zerone/images/zrn.svg
+++ b/zerone/images/zrn.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64">
+  <rect width="64" height="64" rx="16" fill="#0b0b10"/>
+  <circle cx="32" cy="32" r="20" fill="none" stroke="#b997ff" stroke-width="2"/>
+  <path d="M32 12v40M12 32h40" stroke="#dfff72" stroke-width="2"/>
+  <circle cx="32" cy="32" r="6" fill="#b997ff"/>
+</svg>


### PR DESCRIPTION
## Summary

- adds Zerone mainnet chain and native ZRN asset metadata
- includes the verified genesis, public CometBFT RPC, seed, fee token, staking lock duration, and source versions
- adds the ZRN SVG asset

## Validation

- @chain-registry/cli@1.47.0: all 2,235 tests passed
- Zerone source fact checker passed against the committed genesis and deployment configuration
- bundle source: https://github.com/cambridgetcg/zerone-core/tree/main/integrations/chain-registry/zerone

## Evidence and scope

- source: https://github.com/cambridgetcg/zerone-core
- genesis: https://raw.githubusercontent.com/cambridgetcg/zerone-core/main/deploy/mainnet/artifacts/genesis.json
- live dashboard: https://zerone.ai/
- zrn HRP registration proposal: https://github.com/satoshilabs/slips/pull/2039

The metadata intentionally omits REST/gRPC, IBC channels, snapshots, binaries, and a recommended version until those claims have stable public evidence. SLIP-0044 value 118 is presented as the shared Cosmos derivation path, not a Zerone-owned allocation.