### PR TITLE
Add Kava RPC/REST/gRPC endpoints for jjozzietech

### DIFF
--- a/kava/chain.json
+++ b/kava/chain.json
@@ -118,7 +118,7 @@
         "provider": "Polkachu"
       },
       {
-        "address": "https://rpc.jjozzietech.com.au:9443/kava/tendermint",
+        "address": "https://rpc.jjozzietech.com.au:9443/kava/tendermint/",
         "provider": "jjozzietech"
       }
     ],
@@ -148,7 +148,7 @@
         "provider": "Pocket Network"
       },
       {
-        "address": "https://rpc.jjozzietech.com.au:9443/kava/rest",
+        "address": "https://rpc.jjozzietech.com.au:9443/kava/rest/",
         "provider": "jjozzietech"
       }
     ],
@@ -172,10 +172,6 @@
       {
         "address": "https://grpc.kava.nodestake.org",
         "provider": "NodeStake"
-      },
-      {
-        "address": "https://rpc.jjozzietech.com.au:9443/kava/grpc",
-        "provider": "jjozzietech"
       }
     ],
     "evm-http-jsonrpc": [

--- a/kava/chain.json
+++ b/kava/chain.json
@@ -116,6 +116,10 @@
       {
         "address": "https://kava-rpc.polkachu.com:443",
         "provider": "Polkachu"
+      },
+      {
+        "address": "https://rpc.jjozzietech.com.au:9443/kava/tendermint",
+        "provider": "jjozzietech"
       }
     ],
     "rest": [
@@ -142,6 +146,10 @@
       {
         "address": "https://kava.api.pocket.network",
         "provider": "Pocket Network"
+      },
+      {
+        "address": "https://rpc.jjozzietech.com.au:9443/kava/rest",
+        "provider": "jjozzietech"
       }
     ],
     "grpc": [
@@ -164,6 +172,10 @@
       {
         "address": "https://grpc.kava.nodestake.org",
         "provider": "NodeStake"
+      },
+      {
+        "address": "https://rpc.jjozzietech.com.au:9443/kava/grpc",
+        "provider": "jjozzietech"
       }
     ],
     "evm-http-jsonrpc": [


### PR DESCRIPTION
Adding public Kava RPC, REST, and gRPC endpoints operated by jjozzietech (independent Kava validator, homelab-based, Sydney).

Endpoints have been running and internally load-tested since 27 July 2026. Rate-limited to 30 req/sec/IP via Caddy. Both RPC and REST endpoints verified locally against the CI's test paths:

- RPC `/status`: HTTP 200 in 23 ms
- REST `/cosmos/base/tendermint/v1beta1/syncing`: HTTP 200 in 24 ms, `{"syncing":false}`

Landing page and endpoint documentation: https://rpc.jjozzietech.com.au:9443/

Note on non-standard port `:9443` — WAN 443 is claimed by other infrastructure operated by the same team; the RPC is served on 9443 by design. The chain-registry format supports explicit ports in URLs (existing entries such as Polkachu's gRPC endpoint at `:13990` confirm this).