### PR TITLE
feat(_IBC): add noble <-> ritbit transfer channel

### DIFF
--- a/_IBC/noble-ritbit.json
+++ b/_IBC/noble-ritbit.json
@@ -1,0 +1,33 @@
+{
+  "$schema": "../ibc_data.schema.json",
+  "chain_1": {
+    "chain_name": "noble",
+    "chain_id": "noble-1",
+    "client_id": "07-tendermint-228",
+    "connection_id": "connection-212"
+  },
+  "chain_2": {
+    "chain_name": "ritbit",
+    "chain_id": "ritbit-mainnet",
+    "client_id": "07-tendermint-0",
+    "connection_id": "connection-0"
+  },
+  "channels": [
+    {
+      "chain_1": {
+        "channel_id": "channel-607",
+        "port_id": "transfer"
+      },
+      "chain_2": {
+        "channel_id": "channel-0",
+        "port_id": "transfer"
+      },
+      "ordering": "unordered",
+      "version": "ics20-1",
+      "tags": {
+        "preferred": true,
+        "status": "ACTIVE"
+      }
+    }
+  ]
+}


### PR DESCRIPTION
Adds the live ICS-20 path between `noble-1` and `ritbit-mainnet` so routers and wallets can discover it.

Every field was read from **both ends**, not from one side's explorer view:

| | noble-1 | ritbit-mainnet |
|---|---|---|
| client | `07-tendermint-228` | `07-tendermint-0` |
| connection | `connection-212` | `connection-0` |
| channel | `channel-607` | `channel-0` |

Both ends report `STATE_OPEN`, `ics20-1`, `ORDER_UNORDERED`, and each names the other as its counterparty.

The `ritbit` chain entry is being updated in parallel in #7858 (display name and codebase version); this PR is independent of it.