### PR TITLE
Update Unification upgrades and binary versions

### DIFF
--- a/testnets/unificationtestnet/chain.json
+++ b/testnets/unificationtestnet/chain.json
@@ -37,34 +37,37 @@
   },
   "codebase": {
     "git_repo": "https://github.com/unification-com/mainchain",
-    "recommended_version": "v1.11.0",
+    "recommended_version": "v1.12.0",
     "compatible_versions": [
-      "v1.11.0"
+      "v1.12.0"
     ],
     "binaries": {
-      "linux/amd64": "https://github.com/unification-com/mainchain/releases/download/v1.11.0/und_v1.11.0_linux_x86_64.tar.gz",
-      "darwin/amd64": "https://github.com/unification-com/mainchain/releases/download/v1.11.0/und_v1.11.0_darwin_x86_64.tar.gz",
-      "windows/amd64": "https://github.com/unification-com/mainchain/releases/download/v1.11.0/und_v1.11.0_windows_x86_64.tar.gz"
+      "linux/amd64": "https://github.com/unification-com/mainchain/releases/download/v1.12.0/und_v1.12.0_linux_x86_64.tar.gz",
+      "linux/arm64": "https://github.com/unification-com/mainchain/releases/download/v1.12.0/und_v1.12.0_linux_arm64.tar.gz",
+      "darwin/amd64": "https://github.com/unification-com/mainchain/releases/download/v1.12.0/und_v1.12.0_darwin_x86_64.tar.gz",
+      "darwin/arm64": "https://github.com/unification-com/mainchain/releases/download/v1.12.0/und_v1.12.0_darwin_arm64.tar.gz",
+      "windows/amd64": "https://github.com/unification-com/mainchain/releases/download/v1.12.0/und_v1.12.0_windows_x86_64.tar.gz",
+      "windows/arm64": "https://github.com/unification-com/mainchain/releases/download/v1.12.0/und_v1.12.0_windows_arm64.tar.gz"
     },
     "consensus": {
       "type": "cometbft",
-      "version": "0.38.12"
+      "version": "0.38.17"
     },
     "genesis": {
-      "genesis_url": "https://raw.githubusercontent.com/unification-com/mainnet/master/latest/genesis.json"
+      "genesis_url": "https://raw.githubusercontent.com/unification-com/testnet/master/latest/genesis.json"
     },
     "sdk": {
       "type": "cosmos",
-      "version": "0.50.13"
+      "version": "0.53.4"
     },
     "ibc": {
       "type": "go",
-      "version": "8.7.0"
+      "version": "10.3.0"
     },
     "cosmwasm": {
       "enabled": false
     },
-    "tag": "v1.11.0"
+    "tag": "v1.12.0"
   },
   "images": [
     {

--- a/testnets/unificationtestnet/versions.json
+++ b/testnets/unificationtestnet/versions.json
@@ -173,6 +173,72 @@
         "type": "go",
         "version": "8.7.0"
       }
+    },
+    {
+      "name": "7-taryon",
+      "tag": "v1.12.0",
+      "proposal": 47,
+      "height": 19793940,
+      "consensus": {
+        "type": "cometbft",
+        "version": "0.38.17"
+      },
+      "recommended_version": "v1.12.0",
+      "compatible_versions": [
+        "v1.12.0"
+      ],
+      "binaries": {
+        "linux/amd64": "https://github.com/unification-com/mainchain/releases/download/v1.12.0/und_v1.12.0_linux_x86_64.tar.gz",
+        "linux/arm64": "https://github.com/unification-com/mainchain/releases/download/v1.12.0/und_v1.12.0_linux_arm64.tar.gz",
+        "darwin/amd64": "https://github.com/unification-com/mainchain/releases/download/v1.12.0/und_v1.12.0_darwin_x86_64.tar.gz",
+        "darwin/arm64": "https://github.com/unification-com/mainchain/releases/download/v1.12.0/und_v1.12.0_darwin_arm64.tar.gz",
+        "windows/amd64": "https://github.com/unification-com/mainchain/releases/download/v1.12.0/und_v1.12.0_windows_x86_64.tar.gz",
+        "windows/arm64": "https://github.com/unification-com/mainchain/releases/download/v1.12.0/und_v1.12.0_windows_arm64.tar.gz"
+      },
+      "sdk": {
+        "type": "cosmos",
+        "version": "0.53.4"
+      },
+      "cosmwasm": {
+        "enabled": false
+      },
+      "ibc": {
+        "type": "go",
+        "version": "10.3.0"
+      }
+    },
+    {
+      "name": "8-vaxildan",
+      "tag": "v1.13.0",
+      "proposal": 50,
+      "height": 25638900,
+      "consensus": {
+        "type": "cometbft",
+        "version": "0.39.4"
+      },
+      "recommended_version": "v1.13.0",
+      "compatible_versions": [
+        "v1.13.0"
+      ],
+      "binaries": {
+        "linux/amd64": "https://github.com/unification-com/mainchain/releases/download/v1.13.0/und_v1.13.0_linux_x86_64.tar.gz",
+        "linux/arm64": "https://github.com/unification-com/mainchain/releases/download/v1.13.0/und_v1.13.0_linux_arm64.tar.gz",
+        "darwin/amd64": "https://github.com/unification-com/mainchain/releases/download/v1.13.0/und_v1.13.0_darwin_x86_64.tar.gz",
+        "darwin/arm64": "https://github.com/unification-com/mainchain/releases/download/v1.13.0/und_v1.13.0_darwin_arm64.tar.gz",
+        "windows/amd64": "https://github.com/unification-com/mainchain/releases/download/v1.13.0/und_v1.13.0_windows_x86_64.tar.gz",
+        "windows/arm64": "https://github.com/unification-com/mainchain/releases/download/v1.13.0/und_v1.13.0_windows_arm64.tar.gz"
+      },
+      "sdk": {
+        "type": "cosmos",
+        "version": "0.54.4"
+      },
+      "cosmwasm": {
+        "enabled": false
+      },
+      "ibc": {
+        "type": "go",
+        "version": "11.2.0"
+      }
     }
   ]
 }

--- a/unification/chain.json
+++ b/unification/chain.json
@@ -37,34 +37,37 @@
   },
   "codebase": {
     "git_repo": "https://github.com/unification-com/mainchain",
-    "recommended_version": "v1.11.0",
+    "recommended_version": "v1.12.0",
     "compatible_versions": [
-      "v1.11.0"
+      "v1.12.0"
     ],
     "binaries": {
-      "linux/amd64": "https://github.com/unification-com/mainchain/releases/download/v1.11.0/und_v1.11.0_linux_x86_64.tar.gz",
-      "darwin/amd64": "https://github.com/unification-com/mainchain/releases/download/v1.11.0/und_v1.11.0_darwin_x86_64.tar.gz",
-      "windows/amd64": "https://github.com/unification-com/mainchain/releases/download/v1.11.0/und_v1.11.0_windows_x86_64.tar.gz"
+      "linux/amd64": "https://github.com/unification-com/mainchain/releases/download/v1.12.0/und_v1.12.0_linux_x86_64.tar.gz",
+      "linux/arm64": "https://github.com/unification-com/mainchain/releases/download/v1.12.0/und_v1.12.0_linux_arm64.tar.gz",
+      "darwin/amd64": "https://github.com/unification-com/mainchain/releases/download/v1.12.0/und_v1.12.0_darwin_x86_64.tar.gz",
+      "darwin/arm64": "https://github.com/unification-com/mainchain/releases/download/v1.12.0/und_v1.12.0_darwin_arm64.tar.gz",
+      "windows/amd64": "https://github.com/unification-com/mainchain/releases/download/v1.12.0/und_v1.12.0_windows_x86_64.tar.gz",
+      "windows/arm64": "https://github.com/unification-com/mainchain/releases/download/v1.12.0/und_v1.12.0_windows_arm64.tar.gz"
     },
     "consensus": {
       "type": "cometbft",
-      "version": "0.38.12"
+      "version": "0.38.17"
     },
     "genesis": {
       "genesis_url": "https://raw.githubusercontent.com/unification-com/mainnet/master/latest/genesis.json"
     },
     "sdk": {
       "type": "cosmos",
-      "version": "0.50.13"
+      "version": "0.53.4"
     },
     "ibc": {
       "type": "go",
-      "version": "8.7.0"
+      "version": "10.3.0"
     },
     "cosmwasm": {
       "enabled": false
     },
-    "tag": "v1.11.0"
+    "tag": "v1.12.0"
   },
   "images": [
     {

--- a/unification/versions.json
+++ b/unification/versions.json
@@ -173,6 +173,39 @@
         "type": "go",
         "version": "8.7.0"
       }
+    },
+    {
+      "name": "7-taryon",
+      "tag": "v1.12.0",
+      "proposal": 27,
+      "height": 18055500,
+      "consensus": {
+        "type": "cometbft",
+        "version": "0.38.17"
+      },
+      "recommended_version": "v1.12.0",
+      "compatible_versions": [
+        "v1.12.0"
+      ],
+      "binaries": {
+        "linux/amd64": "https://github.com/unification-com/mainchain/releases/download/v1.12.0/und_v1.12.0_linux_x86_64.tar.gz",
+        "linux/arm64": "https://github.com/unification-com/mainchain/releases/download/v1.12.0/und_v1.12.0_linux_arm64.tar.gz",
+        "darwin/amd64": "https://github.com/unification-com/mainchain/releases/download/v1.12.0/und_v1.12.0_darwin_x86_64.tar.gz",
+        "darwin/arm64": "https://github.com/unification-com/mainchain/releases/download/v1.12.0/und_v1.12.0_darwin_arm64.tar.gz",
+        "windows/amd64": "https://github.com/unification-com/mainchain/releases/download/v1.12.0/und_v1.12.0_windows_x86_64.tar.gz",
+        "windows/arm64": "https://github.com/unification-com/mainchain/releases/download/v1.12.0/und_v1.12.0_windows_arm64.tar.gz"
+      },
+      "sdk": {
+        "type": "cosmos",
+        "version": "0.53.4"
+      },
+      "cosmwasm": {
+        "enabled": false
+      },
+      "ibc": {
+        "type": "go",
+        "version": "10.3.0"
+      }
     }
   ]
 }


### PR DESCRIPTION
Adds the two und releases missing from the registry for both Unification networks.

- 7-taryon (v1.12.0) — shipped Aug/Sep 2025 and was never filed upstream; the registry currently stops at 6-scanlan/v1.11.0 while both chains have run v1.12.0 since.
- 8-vaxildan (v1.13.0) — TestNet upgrade scheduled at height 25638900 (~11 Aug 2026), governance proposal 50, currently in its voting period. The MainNet entry will follow once that window is scheduled.

binaries now lists all six goreleaser targets (linux/darwin/windows × amd64/arm64); previous entries listed amd64 only