### PR TITLE
feat(celestia): update codebase to v9.0.4 and backfill v4-v9 history

### DIFF
--- a/celestia/chain.json
+++ b/celestia/chain.json
@@ -34,20 +34,21 @@
   },
   "codebase": {
     "git_repo": "https://github.com/celestiaorg/celestia-app",
-    "recommended_version": "v3.3.1",
+    "recommended_version": "v9.0.4",
     "compatible_versions": [
-      "v3.3.1",
-      "v3.3.0",
-      "v3.2.0",
-      "v3.1.1",
-      "v3.0.2",
-      "v3.0.1"
+      "v9.0.4"
     ],
+    "binaries": {
+      "linux/amd64": "https://github.com/celestiaorg/celestia-app/releases/download/v9.0.4/celestia-app_Linux_x86_64.tar.gz",
+      "linux/arm64": "https://github.com/celestiaorg/celestia-app/releases/download/v9.0.4/celestia-app_Linux_arm64.tar.gz",
+      "darwin/amd64": "https://github.com/celestiaorg/celestia-app/releases/download/v9.0.4/celestia-app_Darwin_x86_64.tar.gz",
+      "darwin/arm64": "https://github.com/celestiaorg/celestia-app/releases/download/v9.0.4/celestia-app_Darwin_arm64.tar.gz"
+    },
     "consensus": {
-      "type": "tendermint",
-      "version": "v1.45.0",
+      "type": "cometbft",
+      "version": "v0.40.6",
       "repo": "https://github.com/celestiaorg/celestia-core",
-      "tag": "v1.45.0-tm-v0.34.35"
+      "tag": "v0.40.6"
     },
     "genesis": {
       "genesis_url": "https://raw.githubusercontent.com/celestiaorg/networks/master/celestia/genesis.json"
@@ -55,12 +56,14 @@
     "sdk": {
       "type": "cosmos",
       "repo": "https://github.com/celestiaorg/cosmos-sdk",
-      "version": "v1.27.0",
-      "tag": "v1.27.0-sdk-v0.46.16"
+      "version": "v0.52.8",
+      "tag": "v0.52.8"
     },
     "ibc": {
       "type": "go",
-      "version": "v6.2.2"
+      "repo": "https://github.com/celestiaorg/ibc-go",
+      "version": "v8.7.2",
+      "tag": "v8.7.2"
     }
   },
   "logo_URIs": {

--- a/celestia/versions.json
+++ b/celestia/versions.json
@@ -93,7 +93,166 @@
         "version": "v6.2.2"
       },
       "previous_version_name": "v2",
-      "next_version_name": ""
+      "next_version_name": "v4"
+    },
+    {
+      "name": "v4",
+      "height": 6680339,
+      "recommended_version": "v4.1.0",
+      "compatible_versions": [
+        "v4.0.10",
+        "v4.1.0"
+      ],
+      "consensus": {
+        "type": "cometbft",
+        "version": "v1.57.2",
+        "repo": "https://github.com/celestiaorg/celestia-core",
+        "tag": "v1.57.2-tm-v0.38.17"
+      },
+      "sdk": {
+        "type": "cosmos",
+        "repo": "https://github.com/celestiaorg/cosmos-sdk",
+        "version": "v1.29.4",
+        "tag": "v1.29.4-sdk-v0.50.14"
+      },
+      "ibc": {
+        "type": "go",
+        "version": "v8.7.0"
+      },
+      "previous_version_name": "v3",
+      "next_version_name": "v5"
+    },
+    {
+      "name": "v5",
+      "height": 6748821,
+      "recommended_version": "v5.0.12",
+      "compatible_versions": [
+        "v5.0.1",
+        "v5.0.2",
+        "v5.0.5",
+        "v5.0.6",
+        "v5.0.7",
+        "v5.0.8",
+        "v5.0.9",
+        "v5.0.10",
+        "v5.0.11",
+        "v5.0.12"
+      ],
+      "consensus": {
+        "type": "cometbft",
+        "version": "v1.59.0",
+        "repo": "https://github.com/celestiaorg/celestia-core",
+        "tag": "v1.59.0-tm-v0.38.17"
+      },
+      "sdk": {
+        "type": "cosmos",
+        "repo": "https://github.com/celestiaorg/cosmos-sdk",
+        "version": "v1.31.0",
+        "tag": "v1.31.0-sdk-v0.50.14"
+      },
+      "ibc": {
+        "type": "go",
+        "version": "v8.7.0"
+      },
+      "previous_version_name": "v4",
+      "next_version_name": "v6"
+    },
+    {
+      "name": "v6",
+      "height": 8662012,
+      "recommended_version": "v6.4.10",
+      "compatible_versions": [
+        "v6.2.3",
+        "v6.2.4",
+        "v6.2.5",
+        "v6.3.0",
+        "v6.4.2",
+        "v6.4.4",
+        "v6.4.5",
+        "v6.4.10"
+      ],
+      "consensus": {
+        "type": "cometbft",
+        "version": "v0.39.23",
+        "repo": "https://github.com/celestiaorg/celestia-core",
+        "tag": "v0.39.23"
+      },
+      "sdk": {
+        "type": "cosmos",
+        "repo": "https://github.com/celestiaorg/cosmos-sdk",
+        "version": "v0.51.8",
+        "tag": "v0.51.8"
+      },
+      "ibc": {
+        "type": "go",
+        "repo": "https://github.com/celestiaorg/ibc-go",
+        "version": "v8.7.2",
+        "tag": "v8.7.2"
+      },
+      "previous_version_name": "v5",
+      "next_version_name": "v8"
+    },
+    {
+      "name": "v8",
+      "height": 10960599,
+      "recommended_version": "v8.0.8",
+      "compatible_versions": [
+        "v8.0.3",
+        "v8.0.8"
+      ],
+      "consensus": {
+        "type": "cometbft",
+        "version": "v0.39.30",
+        "repo": "https://github.com/celestiaorg/celestia-core",
+        "tag": "v0.39.30"
+      },
+      "sdk": {
+        "type": "cosmos",
+        "repo": "https://github.com/celestiaorg/cosmos-sdk",
+        "version": "v0.52.6",
+        "tag": "v0.52.6"
+      },
+      "ibc": {
+        "type": "go",
+        "repo": "https://github.com/celestiaorg/ibc-go",
+        "version": "v8.7.2",
+        "tag": "v8.7.2"
+      },
+      "previous_version_name": "v6",
+      "next_version_name": "v9"
+    },
+    {
+      "name": "v9",
+      "height": 11771699,
+      "recommended_version": "v9.0.4",
+      "compatible_versions": [
+        "v9.0.4"
+      ],
+      "binaries": {
+        "linux/amd64": "https://github.com/celestiaorg/celestia-app/releases/download/v9.0.4/celestia-app_Linux_x86_64.tar.gz",
+        "linux/arm64": "https://github.com/celestiaorg/celestia-app/releases/download/v9.0.4/celestia-app_Linux_arm64.tar.gz",
+        "darwin/amd64": "https://github.com/celestiaorg/celestia-app/releases/download/v9.0.4/celestia-app_Darwin_x86_64.tar.gz",
+        "darwin/arm64": "https://github.com/celestiaorg/celestia-app/releases/download/v9.0.4/celestia-app_Darwin_arm64.tar.gz"
+      },
+      "consensus": {
+        "type": "cometbft",
+        "version": "v0.40.6",
+        "repo": "https://github.com/celestiaorg/celestia-core",
+        "tag": "v0.40.6"
+      },
+      "sdk": {
+        "type": "cosmos",
+        "repo": "https://github.com/celestiaorg/cosmos-sdk",
+        "version": "v0.52.8",
+        "tag": "v0.52.8"
+      },
+      "ibc": {
+        "type": "go",
+        "repo": "https://github.com/celestiaorg/ibc-go",
+        "version": "v8.7.2",
+        "tag": "v8.7.2"
+      },
+      "previous_version_name": "v8"
     }
   ]
 }


### PR DESCRIPTION
## What

`celestia/chain.json` recorded `recommended_version: v3.3.1`. Celestia mainnet has been on **app version 9 since block 11,771,699** (2026-07-01) and the current mainnet tag is **v9.0.4** — six app versions ahead of the registry. `versions.json` also stopped at v3, so the `[AUTO] Sync Versions` job had no current entry to extend and no way to know the upgrade heights.

## Changes

**`celestia/chain.json` — `codebase`**

| field | before | after |
|---|---|---|
| `recommended_version` | `v3.3.1` | `v9.0.4` |
| `compatible_versions` | 6 × `v3.x` | `v9.0.4` |
| `binaries` | — | linux/darwin × amd64/arm64 |
| `consensus` | `tendermint` `v1.45.0-tm-v0.34.35` | `cometbft` `v0.40.6` (celestia-core) |
| `sdk` | `v1.27.0-sdk-v0.46.16` | `v0.52.8` (celestiaorg/cosmos-sdk) |
| `ibc` | `v6.2.2` | `v8.7.2` (celestiaorg/ibc-go) |

**`celestia/versions.json`** — added `v4`, `v5`, `v6`, `v8`, `v9` with heights and per-version dependency versions; set `v3.next_version_name` (was `""`) to `v4`.

## Sources

| value | source |
|---|---|
| current tag `v9.0.4` | [`celestiaorg/docs` → `constants/mainnet_versions.json`](https://github.com/celestiaorg/docs/blob/main/constants/mainnet_versions.json) (`app-latest-tag`) |
| upgrade heights | Celestia network-upgrades table, Mainnet Beta section |
| `consensus` / `sdk` / `ibc` | `go.mod` `replace` directives at each release tag |
| `binaries` | `v9.0.4` release assets — all four return HTTP 200 |

## A note on the height convention

The heights here are the ones published in Celestia's own upgrade table, which is also what the existing `v2` / `v3` entries use. For signalling upgrades (v3+) that published height is the **last block of the previous app version**; the new version's first block is +1. I checked every one of them against block headers on an archive node (`rpc.archive.celestia.validatus.com`, `header.version.app`):

| entry | height in this PR | app version at that height | first block of the new version |
|---|---|---|---|
| v2 (existing) | 2,371,495 | 2 | 2,371,495 |
| v3 (existing) | 2,993,219 | 2 | 2,993,220 |
| v4 | 6,680,339 | 3 | 6,680,340 |
| v5 | 6,748,821 | 4 | 6,748,822 |
| v6 | 8,662,012 | 5 | 8,662,013 |
| v8 | 10,960,599 | 6 | 10,960,600 |
| v9 | 11,771,699 | 9 | 11,771,699 |

I kept the published numbers so the new entries match the existing ones. If the registry's convention is the first block of the new version instead, say so and I will shift the five new entries (and `v3`) — it is one number per entry.

## v7

`v7` (Hibiscus) is intentionally absent. It was skipped on mainnet in favour of `v8` (CIP-49) and has no stable release, so `v6.next_version_name` is `v8`.

## Validation

```
npm install -g @chain-registry/cli@1.47.0
chain-registry validate --registryDir . --logLevel error
→ ✅ Validation Passed. 2242 Tests.
```

Disclosure: I run a Celestia mainnet validator (DURE Nodes) on v9.0.4.
