### PR TITLE
Add allUSDC (Osmosis USDC alloy) to the Osmosis assetlist

### DIFF
--- a/osmosis/assetlist.json
+++ b/osmosis/assetlist.json
@@ -18217,6 +18217,53 @@
       ]
     },
     {
+      "description": "An alloy of USDC asset variants on Osmosis.",
+      "extended_description": "Multiple USD Coin variants on Osmosis comprise the liquidity backing of a tokenized transmuter pool to create an alloy of USDC.",
+      "denom_units": [
+        {
+          "denom": "factory/osmo147h5x9pcj7lm0cttlaefx6sqq5vdfnmwfcqxkmjd7exqm9gc7grqhr75m0/alloyed/allUSDC",
+          "exponent": 0
+        },
+        {
+          "denom": "allUSDC",
+          "exponent": 6
+        }
+      ],
+      "type_asset": "sdk.coin",
+      "address": "osmo147h5x9pcj7lm0cttlaefx6sqq5vdfnmwfcqxkmjd7exqm9gc7grqhr75m0",
+      "base": "factory/osmo147h5x9pcj7lm0cttlaefx6sqq5vdfnmwfcqxkmjd7exqm9gc7grqhr75m0/alloyed/allUSDC",
+      "name": "USD Coin",
+      "display": "allUSDC",
+      "symbol": "USDC",
+      "traces": [
+        {
+          "type": "synthetic",
+          "counterparty": {
+            "chain_name": "ethereum",
+            "base_denom": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48"
+          },
+          "provider": "Osmosis"
+        }
+      ],
+      "logo_URIs": {
+        "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/_non-cosmos/ethereum/images/usdc.png",
+        "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/_non-cosmos/ethereum/images/usdc.svg"
+      },
+      "images": [
+        {
+          "image_sync": {
+            "chain_name": "ethereum",
+            "base_denom": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48"
+          },
+          "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/_non-cosmos/ethereum/images/usdc.svg",
+          "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/_non-cosmos/ethereum/images/usdc.png",
+          "theme": {
+            "circle": true
+          }
+        }
+      ]
+    },
+    {
       "description": "Whinecoin is an experimental memecoin by the Sommelier Finance team.",
       "denom_units": [
         {


### PR DESCRIPTION
Adds the alloyed USDC asset on Osmosis, backed by a transmuter pool holding USDC (Noble), USDC.eth.axl and the Injective USDC variant.

- Contract: `osmo147h5x9pcj7lm0cttlaefx6sqq5vdfnmwfcqxkmjd7exqm9gc7grqhr75m0`
- Pool 3497, transmuter code 996, admin is the Osmosis governance module account
- 6 decimals, matching all three constituents
- Modelled on the existing allUSDT entry, the closest analogue
- `synthetic` trace and `image_sync` to Ethereum-native USDC