### PR TITLE
feat(celestiatestnet3): update codebase to v9.0.4-mocha

### DIFF
--- a/testnets/celestiatestnet3/chain.json
+++ b/testnets/celestiatestnet3/chain.json
@@ -26,15 +26,9 @@
   },
   "codebase": {
     "git_repo": "https://github.com/celestiaorg/celestia-app",
-    "recommended_version": "v3.3.1-mocha",
+    "recommended_version": "v9.0.4-mocha",
     "compatible_versions": [
-      "v3.0.0-mocha",
-      "v3.0.1-mocha",
-      "v3.0.2-mocha",
-      "v3.1.1-mocha",
-      "v3.2.0-mocha",
-      "v3.3.0-mocha",
-      "v3.3.1-mocha"
+      "v9.0.4-mocha"
     ],
     "genesis": {
       "genesis_url": "https://raw.githubusercontent.com/celestiaorg/networks/master/mocha-4/genesis.json"

--- a/testnets/celestiatestnet3/versions.json
+++ b/testnets/celestiatestnet3/versions.json
@@ -40,6 +40,14 @@
         "v3.3.0-mocha",
         "v3.3.1-mocha"
       ]
+    },
+    {
+      "name": "v9",
+      "height": 11655991,
+      "recommended_version": "v9.0.4-mocha",
+      "compatible_versions": [
+        "v9.0.4-mocha"
+      ]
     }
   ]
 }


### PR DESCRIPTION
mocha-4 has been running app version 9 since block 11,655,991, but this
entry still recommends v3.3.1-mocha. A node bootstrapped from these
values today installs a binary six app versions behind the network.

Verified against the chain rather than release notes:

  - the app version in the block header is 9 at 11,655,991 and 8 at
    11,655,990, so that block is the transition
  - nodes on mocha-4 report application_version 9.0.4 today
  - celestiaorg/docs constants/mocha_versions.json publishes
    "app-latest-tag": "v9.0.4-mocha"

versions.json gets the matching v9 entry with that height. Running
.github/workflows/utility/sync_versions.mjs against this change
produces no further edits.

compatible_versions lists only v9.0.4-mocha, although v9.0.0-mocha,
v9.0.1-mocha and v9.0.2-mocha also exist. The release notes for
v9.0.4-mocha say it "has a fix to an app hash mismatch bug that could
lead to a node halt" and that it is "very important for validators to
upgrade to this release". Listing the earlier three as compatible would
point operators at binaries that can halt. This also matches the
celestia mainnet entry, where v9 carries a single compatible version.

I did not backfill v4-v8. Every mocha endpoint listed in this registry
prunes below block 10,514,114, so those transitions could not be
verified on-chain. The one exception I could confirm is the v8
transition at 10,941,527, if a maintainer would like the history filled
in a follow-up.