### PR TITLE
chore(atomone): update atomone to v4

### DIFF
--- a/atomone/chain.json
+++ b/atomone/chain.json
@@ -41,32 +41,31 @@
   },
   "codebase": {
     "git_repo": "https://github.com/atomone-hub/atomone",
-    "recommended_version": "v3.3.0",
+    "recommended_version": "v4.1.0",
     "compatible_versions": [
-      "v3.0.3",
-      "v3.2.0",
-      "v3.3.0"
+      "v4.1.0",
+      "v4.0.1"
     ],
     "binaries": {
-      "linux/amd64": "https://github.com/atomone-hub/atomone/releases/download/v3.3.0/atomoned-v3.3.0-linux-amd64",
-      "linux/arm64": "https://github.com/atomone-hub/atomone/releases/download/v3.3.0/atomoned-v3.3.0-linux-arm64",
-      "darwin/amd64": "https://github.com/atomone-hub/atomone/releases/download/v3.3.0/atomoned-v3.3.0-darwin-amd64",
-      "darwin/arm64": "https://github.com/atomone-hub/atomone/releases/download/v3.3.0/atomoned-v3.3.0-darwin-arm64",
-      "windows/amd64": "https://github.com/atomone-hub/atomone/releases/download/v3.3.0/atomoned-v3.3.0-windows-amd64.exe",
-      "windows/arm64": "https://github.com/atomone-hub/atomone/releases/download/v3.3.0/atomoned-v3.3.0-windows-arm64.exe"
+      "linux/amd64": "https://github.com/atomone-hub/atomone/releases/download/v4.1.0/atomoned-v4.1.0-linux-amd64",
+      "linux/arm64": "https://github.com/atomone-hub/atomone/releases/download/v4.1.0/atomoned-v4.1.0-linux-arm64",
+      "darwin/amd64": "https://github.com/atomone-hub/atomone/releases/download/v4.1.0/atomoned-v4.1.0-darwin-amd64",
+      "darwin/arm64": "https://github.com/atomone-hub/atomone/releases/download/v4.1.0/atomoned-v4.1.0-darwin-arm64",
+      "windows/amd64": "https://github.com/atomone-hub/atomone/releases/download/v4.1.0/atomoned-v4.1.0-windows-amd64.exe",
+      "windows/arm64": "https://github.com/atomone-hub/atomone/releases/download/v4.1.0/atomoned-v4.1.0-windows-arm64.exe"
     },
     "genesis": {
       "genesis_url": "https://atomone.fra1.digitaloceanspaces.com/atomone-1/genesis.json"
     },
     "consensus": {
       "type": "cometbft",
-      "version": "v0.37.18"
+      "version": "v0.38.23"
     },
     "sdk": {
       "type": "cosmos",
-      "version": "v0.47.17"
+      "version": "v0.500.2"
     },
-    "tag": "v3.3.0"
+    "tag": "v4.1.0"
   },
   "logo_URIs": {
     "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/atomone/images/atomone.png",

--- a/atomone/versions.json
+++ b/atomone/versions.json
@@ -3,7 +3,7 @@
   "chain_name": "atomone",
   "versions": [
     {
-      "name": "v1.1.2",
+      "name": "genesis",
       "tag": "v1.1.2",
       "recommended_version": "v1.1.2",
       "compatible_versions": [
@@ -28,7 +28,7 @@
       }
     },
     {
-      "name": "v2.0.0",
+      "name": "v2",
       "tag": "v2.0.0",
       "recommended_version": "v2.0.0",
       "compatible_versions": [
@@ -53,7 +53,7 @@
       }
     },
     {
-      "name": "v3.0.3",
+      "name": "v3",
       "tag": "v3.3.0",
       "recommended_version": "v3.3.0",
       "compatible_versions": [
@@ -106,7 +106,7 @@
       }
     },
     {
-      "name": "v4.0.0",
+      "name": "v4",
       "tag": "v4.1.0",
       "recommended_version": "v4.1.0",
       "compatible_versions": [

--- a/atomone/versions.json
+++ b/atomone/versions.json
@@ -104,6 +104,32 @@
         "type": "cosmos",
         "version": "v0.47.17"
       }
+    },
+    {
+      "name": "v4.0.0",
+      "tag": "v4.1.0",
+      "recommended_version": "v4.1.0",
+      "compatible_versions": [
+        "v4.1.0",
+        "v4.0.1"
+      ],
+      "consensus": {
+        "type": "cometbft",
+        "version": "v0.38.23"
+      },
+      "height": 9550000,
+      "binaries": {
+        "linux/amd64": "https://github.com/atomone-hub/atomone/releases/download/v4.1.0/atomoned-v4.1.0-linux-amd64",
+        "linux/arm64": "https://github.com/atomone-hub/atomone/releases/download/v4.1.0/atomoned-v4.1.0-linux-arm64",
+        "darwin/amd64": "https://github.com/atomone-hub/atomone/releases/download/v4.1.0/atomoned-v4.1.0-darwin-amd64",
+        "darwin/arm64": "https://github.com/atomone-hub/atomone/releases/download/v4.1.0/atomoned-v4.1.0-darwin-arm64",
+        "windows/amd64": "https://github.com/atomone-hub/atomone/releases/download/v4.1.0/atomoned-v4.1.0-windows-amd64.exe",
+        "windows/arm64": "https://github.com/atomone-hub/atomone/releases/download/v4.1.0/atomoned-v4.1.0-windows-arm64.exe"
+      },
+      "sdk": {
+        "type": "cosmos",
+        "version": "v0.500.2"
+      }
     }
   ]
 }


### PR DESCRIPTION
This pull request is made to update atomone version to v4. It also adjusts the style of the version names to match the guide provided in the `_guides/version.md`. 

Following the guide provided the versions have been adjusted:
1. v1.1.2 to genesis
2. v2.0.0 to v2 according to the upgrade name set in the [proposal 8](https://www.mintscan.io/atomone/proposals/8)
3. v3.0.3 to v3 according to the upgrade name set in the [proposal 8](https://www.mintscan.io/atomone/proposals/18)
4. The new upgrade will also follow this same recommendations from the guide and use upgrade name v4 set in the [proposal 21] (https://www.mintscan.io/atomone/proposals/21)
5. v3.3.0 will remain as it is because it was an unplanned upgrade.