### PR TITLE
fix(provider-sync): retry transient manifest fetches, exit neutral when unreachable

### DIFF
--- a/.github/workflows/sync_provider_manifests.yml
+++ b/.github/workflows/sync_provider_manifests.yml
@@ -116,6 +116,8 @@ jobs:
             const uvNew = (r.unverified||[]).filter(u => addedKeys.has(hbKey(u)));
             const uvExisting = (r.unverified||[]).filter(u => !addedKeys.has(hbKey(u)));
             console.log(`**Sync report** (manifest sha256 \`${(r.manifest_sha256||"").slice(0,12)}\`, fetched ${r.fetched_at})`);
+            // A neutral exit must not read as a clean run: say so loudly when nothing arrived.
+            if (r.error) console.log(`\n> [!WARNING]\n> **No manifest was applied this run.** ${r.error}`);
             console.log(`\n**Added (${r.added.length})**\n${li(r.added)}`);
             console.log(`\n**Updated (${r.updated.length})**\n${li(r.updated)}`);
             console.log(`\n**Removed — absent from manifest (${r.removed.length})**\n${li(r.removed)}`);

--- a/.github/workflows/utility/sync_provider_manifests.mjs
+++ b/.github/workflows/utility/sync_provider_manifests.mjs
@@ -39,7 +39,8 @@ if (!providerName) { console.error('PROVIDER_NAME env var required'); process.ex
 
 const report = { provider: providerName, fetched_at: new Date().toISOString(),
                  manifest_url: null, manifest_sha256: null,
-                 added: [], updated: [], removed: [], retained: [], held_back: [], unverified: [], conflicts: [], skipped_chains: [] };
+                 added: [], updated: [], removed: [], retained: [], held_back: [], unverified: [], conflicts: [], skipped_chains: [],
+                 error: null };   // set when the manifest never arrived, so a neutral exit still shows why
 
 // ---------- 1. Allowlist lookup ----------
 const allowlist = JSON.parse(fs.readFileSync(ALLOWLIST, 'utf8'));
@@ -49,6 +50,30 @@ report.manifest_url = entry.manifest_url;
 const allowedOrigin = new URL(entry.manifest_url).origin;
 
 // ---------- 2. Fetch (size cap, timeout, no cross-origin redirects) ----------
+// Network faults that a provider must fix and that never heal on their own. Retrying them
+// is futile, and letting them exit neutral would strand a provider silently: the run stays
+// green while it quietly stops syncing. EAI_AGAIN is the retryable DNS code and is absent
+// here on purpose; ENOTFOUND is NXDOMAIN, i.e. the manifest host no longer exists.
+const PERMANENT_NET_CODES = new Set([
+  'CERT_HAS_EXPIRED', 'CERT_NOT_YET_VALID', 'DEPTH_ZERO_SELF_SIGNED_CERT',
+  'SELF_SIGNED_CERT_IN_CHAIN', 'UNABLE_TO_VERIFY_LEAF_SIGNATURE',
+  'UNABLE_TO_GET_ISSUER_CERT', 'UNABLE_TO_GET_ISSUER_CERT_LOCALLY',
+  'ERR_TLS_CERT_ALTNAME_INVALID', 'ERR_SSL_WRONG_VERSION_NUMBER',
+  'ENOTFOUND',
+]);
+
+// Node's fetch reports the real reason on .cause and leaves the top-level message as the
+// useless "fetch failed"; AbortSignal.timeout instead throws a DOMException directly, whose
+// numeric legacy .code must not be mistaken for an error string.
+function classifyNetError(e) {
+  const raw = e?.cause?.code ?? e?.code;
+  const code = typeof raw === 'string' ? raw : undefined;
+  const msg = e?.cause?.message || e?.message || String(e);
+  const err = new Error(code ? `${msg} (${code})` : msg);
+  err.transient = !(code && PERMANENT_NET_CODES.has(code));
+  return err;
+}
+
 async function fetchManifest(url, hops = 0) {
   if (hops > 5) throw new Error('too many redirects');
   let res;
@@ -58,11 +83,7 @@ async function fetchManifest(url, hops = 0) {
       redirect: 'manual',
     });
   } catch (e) {
-    // No HTTP response at all (timeout / DNS / reset). AbortSignal.timeout throws a
-    // DOMException, so re-wrap rather than tagging it in place.
-    const err = new Error(e?.message || String(e));
-    err.transient = true;
-    throw err;
+    throw classifyNetError(e);                           // no HTTP response at all
   }
   if (res.status >= 300 && res.status < 400) {
     const loc = new URL(res.headers.get('location'), url);
@@ -74,7 +95,14 @@ async function fetchManifest(url, hops = 0) {
     err.transient = res.status === 429 || res.status >= 500;   // 4xx = the manifest is really gone
     throw err;
   }
-  const buf = Buffer.from(await res.arrayBuffer());
+  let buf;
+  try {
+    buf = Buffer.from(await res.arrayBuffer());
+  } catch (e) {
+    // Headers arrived but the body did not: a reset or a timeout mid-stream is the same
+    // infrastructure class as a failure before the response, so it retries too.
+    throw classifyNetError(e);
+  }
   if (buf.length > MAX_MANIFEST_BYTES) throw new Error(`manifest too large: ${buf.length}B`);
   return buf;
 }
@@ -97,9 +125,13 @@ let manifestRaw;
 try { manifestRaw = await fetchManifestWithRetry(entry.manifest_url); }
 catch (e) {
   console.error(`Fetch failed: ${e.message}`);
+  report.error = e.transient
+    ? `manifest unreachable after ${FETCH_ATTEMPTS} attempts: ${e.message}`
+    : `manifest fetch failed: ${e.message}`;
   writeReport();
   // Unreachable is not the same as wrong. Exit 78 (neutral, no PR) so a provider-side
-  // blip doesn't fail the whole scheduled matrix; real faults still exit 1.
+  // blip doesn't fail the whole scheduled matrix; real faults still exit 1. report.error
+  // keeps the neutral case visible in the job summary instead of reading as a clean run.
   process.exit(e.transient ? 78 : 1);
 }
 report.manifest_sha256 = (await import('crypto')).createHash('sha256').update(manifestRaw).digest('hex');

--- a/.github/workflows/utility/sync_provider_manifests.mjs
+++ b/.github/workflows/utility/sync_provider_manifests.mjs
@@ -6,8 +6,9 @@
 //
 // Invocation:  PROVIDER_NAME="Example Infra" node sync_provider_manifests.mjs
 // Exit codes:  0 = changes applied (commit+PR)
-//             78 = clean run, no changes (workflow skips PR)
-//              1 = hard error (bad manifest, identity mismatch, fetch failure)
+//             78 = clean run, no changes (workflow skips PR), or the manifest was
+//                  unreachable after retries (transient: timeout/DNS/429/5xx)
+//              1 = hard error (bad manifest, identity mismatch, HTTP 4xx)
 
 import * as fs from 'fs';
 import * as path from 'path';
@@ -20,7 +21,12 @@ const REPO_ROOT = path.join(process.cwd(), '..', '..', '..');
 const ALLOWLIST = path.join(REPO_ROOT, '_providers', 'provider-allowlist.json');
 const MANIFEST_SCHEMA = path.join(REPO_ROOT, 'provider-manifest.schema.json');
 
-const FETCH_TIMEOUT_MS = 10_000;
+// 25s, not 10s: providers serving from a bare origin (cumulo.pro answers from its own
+// HTTPd, not a CDN edge) pay full RTT + TLS from the runner and overran a 10s budget on
+// the 2026-07-30 and 2026-08-03 scheduled runs.
+const FETCH_TIMEOUT_MS = 25_000;
+const FETCH_ATTEMPTS = 3;
+const FETCH_BACKOFF_MS = [2_000, 5_000];
 const MAX_MANIFEST_BYTES = 512 * 1024;
 const HEALTH_TIMEOUT_MS = 15_000;
 
@@ -45,24 +51,57 @@ const allowedOrigin = new URL(entry.manifest_url).origin;
 // ---------- 2. Fetch (size cap, timeout, no cross-origin redirects) ----------
 async function fetchManifest(url, hops = 0) {
   if (hops > 5) throw new Error('too many redirects');
-  const res = await fetch(url, {
-    signal: AbortSignal.timeout(FETCH_TIMEOUT_MS),
-    redirect: 'manual',
-  });
+  let res;
+  try {
+    res = await fetch(url, {
+      signal: AbortSignal.timeout(FETCH_TIMEOUT_MS),
+      redirect: 'manual',
+    });
+  } catch (e) {
+    // No HTTP response at all (timeout / DNS / reset). AbortSignal.timeout throws a
+    // DOMException, so re-wrap rather than tagging it in place.
+    const err = new Error(e?.message || String(e));
+    err.transient = true;
+    throw err;
+  }
   if (res.status >= 300 && res.status < 400) {
     const loc = new URL(res.headers.get('location'), url);
     if (loc.origin !== allowedOrigin) throw new Error(`redirect off-domain: ${loc.origin}`);
     return fetchManifest(loc.href, hops + 1);            // same-origin redirect ok
   }
-  if (!res.ok) throw new Error(`HTTP ${res.status}`);
+  if (!res.ok) {
+    const err = new Error(`HTTP ${res.status}`);
+    err.transient = res.status === 429 || res.status >= 500;   // 4xx = the manifest is really gone
+    throw err;
+  }
   const buf = Buffer.from(await res.arrayBuffer());
   if (buf.length > MAX_MANIFEST_BYTES) throw new Error(`manifest too large: ${buf.length}B`);
   return buf;
 }
 
+// Retry only the transient classes; a 404 or an off-domain redirect is answered the same
+// way on every attempt, so retrying it just burns runner minutes.
+async function fetchManifestWithRetry(url) {
+  for (let attempt = 1; ; attempt++) {
+    try { return await fetchManifest(url); }
+    catch (e) {
+      if (!e.transient || attempt >= FETCH_ATTEMPTS) throw e;
+      const wait = FETCH_BACKOFF_MS[attempt - 1] ?? FETCH_BACKOFF_MS.at(-1);
+      console.error(`Fetch attempt ${attempt}/${FETCH_ATTEMPTS} failed (${e.message}); retrying in ${wait}ms`);
+      await new Promise(r => setTimeout(r, wait));
+    }
+  }
+}
+
 let manifestRaw;
-try { manifestRaw = await fetchManifest(entry.manifest_url); }
-catch (e) { console.error(`Fetch failed: ${e.message}`); writeReport(); process.exit(1); }
+try { manifestRaw = await fetchManifestWithRetry(entry.manifest_url); }
+catch (e) {
+  console.error(`Fetch failed: ${e.message}`);
+  writeReport();
+  // Unreachable is not the same as wrong. Exit 78 (neutral, no PR) so a provider-side
+  // blip doesn't fail the whole scheduled matrix; real faults still exit 1.
+  process.exit(e.transient ? 78 : 1);
+}
 report.manifest_sha256 = (await import('crypto')).createHash('sha256').update(manifestRaw).digest('hex');
 
 // ---------- 3. Schema validation (whole-file reject on any error) ----------


### PR DESCRIPTION
## Problem

The scheduled `Sync Provider Manifests` run failed on **2026-07-30** ([run 30522492148](https://github.com/cosmos/chain-registry/actions/runs/30522492148)) and **2026-08-03** ([run 30794276540](https://github.com/cosmos/chain-registry/actions/runs/30794276540)). Both times only the `Sync Cumulo` matrix job failed — Polkachu, Kleomedes and High Stakes 🇨🇭 passed — with:

```
Fetch failed: The operation was aborted due to timeout
##[error]Process completed with exit code 1.
```

Three things combined in `sync_provider_manifests.mjs`:

| | Behaviour |
|---|---|
| `FETCH_TIMEOUT_MS = 10_000` | 10s budget for the manifest fetch |
| `fetchManifest()` | single attempt, no retry |
| catch → `process.exit(1)` | the workflow maps only `0`/`78` to success, so a blip is a hard error |

**Cumulo is not down.** Its manifest fetches in ~0.8s. It is, however, the only allowlisted provider serving from a bare origin (`server: HTTPd`) rather than a CDN edge — Polkachu answers as `server: cloudflare`. A runner therefore pays full RTT + TLS to the origin on every fetch and can overrun a 10s budget, while the CDN-fronted providers cannot. This is runner-to-origin tail latency, not a data fault, and it should not red-X the whole matrix.

## Change

- **`FETCH_TIMEOUT_MS` 10s → 25s** — 10s is tight for a non-CDN origin.
- **Retry 3× with 2s/5s backoff**, transient classes only: timeout / DNS / reset, `429`, `5xx`. A `4xx` or an off-domain redirect answers the same way on every attempt, so retrying it only burns runner minutes.
- **`exit 78` on transient failure after retries** — already mapped to neutral by the workflow, so no PR is opened and the run stays green. Genuine faults (`4xx`, invalid JSON, schema violation, identity mismatch) still `exit 1`.

Unreachable is not the same as wrong, and a maintainer has nothing to action on a provider-side blip.

## Verification

Ran the script end to end against a local server (timeout and backoff values scaled down for the test only):

| Case | Behaviour | Exit |
|---|---|---|
| never responds | 3 attempts, 2 backoff log lines | **78** ✅ |
| `HTTP 404` | **1 attempt**, no retry | **1** ✅ |
| `503, 503, 200` | retried twice, fetch recovered and advanced past the fetch stage | ✅ |

`node --check` clean. No behavioural change on the success path — the same bytes reach schema validation.

## Note on scope

The **2026-07-20** failure of this workflow was a *different* bug (`syntax error near unexpected token '('`, exit 2), already fixed by #7826. Only the two runs above are this timeout. No change to health-check logic, the diff applier, or `MANAGED` blocks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)