### PR TITLE
_IBC: add noble-ritbit

### DIFF
--- a/_IBC/noble-ritbit.json
+++ b/_IBC/noble-ritbit.json
@@ -1,0 +1,33 @@
+{
+  "$schema": "../ibc_data.schema.json",
+  "chain_1": {
+    "chain_name": "noble",
+    "chain_id": "noble-1",
+    "client_id": "07-tendermint-228",
+    "connection_id": "connection-212"
+  },
+  "chain_2": {
+    "chain_name": "ritbit",
+    "chain_id": "ritbit-mainnet",
+    "client_id": "07-tendermint-0",
+    "connection_id": "connection-0"
+  },
+  "channels": [
+    {
+      "chain_1": {
+        "channel_id": "channel-607",
+        "port_id": "transfer"
+      },
+      "chain_2": {
+        "channel_id": "channel-0",
+        "port_id": "transfer"
+      },
+      "ordering": "unordered",
+      "version": "ics20-1",
+      "tags": {
+        "preferred": true,
+        "status": "ACTIVE"
+      }
+    }
+  ]
+}


### PR DESCRIPTION
Adds the IBC path metadata for the transfer channel between Noble and RITBIT (Rubin).

The channel is open on both ends and carrying packets. Values verified against both chains:

| | noble-1 | ritbit-mainnet |
| --- | --- | --- |
| client | `07-tendermint-228` | `07-tendermint-0` |
| connection | `connection-212` | `connection-0` |
| channel | `channel-607` | `channel-0` |

Both channels report `STATE_OPEN` and name each other as counterparty:

```
$ curl -s https://noble-api.polkachu.com/ibc/core/channel/v1/channels/channel-607/ports/transfer
{"state":"STATE_OPEN","counterparty":{"port_id":"transfer","channel_id":"channel-0"},"connection_hops":["connection-212"]}

$ curl -s https://rest.mainnet.rubin.trade/ibc/core/channel/v1/channels
channel-0 transfer state=STATE_OPEN counterparty=channel-607 conn=connection-0
```

The `ritbit` chain entry is already in the registry; a separate PR (#7858) updates its display name and codebase metadata.

🤖 Generated with [Claude Code](https://claude.com/claude-code)