### PR TITLE
fix(cosmoshubtestnet): mark theta-testnet-001 as killed

### DIFF
--- a/testnets/cosmoshubtestnet/chain.json
+++ b/testnets/cosmoshubtestnet/chain.json
@@ -4,7 +4,7 @@
   "chain_type": "cosmos",
   "chain_id": "theta-testnet-001",
   "pretty_name": "[DEPRECATED] Cosmos Hub Public Testnet, will be sunset 2024-12-01",
-  "status": "live",
+  "status": "killed",
   "network_type": "testnet",
   "bech32_prefix": "cosmos",
   "daemon_name": "gaiad",


### PR DESCRIPTION
The entry still carries "status": "live", while its own pretty_name
reads "[DEPRECATED] Cosmos Hub Public Testnet, will be sunset
2024-12-01" -- a date that passed 20 months ago.

The operator has already archived it. In cosmos/testnets, the
repository Hypha maintains for Cosmos Hub testnets, theta-testnet-001
sits under legacy/ next to vega and the retired gaia-* networks, and
that README describes legacy/ as "legacy network information".

Every endpoint listed in this file was checked, twice, twelve hours
apart. All 14 fail both times: the seven RPC and seven REST addresses
return timeouts (polypore.xyz sentry and state-sync hosts), DNS
failures (public-cosmos-theta.w3node.com), or 403/404 (lava.build,
osmotest5.osmosis.zone). None returns a block height. Both seed hosts
still resolve but neither accepts a TCP connection on 26656.

To rule out a problem on my end, I ran the same TCP check against the
provider testnet seeds run by the same operator, from the same machine:
provider-seed-01 and -02.hub-testnet.polypore.xyz both accept
connections. Hypha's hosts are reachable; the theta hosts are not.

Tooling that filters on status: live still surfaces this chain. The
current Cosmos Hub testnet is already in this registry as
testnets/cosmosicsprovidertestnet (chain_id: provider), live and
current at v28.0.0-rc0.

Only the status field changes. Endpoints and peers are left as they
are, matching the other killed testnets in this registry.