### PR TITLE
Add Kava gRPC endpoint for jjozzietech (follow-up to #7868 on dedicated port :9444)

### DIFF
--- a/kava/chain.json
+++ b/kava/chain.json
@@ -164,6 +164,10 @@
       {
         "address": "https://grpc.kava.nodestake.org",
         "provider": "NodeStake"
+      },
+      {
+        "address": "rpc.jjozzietech.com.au:9444",
+        "provider": "jjozzietech"
       }
     ],
     "evm-http-jsonrpc": [


### PR DESCRIPTION
Follow-up to #7868. Adding jjozzietech's Kava gRPC endpoint on a dedicated port, rebuilt per the reviewer feedback from that PR.

## What changed since #7868

The original gRPC entry was placed behind a path prefix (`/kava/grpc/`) with Caddy proxying to the upstream. Two issues surfaced during review:

1. **Path prefix architecture doesn't work for gRPC.** The HTTP/2 `:path` header carries the gRPC method name (`/cosmos.base.tendermint.v1beta1.Service/GetLatestBlock` and similar), so any path prefix intercepts what should be the method routing. No standard gRPC client can be told to prepend a fixed prefix.
2. **HTTP protocol mismatch.** Caddy was dialling the Cosmos SDK gRPC server over HTTP/1.1, but the server only speaks HTTP/2.

Both are structural, not tunable. Fixed by moving gRPC to a dedicated port with `h2c://` upstream.

## Verification

Verified from an external network, over public TLS, without `-insecure`:
$ grpcurl rpc.jjozzietech.com.au:9444 list
[41 services listed, cosmos.* and kava.*]

$ grpcurl rpc.jjozzietech.com.au:9444 cosmos.base.tendermint.v1beta1.Service/GetLatestBlock
{
"block": {
"header": {
"chainId": "kava_2222-10",
"height": "21976164"
}
}
}


Reflection is enabled. Rate limiting is 30 req/sec/IP, consistent with the RPC and REST endpoints from #7868.

## Format note

Bare `host:port` (no scheme, no path). The existing `grpc` array mixes conventions — NodeStake uses `https://`, Polkachu and AutoStake use `host:port`. Bare form is what gRPC clients consume directly, so it's the safer choice.

## Endpoint documentation

https://rpc.jjozzietech.com.au:9443/ (landing page for all three services — RPC, REST, gRPC)