### PR TITLE
Add extended_description for Sovren (SOVR)

### DIFF
--- a/sovr/assetlist.json
+++ b/sovr/assetlist.json
@@ -4,6 +4,7 @@
   "assets": [
     {
       "description": "SOVR is the sole unit of account of the Sovren Layer 1: staking, governance, gas, and service payments.",
+      "extended_description": "Sovren is a Layer 1 blockchain built with the Cosmos SDK and CometBFT consensus that settles payment for infrastructure work. Licensed node operators supply storage, bandwidth, content delivery, compute and vector search. That capacity is offered as conventional cloud services through Triton Cloud and is also consumed by Sovren Technologies' own applications, including Parler, Play, Pay and Shop. Every processed request produces a signed cryptographic receipt, and operator weight derives from verified delivery. SOVR pays transaction fees, is staked to secure the chain under proof-of-stake consensus, carries governance rights over protocol parameters and upgrades, and settles payment to node operators for services delivered. Holders can also use SOVR to pay for Triton Cloud services. The sovr-1 mainnet produced its genesis block on 6 May 2026. Maximum supply is fixed at 1,000,000,000 SOVR.",
       "denom_units": [
         {
           "denom": "usovr",


### PR DESCRIPTION
Adds the `extended_description` field to the SOVR asset (required for Osmosis verified-asset status; the existing entry has only the short `description`). One field, one insertion; validates against `assetlist.schema.json`.