### PR TITLE
Gnodi Updates

### DIFF
--- a/gnodi/chain.json
+++ b/gnodi/chain.json
@@ -41,27 +41,29 @@
       "name": "v1",
       "genesis_url": "https://raw.githubusercontent.com/gnodi-network/genesis-mainnet/refs/heads/main/genesis.json"
     },
-    "recommended_version": "1.0.1",
+    "recommended_version": "2.0.2",
     "compatible_versions": [
-      "1.0.1"
+      "2.0.0",
+      "2.0.1",
+      "2.0.2"
     ],
     "consensus": {
       "type": "cometbft",
-      "version": "0.38.17",
+      "version": "0.38.21",
       "repo": "https://github.com/cometbft/cometbft",
-      "tag": "v0.38.17"
+      "tag": "v0.38.21"
     },
     "sdk": {
       "type": "cosmos",
-      "version": "0.53.3",
+      "version": "0.53.5",
       "repo": "https://github.com/cosmos/cosmos-sdk",
-      "tag": "v0.53.3"
+      "tag": "v0.53.5-0.20251030204916-768cb210885c"
     },
     "ibc": {
       "type": "go",
-      "version": "10.2.0",
+      "version": "10.3.1",
       "repo": "https://github.com/cosmos/ibc-go",
-      "tag": "v10.2.0",
+      "tag": "v10.3.1-0.20250909102629-ed3b125c7b6f",
       "ics_enabled": [
         "ics20-1"
       ]
@@ -70,7 +72,7 @@
       "type": "go",
       "version": "1.24.0"
     },
-    "tag": "v1.0.1"
+    "tag": "v2.0.2"
   },
   "images": [
     {
@@ -100,6 +102,11 @@
         "provider": "Gnodi Team"
       },
       {
+        "address": "https://rpc.gnodipowered.com",
+        "provider": "Gnodi Powered",
+        "archive": true
+      },
+      {
         "address": "https://rpc-gnodi.vinjan-inc.com",
         "provider": "Vinjan.Inc"
       }
@@ -110,6 +117,11 @@
         "provider": "Gnodi Team"
       },
       {
+        "address": "https://api.gnodipowered.com",
+        "provider": "Gnodi Powered",
+        "archive": true
+      },
+      {
         "address": "https://api-gnodi.vinjan-inc.com",
         "provider": "Vinjan.Inc"
       }
@@ -118,6 +130,23 @@
       {
         "address": "grpc.gnodi.zone:443",
         "provider": "Gnodi Team"
+      },
+      {
+        "address": "grpc-native.gnodipowered.com:443",
+        "provider": "Gnodi Powered",
+        "archive": true
+      }
+    ],
+    "wss": [
+      {
+        "address": "wss://rpc.gnodipowered.com/websocket",
+        "provider": "Gnodi Powered"
+      }
+    ],
+    "evm-http-jsonrpc": [
+      {
+        "address": "https://evm.gnodipowered.com",
+        "provider": "Gnodi Powered"
       }
     ]
   },
@@ -133,6 +162,28 @@
       "url": "https://explorer.vinjan-inc.com/gnodi",
       "tx_page": "https://explorer.vinjan-inc.com/gnodi/tx/${txHash}",
       "account_page": "https://explorer.vinjan-inc.com/gnodi/account/${accountAddress}"
+    },
+    {
+      "kind": "NodeStake",
+      "url": "https://explorer.nodestake.org/gnodi",
+      "tx_page": "https://explorer.nodestake.org/gnodi/tx/${txHash}",
+      "account_page": "https://explorer.nodestake.org/gnodi/account/${accountAddress}"
+    },
+    {
+      "kind": "GnodiScan",
+      "url": "https://gnodiscanner.com",
+      "tx_page": "https://gnodiscanner.com/txs/${txHash}",
+      "account_page": "https://gnodiscanner.com/account/${accountAddress}",
+      "validator_page": "https://gnodiscanner.com/validators/${validatorAddress}",
+      "proposal_page": "https://gnodiscanner.com/governance/${proposalId}",
+      "block_page": "https://gnodiscanner.com/blocks/${blockHeight}"
+    },
+    {
+      "kind": "GnodiScan EVM",
+      "url": "https://evm.gnodiscanner.com",
+      "tx_page": "https://evm.gnodiscanner.com/tx/${txHash}",
+      "account_page": "https://evm.gnodiscanner.com/address/${accountAddress}",
+      "block_page": "https://evm.gnodiscanner.com/block/${blockHeight}"
     }
   ]
 }

--- a/gnodi/versions.json
+++ b/gnodi/versions.json
@@ -9,6 +9,7 @@
         "1.0.1"
       ],
       "tag": "v1.0.1",
+      "next_version_name": "evm-upgrade",
       "language": {
         "type": "go",
         "version": "1.24.0"
@@ -30,6 +31,44 @@
         "version": "10.2.0",
         "repo": "https://github.com/cosmos/ibc-go",
         "tag": "v10.2.0",
+        "ics_enabled": [
+          "ics20-1"
+        ]
+      }
+    },
+    {
+      "name": "evm-upgrade",
+      "proposal": 3,
+      "height": 339010,
+      "previous_version_name": "1.0.1",
+      "recommended_version": "2.0.2",
+      "compatible_versions": [
+        "2.0.0",
+        "2.0.1",
+        "2.0.2"
+      ],
+      "tag": "v2.0.2",
+      "language": {
+        "type": "go",
+        "version": "1.24.0"
+      },
+      "sdk": {
+        "type": "cosmos",
+        "version": "0.53.5",
+        "repo": "https://github.com/cosmos/cosmos-sdk",
+        "tag": "v0.53.5-0.20251030204916-768cb210885c"
+      },
+      "consensus": {
+        "type": "cometbft",
+        "version": "0.38.21",
+        "repo": "https://github.com/cometbft/cometbft",
+        "tag": "v0.38.21"
+      },
+      "ibc": {
+        "type": "go",
+        "version": "10.3.1",
+        "repo": "https://github.com/cosmos/ibc-go",
+        "tag": "v10.3.1-0.20250909102629-ed3b125c7b6f",
         "ics_enabled": [
           "ics20-1"
         ]


### PR DESCRIPTION
Gnodi update. Chain audit: https://skynet.certik.com/projects/gnodi-blockchain

Both files are updated and pass the repo's own CI validator (chain-registry validate — 2247 tests, no
  errors) plus direct JSON Schema validation.

  Codebase — bumped to v2.0.2, verified against go.mod at each v2 tag (all three v2 releases share identical
  deps):
  - recommended_version 2.0.2, compatible_versions [2.0.0, 2.0.1, 2.0.2], tag v2.0.2
  - CometBFT 0.38.17 → 0.38.21
  - Cosmos SDK 0.53.3 → 0.53.5 (tag carries the pseudo-version v0.53.5-0.20251030204916-768cb210885c, matching what the live LCD reports)
  - ibc-go 10.2.0 → 10.3.1 (tag v10.3.1-0.20250909102629-ed3b125c7b6f)

  APIs — all new endpoints probed live before adding:
  - RPC / REST / gRPC under provider "Gnodi Powered", each flagged archive: true (RPC serves block 1)
  - evm-http-jsonrpc: https://evm.gnodipowered.com — eth_chainId returns 0xb62a = 46634, matching EVMChainID in app/config.go
  - wss: wss://rpc.gnodipowered.com/websocket (101 Switching Protocols)

  Explorers — added NodeStake (Ping.pub route pattern, consistent with the 19 other NodeStake entries in the
  registry), GnodiScan, and GnodiScan EVM. GnodiScan page patterns came from the route tables in their JS
  bundles, not guessed — cosmos side uses /txs/:hash, /account/:address, /validators/:address,
  /governance/:id, /blocks/:height; EVM side uses /tx/:hash, /address/:address, /block/:param.

  gnodi/versions.json — added the evm-upgrade entry with proposal: 3 and height: 339010, both confirmed
  on-chain (applied_plan/evm-upgrade and gov proposal 3, "EVM Integration Upgrade: v2.0.0"), and linked the
  two entries via previous_version_name / next_version_name.