### PR TITLE
Update Unification TestNet to und v1.13.4

### DIFF
--- a/testnets/unificationtestnet/chain.json
+++ b/testnets/unificationtestnet/chain.json
@@ -37,17 +37,17 @@
   },
   "codebase": {
     "git_repo": "https://github.com/unification-com/mainchain",
-    "recommended_version": "v1.12.0",
+    "recommended_version": "v1.13.4",
     "compatible_versions": [
-      "v1.12.0"
+      "v1.13.4"
     ],
     "binaries": {
-      "linux/amd64": "https://github.com/unification-com/mainchain/releases/download/v1.12.0/und_v1.12.0_linux_x86_64.tar.gz",
-      "linux/arm64": "https://github.com/unification-com/mainchain/releases/download/v1.12.0/und_v1.12.0_linux_arm64.tar.gz",
-      "darwin/amd64": "https://github.com/unification-com/mainchain/releases/download/v1.12.0/und_v1.12.0_darwin_x86_64.tar.gz",
-      "darwin/arm64": "https://github.com/unification-com/mainchain/releases/download/v1.12.0/und_v1.12.0_darwin_arm64.tar.gz",
-      "windows/amd64": "https://github.com/unification-com/mainchain/releases/download/v1.12.0/und_v1.12.0_windows_x86_64.tar.gz",
-      "windows/arm64": "https://github.com/unification-com/mainchain/releases/download/v1.12.0/und_v1.12.0_windows_arm64.tar.gz"
+      "linux/amd64": "https://github.com/unification-com/mainchain/releases/download/v1.13.4/und_v1.13.4_linux_x86_64.tar.gz",
+      "linux/arm64": "https://github.com/unification-com/mainchain/releases/download/v1.13.4/und_v1.13.4_linux_arm64.tar.gz",
+      "darwin/amd64": "https://github.com/unification-com/mainchain/releases/download/v1.13.4/und_v1.13.4_darwin_x86_64.tar.gz",
+      "darwin/arm64": "https://github.com/unification-com/mainchain/releases/download/v1.13.4/und_v1.13.4_darwin_arm64.tar.gz",
+      "windows/amd64": "https://github.com/unification-com/mainchain/releases/download/v1.13.4/und_v1.13.4_windows_x86_64.tar.gz",
+      "windows/arm64": "https://github.com/unification-com/mainchain/releases/download/v1.13.4/und_v1.13.4_windows_arm64.tar.gz"
     },
     "consensus": {
       "type": "cometbft",

--- a/testnets/unificationtestnet/versions.json
+++ b/testnets/unificationtestnet/versions.json
@@ -209,24 +209,24 @@
     },
     {
       "name": "8-vaxildan",
-      "tag": "v1.13.0",
+      "tag": "v1.13.4",
       "proposal": 50,
       "height": 25638900,
       "consensus": {
         "type": "cometbft",
         "version": "0.39.4"
       },
-      "recommended_version": "v1.13.0",
+      "recommended_version": "v1.13.4",
       "compatible_versions": [
-        "v1.13.0"
+        "v1.13.4"
       ],
       "binaries": {
-        "linux/amd64": "https://github.com/unification-com/mainchain/releases/download/v1.13.0/und_v1.13.0_linux_x86_64.tar.gz",
-        "linux/arm64": "https://github.com/unification-com/mainchain/releases/download/v1.13.0/und_v1.13.0_linux_arm64.tar.gz",
-        "darwin/amd64": "https://github.com/unification-com/mainchain/releases/download/v1.13.0/und_v1.13.0_darwin_x86_64.tar.gz",
-        "darwin/arm64": "https://github.com/unification-com/mainchain/releases/download/v1.13.0/und_v1.13.0_darwin_arm64.tar.gz",
-        "windows/amd64": "https://github.com/unification-com/mainchain/releases/download/v1.13.0/und_v1.13.0_windows_x86_64.tar.gz",
-        "windows/arm64": "https://github.com/unification-com/mainchain/releases/download/v1.13.0/und_v1.13.0_windows_arm64.tar.gz"
+        "linux/amd64": "https://github.com/unification-com/mainchain/releases/download/v1.13.4/und_v1.13.4_linux_x86_64.tar.gz",
+        "linux/arm64": "https://github.com/unification-com/mainchain/releases/download/v1.13.4/und_v1.13.4_linux_arm64.tar.gz",
+        "darwin/amd64": "https://github.com/unification-com/mainchain/releases/download/v1.13.4/und_v1.13.4_darwin_x86_64.tar.gz",
+        "darwin/arm64": "https://github.com/unification-com/mainchain/releases/download/v1.13.4/und_v1.13.4_darwin_arm64.tar.gz",
+        "windows/amd64": "https://github.com/unification-com/mainchain/releases/download/v1.13.4/und_v1.13.4_windows_x86_64.tar.gz",
+        "windows/arm64": "https://github.com/unification-com/mainchain/releases/download/v1.13.4/und_v1.13.4_windows_arm64.tar.gz"
       },
       "sdk": {
         "type": "cosmos",


### PR DESCRIPTION
- bumps TestNet `und` version to v1.13.4 following successful network upgrade