### PR TITLE
fix(cosmoshub): remove 6 peer entries whose hostnames no longer resolve

### DIFF
--- a/cosmoshub/chain.json
+++ b/cosmoshub/chain.json
@@ -73,11 +73,6 @@
   "peers": {
     "seeds": [
       {
-        "id": "ba3bacc714817218562f743178228f23678b2873",
-        "address": "public-seed-node.cosmoshub.certus.one:26656",
-        "provider": "certusone"
-      },
-      {
         "id": "ade4d8bc8cbe014af6ebdf3cb7b1e9ad36f412c0",
         "address": "seeds.polkachu.com:14956",
         "provider": "Polkachu"
@@ -93,11 +88,6 @@
         "provider": "Golden Ratio Staking"
       },
       {
-        "id": "c28827cb96c14c905b127b92065a3fb4cd77d7f6",
-        "address": "seeds.whispernode.com:14956",
-        "provider": "WhisperNode 🤐"
-      },
-      {
         "id": "8542cd7e6bf9d260fef543bc49e59be5a3fa9074",
         "address": "seed.publicnode.com:26656",
         "provider": "Allnodes ⚡️ Nodes & Staking"
@@ -106,16 +96,6 @@
         "id": "400f3d9e30b69e78a7fb891f60d76fa3c73f0ecc",
         "address": "cosmoshub.rpc.kjnodes.com:11359",
         "provider": "kjnodes"
-      },
-      {
-        "id": "fe21dd474640247888fc7c4dce82da8da08a8bfd",
-        "address": "seed-cosmos-hub-01.stakeflow.io:26656",
-        "provider": "Stakeflow"
-      },
-      {
-        "id": "11c6114a18f7b380e536b0bd17c031f4746e4ded",
-        "address": "seed-node.mms.team:43656",
-        "provider": "MMS"
       },
       {
         "id": "87ccc1dcc0b846fc1623ab9a5ab55682e8e2ad2e",
@@ -158,19 +138,9 @@
         "provider": "IcyCRO 🧊"
       },
       {
-        "id": "fe21dd474640247888fc7c4dce82da8da08a8bfd",
-        "address": "peer-cosmos-hub-01.stakeflow.io:26656",
-        "provider": "Stakeflow"
-      },
-      {
         "id": "01c0d24922dcdf6f8816ec814a5c3436c5d5fbc5",
         "address": "65.108.195.29:36656",
         "provider": "Staketab"
-      },
-      {
-        "id": "28d36c3d45f0208528de3c38f2934ae241bd23e7",
-        "address": "peer-cosmoshub.mms.team:26656",
-        "provider": "MMS"
       },
       {
         "id": "87ccc1dcc0b846fc1623ab9a5ab55682e8e2ad2e",


### PR DESCRIPTION
`certusone`, `WhisperNode`, `Stakeflow` and `MMS` each still have a seed or persistent peer entry in `cosmoshub/chain.json` pointing at a hostname that no longer resolves. A node bootstrapping from this registry spends dial attempts on addresses that cannot resolve, and starts with fewer usable seeds than the file implies.

## Removed — NXDOMAIN on two independent resolvers

Google DoH and Cloudflare DoH both return `Status: 3` with no answer section:

| Section | Address | Provider |
| --- | --- | --- |
| `seeds` | `public-seed-node.cosmoshub.certus.one:26656` | certusone |
| `seeds` | `seeds.whispernode.com:14956` | WhisperNode 🤐 |
| `seeds` | `seed-cosmos-hub-01.stakeflow.io:26656` | Stakeflow |
| `seeds` | `seed-node.mms.team:43656` | MMS |
| `persistent_peers` | `peer-cosmos-hub-01.stakeflow.io:26656` | Stakeflow |
| `persistent_peers` | `peer-cosmoshub.mms.team:26656` | MMS |

Controls from the same file, queried from the same place at the same moment, resolved normally:

```
seed.publicnode.com                  Status 0, A record present
cosmoshub-mainnet-seed.itrocket.net  Status 0, A record present
```

So this is not a resolver or network problem on my side.

## Deliberately left alone

Several other entries refuse TCP or time out from my location. I did not touch them. A refused port can be a moved service, and a timeout can be firewalling, geographic filtering, or a listener that has hit `max_incoming_connections` — none of which proves the entry is dead. Only DNS resolution is unambiguous from a single vantage point, so that is the whole scope here.

## Notes

- These six hostnames appear nowhere else in the registry, so this is a single-file change.
- Stakeflow's irisnet entries were removed for the same reason in #7871. The same hostname scheme is still listed for the Hub.
- `apis` entries for these providers were already cleaned up in the June cosmoshub pass; only `peers` remained.
- Diff is deletions only. `chain-registry validate --registryDir .` passes, 2242 tests.
