### PR TITLE
fix(irisnet): remove 19 dead RPC/REST/gRPC/EVM endpoints and peers

### DIFF
--- a/irisnet/chain.json
+++ b/irisnet/chain.json
@@ -58,34 +58,9 @@
         "id": "8542cd7e6bf9d260fef543bc49e59be5a3fa9074",
         "address": "seed.publicnode.com:26656",
         "provider": "Allnodes ⚡️ Nodes & Staking"
-      },
-      {
-        "id": "445b38a181d147c243185d94567412e5c5f1a22c",
-        "address": "seed-irisnet-01.stakeflow.io:1906",
-        "provider": "Stakeflow"
-      },
-      {
-        "id": "400f3d9e30b69e78a7fb891f60d76fa3c73f0ecc",
-        "address": "iris.rpc.kjnodes.com:16659",
-        "provider": "kjnodes"
       }
     ],
     "persistent_peers": [
-      {
-        "id": "83b3f989f3ce089afdf733f8aa06e792d7e00c08",
-        "address": "3.34.6.30:26656",
-        "provider": "cosmostation"
-      },
-      {
-        "id": "445b38a181d147c243185d94567412e5c5f1a22c",
-        "address": "peer-irisnet-01.stakeflow.io:1906",
-        "provider": "Stakeflow"
-      },
-      {
-        "id": "3ddf22082bda8607289bd94b649e0e2595f1fffd",
-        "address": "iris-mainnet.peers.l0vd.com:19656",
-        "provider": "L0vd.com ❤️"
-      },
       {
         "id": "a19022cc07010836ed2a9c77dd56968965edb454",
         "address": "mainnet-iris.konsortech.xyz:30656",
@@ -96,75 +71,18 @@
   "apis": {
     "rpc": [
       {
-        "address": "https://rpc-irisnet-01.stakeflow.io",
-        "provider": "Stakeflow"
-      },
-      {
-        "address": "https://irisnet-rpc.w3coins.io",
-        "provider": "w3coins"
-      },
-      {
-        "address": "https://iris-rpc.publicnode.com:443",
-        "provider": "Allnodes ⚡️ Nodes & Staking"
-      },
-      {
         "address": "https://mainnet-iris-rpc.konsortech.xyz",
         "provider": "KonsorTech"
       }
     ],
     "rest": [
       {
-        "address": "https://api-irisnet-01.stakeflow.io",
-        "provider": "Stakeflow"
-      },
-      {
-        "address": "https://irisnet-api.w3coins.io",
-        "provider": "w3coins"
-      },
-      {
-        "address": "https://iris-rest.publicnode.com",
-        "provider": "Allnodes ⚡️ Nodes & Staking"
-      },
-      {
         "address": "https://mainnet-iris-api.konsortech.xyz",
         "provider": "KonsorTech"
       }
     ],
-    "grpc": [
-      {
-        "address": "grpc-irisnet-01.stakeflow.io:1902",
-        "provider": "Stakeflow"
-      },
-      {
-        "address": "irisnet-grpc.w3coins.io:22690",
-        "provider": "w3coins"
-      },
-      {
-        "address": "iris-grpc.publicnode.com:443",
-        "provider": "Allnodes ⚡️ Nodes & Staking"
-      },
-      {
-        "address": "iris.grpc.kjnodes.com:443",
-        "provider": "kjnodes"
-      },
-      {
-        "address": "https://grpc-irisnet.nodeist.net",
-        "provider": "Nodeist"
-      },
-      {
-        "address": "iris-mainnet.grpc.l0vd.com:80",
-        "provider": "L0vd.com ❤️"
-      },
-      {
-        "address": "mainnet-iris.konsortech.xyz:30090",
-        "provider": "KonsorTech"
-      }
-    ],
+    "grpc": [],
     "evm-http-jsonrpc": [
-      {
-        "address": "https://iris-evm.publicnode.com",
-        "provider": "Allnodes.com ⚡️ Nodes & Staking"
-      },
       {
         "address": "https://mainnet-iris-evm.konsortech.xyz",
         "provider": "KonsorTech"


### PR DESCRIPTION
The `irisnet` chain is healthy — `irishub-1`, height **36,549,130**, `catching_up=false` — but 19 of its 26 registered endpoints and peers no longer answer. Every removal below was probed with a protocol-appropriate test and observed twice; nothing was removed on a single failed request or on format alone.

## DNS gone — NXDOMAIN, confirmed via two independent resolvers

Both Google DoH and Cloudflare DoH return `Status=3`:

| Provider | Entries removed |
|---|---|
| **Stakeflow** | rpc, rest, grpc `:1902`, seed `:1906`, persistent `:1906` — all 5 hosts |
| **w3coins** | rpc, rest, grpc `:22690` — all 3 hosts |

## Provider dropped IRISnet — proven chain-specific, not an IP block

**Allnodes / publicnode** — rpc, rest and evm all return `403 unsupported platform`; the gRPC gateway speaks gRPC but answers `grpc-message: unsupported platform`. Controls hit from the same address at the same moment:

```
iris     -> 403 unsupported platform
cosmoshub-> 200      osmosis -> 200      kava -> 200
grpc: iris = grpc-message: unsupported platform   vs   kava = grpc-message: EOF
```

**kjnodes** — `iris.grpc.kjnodes.com:443` is TCP-open but the TLS handshake returns **alert 112 `unrecognized_name`**: the iris vhost is gone from their shared IP. `celestia.rpc.kjnodes.com` returns 200, so it is iris-specific. Seed `:16659` refuses.

**L0vd** — grpc `:80` plus `:443` and `:9090` all closed; `iris-mainnet.rpc.l0vd.com` and `.api.` both fail; peer `:19656` refuses.

## Unreachable on every form probed

- **Nodeist** `grpc-irisnet.nodeist.net` — resolves to **NODATA (no A record)**; `:443` and `:9090` closed
- **KonsorTech grpc** `:30090` closed, `:9090` closed, `:443` serves `text/html` not gRPC — their only dead entry
- **cosmostation** `3.34.6.30:26656` — bare EC2 IP (`ec2-3-34-6-30.ap-northeast-2`), `:26656` and `:26657` both refuse

## Retained and re-verified live

```
rpc  net=irishub-1 h=36549323 catching_up=false     rest {"syncing":false}
evm  {"result":"0x1a20"}                            all 4 peers DIAL OK
```

KonsorTech rpc/rest/evm/persistent_peer, and both official `irisnet.org` seeds.

**`seed.publicnode.com:26656` is deliberately retained** despite the platform drop: that address and node ID `8542cd7e6bf9…` are registered across **127 chains** as a single shared registry-wide seed, and it dials fine. Removing it here would be inconsistent with every other chain that lists it.

## Note on `apis.grpc`

All 7 gRPC entries were dead, so the array is left **empty** rather than dropping the key — 9 live mainnets already carry `grpc: []` (galaxy, furya, echelon, vector, mises, bluechip, lombardledger, mun, intento) and the schema sets no `minItems`. This leaves IRISnet with a single API provider, which is worth knowing but is a consequence of provider attrition, not of this PR.

Net: `rpc 4→1 · rest 4→1 · grpc 7→0 · evm 2→1 · seeds 5→3 · persistent_peers 4→1`. Local `validate_data.mjs NO_API` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)