### PR TITLE
feat(celestia): update codebase to v9.0.6

### DIFF
--- a/celestia/chain.json
+++ b/celestia/chain.json
@@ -34,21 +34,21 @@
   },
   "codebase": {
     "git_repo": "https://github.com/celestiaorg/celestia-app",
-    "recommended_version": "v9.0.4",
+    "recommended_version": "v9.0.6",
     "compatible_versions": [
-      "v9.0.4"
+      "v9.0.6"
     ],
     "binaries": {
-      "linux/amd64": "https://github.com/celestiaorg/celestia-app/releases/download/v9.0.4/celestia-app_Linux_x86_64.tar.gz",
-      "linux/arm64": "https://github.com/celestiaorg/celestia-app/releases/download/v9.0.4/celestia-app_Linux_arm64.tar.gz",
-      "darwin/amd64": "https://github.com/celestiaorg/celestia-app/releases/download/v9.0.4/celestia-app_Darwin_x86_64.tar.gz",
-      "darwin/arm64": "https://github.com/celestiaorg/celestia-app/releases/download/v9.0.4/celestia-app_Darwin_arm64.tar.gz"
+      "linux/amd64": "https://github.com/celestiaorg/celestia-app/releases/download/v9.0.6/celestia-app_Linux_x86_64.tar.gz",
+      "linux/arm64": "https://github.com/celestiaorg/celestia-app/releases/download/v9.0.6/celestia-app_Linux_arm64.tar.gz",
+      "darwin/amd64": "https://github.com/celestiaorg/celestia-app/releases/download/v9.0.6/celestia-app_Darwin_x86_64.tar.gz",
+      "darwin/arm64": "https://github.com/celestiaorg/celestia-app/releases/download/v9.0.6/celestia-app_Darwin_arm64.tar.gz"
     },
     "consensus": {
       "type": "cometbft",
-      "version": "v0.40.6",
+      "version": "v0.40.8",
       "repo": "https://github.com/celestiaorg/celestia-core",
-      "tag": "v0.40.6"
+      "tag": "v0.40.8"
     },
     "genesis": {
       "genesis_url": "https://raw.githubusercontent.com/celestiaorg/networks/master/celestia/genesis.json"

--- a/celestia/versions.json
+++ b/celestia/versions.json
@@ -224,21 +224,21 @@
     {
       "name": "v9",
       "height": 11771699,
-      "recommended_version": "v9.0.4",
+      "recommended_version": "v9.0.6",
       "compatible_versions": [
-        "v9.0.4"
+        "v9.0.6"
       ],
       "binaries": {
-        "linux/amd64": "https://github.com/celestiaorg/celestia-app/releases/download/v9.0.4/celestia-app_Linux_x86_64.tar.gz",
-        "linux/arm64": "https://github.com/celestiaorg/celestia-app/releases/download/v9.0.4/celestia-app_Linux_arm64.tar.gz",
-        "darwin/amd64": "https://github.com/celestiaorg/celestia-app/releases/download/v9.0.4/celestia-app_Darwin_x86_64.tar.gz",
-        "darwin/arm64": "https://github.com/celestiaorg/celestia-app/releases/download/v9.0.4/celestia-app_Darwin_arm64.tar.gz"
+        "linux/amd64": "https://github.com/celestiaorg/celestia-app/releases/download/v9.0.6/celestia-app_Linux_x86_64.tar.gz",
+        "linux/arm64": "https://github.com/celestiaorg/celestia-app/releases/download/v9.0.6/celestia-app_Linux_arm64.tar.gz",
+        "darwin/amd64": "https://github.com/celestiaorg/celestia-app/releases/download/v9.0.6/celestia-app_Darwin_x86_64.tar.gz",
+        "darwin/arm64": "https://github.com/celestiaorg/celestia-app/releases/download/v9.0.6/celestia-app_Darwin_arm64.tar.gz"
       },
       "consensus": {
         "type": "cometbft",
-        "version": "v0.40.6",
+        "version": "v0.40.8",
         "repo": "https://github.com/celestiaorg/celestia-core",
-        "tag": "v0.40.6"
+        "tag": "v0.40.8"
       },
       "sdk": {
         "type": "cosmos",


### PR DESCRIPTION
`celestia` points at **v9.0.4** (June 16). **v9.0.6** shipped on **2026-08-18** with the release note *"This release is intended for Mainnet"*, and it is what `celestiaorg/docs` now serves as the current mainnet tag.

This updates `codebase` in `chain.json` and the `v9` entry in `versions.json`. **No app-version change** — mainnet is still app version 9 since height 11771699, so nothing about the upgrade history moves and there is nothing for the sync bot to reconstruct. This is a codebase pointer update only.

## What v9.0.6 carries

| Change | |
|---|---|
| [#7674](https://github.com/celestiaorg/celestia-app/pull/7674) | backport of #7661 — `ProcessProposal` compared a scaled square size, so an overflowing value could let a malformed square through (PROTOCO-2276) |
| [#7694](https://github.com/celestiaorg/celestia-app/pull/7694) | reject transactions with duplicate `TxRaw` fields; node-local guard, explicitly does not change `ProcessProposal`'s verdict |
| celestia-core | v0.40.6 → **v0.40.8** |

## Values and where they come from

| Value | Source |
|---|---|
| `v9.0.6` | `celestiaorg/docs` `constants/mainnet_versions.json` → `"app-latest-tag": "v9.0.6"` |
| binaries (4) | v9.0.6 release assets — all four HTTP 200 |
| consensus `celestia-core v0.40.8` | `go.mod` replace at tag `v9.0.6`: `github.com/cometbft/cometbft => github.com/celestiaorg/celestia-core v0.40.8` |
| sdk `v0.52.8`, ibc `v8.7.2` | same file — unchanged from v9.0.4, so those blocks are untouched |

## In the field

Probed `/cosmos/base/tendermint/v1beta1/node_info` on the REST endpoints listed in this entry, **2026-08-24 ~03:20 UTC**:

```
9.0.6   api.celestia.nodestake.org · rest.lavenderfive.com/celestia · celestia.api.kjnodes.com
        api.celestia.pops.one · celestia-api.polkachu.com
9.0.4   celestia-rest.publicnode.com · celestia.rpc.uquad.org · celestia.rest.stakin-nodes.com
```

So both are live on mainnet right now. We also run v9.0.6 on our own mainnet validator (height 13395165 at probe time, in sync).

**`compatible_versions` lists `v9.0.6` only.** v9.0.4 does still run — the probe above shows it — but it carries the `ProcessProposal` overflow that #7674 fixes, and that is a validation-path difference, not a cosmetic one. I would rather not have the registry point an operator at that binary. If you would rather have the field reflect what is running, say so and I will add `v9.0.4` back.

## Validation

```
npx @chain-registry/cli@1.47.0 chain-registry validate --registryDir . --logLevel error
→ ✅ Validation Passed. 2251 Tests.

node .github/workflows/utility/validate_data.mjs NO_API
→ exit 0

node .github/workflows/utility/sync_versions.mjs
→ leaves celestia untouched (chain.json and versions.json agree)
```

## Not in this PR

`celestiatestnet3` (`mocha-4`) is also on `v9.0.4-mocha` while `v9.0.6-mocha` exists. I left it alone here for two reasons: `mocha-4` is scheduled to shut down on **September 1, 2026** per Celestia's docs, and #7905 already edits that file — no reason to create a conflict over a chain with eight days left.
