### PR TITLE
fix(nolus): remove 20 dead API endpoints and 3 dead explorers

### DIFF
--- a/nolus/chain.json
+++ b/nolus/chain.json
@@ -151,36 +151,8 @@
         "provider": "NolusProtocol"
       },
       {
-        "address": "https://nolus-mainnet-rpc.autostake.com:443",
-        "provider": "AutoStake 🛡️ Slash Protected"
-      },
-      {
-        "address": "https://rpc.lavenderfive.com:443/nolus",
-        "provider": "Lavender.Five Nodes 🐝"
-      },
-      {
         "address": "https://nolus.rpc.liveraven.net",
         "provider": "LiveRaveN"
-      },
-      {
-        "address": "https://rpc-nolus.architectnodes.com",
-        "provider": "Architect Nodes"
-      },
-      {
-        "address": "https://nolus.rpc.kjnodes.com",
-        "provider": "kjnodes"
-      },
-      {
-        "address": "https://nolus-rpc.enigma-validator.com/",
-        "provider": "Enigma"
-      },
-      {
-        "address": "https://nolus-rpc.w3coins.io",
-        "provider": "w3coins"
-      },
-      {
-        "address": "https://nolus-rpc.publicnode.com:443",
-        "provider": "Allnodes ⚡️ Nodes & Staking"
       },
       {
         "address": "https://nolus-rpc.polkachu.com:443",
@@ -193,36 +165,8 @@
         "provider": "NolusProtocol"
       },
       {
-        "address": "https://nolus-mainnet-lcd.autostake.com:443",
-        "provider": "AutoStake 🛡️ Slash Protected"
-      },
-      {
-        "address": "https://rest.lavenderfive.com:443/nolus",
-        "provider": "Lavender.Five Nodes 🐝"
-      },
-      {
         "address": "https://nolus.api.liveraven.net",
         "provider": "LiveRaveN"
-      },
-      {
-        "address": "https://rest-nolus.architectnodes.com",
-        "provider": "Architect Nodes"
-      },
-      {
-        "address": "https://nolus.api.kjnodes.com",
-        "provider": "kjnodes"
-      },
-      {
-        "address": "https://nolus-lcd.enigma-validator.com/",
-        "provider": "Enigma"
-      },
-      {
-        "address": "https://nolus-api.w3coins.io",
-        "provider": "w3coins"
-      },
-      {
-        "address": "https://nolus-rest.publicnode.com",
-        "provider": "Allnodes ⚡️ Nodes & Staking"
       },
       {
         "address": "https://nolus-api.polkachu.com",
@@ -235,32 +179,8 @@
         "provider": "NolusProtocol"
       },
       {
-        "address": "nolus-mainnet-grpc.autostake.com:443",
-        "provider": "AutoStake 🛡️ Slash Protected"
-      },
-      {
-        "address": "nolus.lavenderfive.com:443",
-        "provider": "Lavender.Five Nodes 🐝"
-      },
-      {
         "address": "https://nolus.grpc.liveraven.net",
         "provider": "LiveRaveN"
-      },
-      {
-        "address": "grpc-nolus.architectnodes.com:1443",
-        "provider": "Architect Nodes"
-      },
-      {
-        "address": "nolus.grpc.kjnodes.com:14390",
-        "provider": "kjnodes"
-      },
-      {
-        "address": "nolus-grpc.w3coins.io:19790",
-        "provider": "w3coins"
-      },
-      {
-        "address": "nolus-grpc.publicnode.com:443",
-        "provider": "Allnodes ⚡️ Nodes & Staking"
       },
       {
         "address": "nolus-grpc.polkachu.com:19790",
@@ -269,24 +189,6 @@
     ]
   },
   "explorers": [
-    {
-      "kind": "Nolus Explorer",
-      "url": "https://explorer.nolus.io/pirin-1",
-      "tx_page": "https://explorer.nolus.io/pirin-1/tx/${txHash}",
-      "account_page": "https://explorer.nolus.io/pirin-1/account/${accountAddress}"
-    },
-    {
-      "kind": "ping.pub",
-      "url": "https://ping.pub/nolus",
-      "tx_page": "https://ping.pub/nolus/tx/${txHash}",
-      "account_page": "https://ping.pub/nolus/account/${accountAddress}"
-    },
-    {
-      "kind": "NODEXPLORER",
-      "url": "https://explorer.nodexcapital.com/nolus",
-      "tx_page": "https://explorer.nodexcapital.com/nolus/tx/${txHash}",
-      "account_page": "https://explorer.nodexcapital.com/nolus/account/${accountAddress}"
-    },
     {
       "kind": "Nodes Guru Explorer",
       "url": "https://nolus.explorers.guru",


### PR DESCRIPTION
`nolus` (`pirin-1`) lists 29 API endpoints. Only 9 of them still answer, three of each kind. This removes the 20 dead API entries plus 3 dead explorers.

Every removal is verified twice: probed directly, then cross checked against `status.cosmos.directory`, which probes from a different network and records a last success timestamp per endpoint.

## Removed API endpoints

| Provider | Observed here | cosmos.directory last success |
|---|---|---|
| kjnodes | TLS alert `unrecognized name` | 630 days |
| AutoStake | HTTP 404 on every URL form tried | 556 days |
| Allnodes / publicnode | HTTP 404, empty body | 451 days |
| Architect Nodes | `SSL_ERROR_SYSCALL` during TLS handshake | 300 days |
| Lavender.Five | HTTP 503 "No server is available", 3 of 3 tries | 248 days |
| w3coins | NXDOMAIN | 178 days |
| Enigma | NXDOMAIN | never succeeded |

That is 7 rpc, 7 rest and 6 grpc entries. gRPC was probed with `grpcurl` in three modes (TLS, plaintext, insecure) before being called unreachable.

## Removed explorers

```
https://explorer.nolus.io/pirin-1          DNS resolves NOERROR but returns no A record
https://ping.pub/nolus                     HTTP 404
https://explorer.nodexcapital.com/nolus    TLS alert unrecognized name
```

## What still works, confirmed live on pirin-1

```
rpc    https://rpc.nolus.network · https://nolus.rpc.liveraven.net · https://nolus-rpc.polkachu.com:443
rest   https://lcd.nolus.network · https://nolus.api.liveraven.net · https://nolus-api.polkachu.com
grpc   https://grpc.nolus.network · https://nolus.grpc.liveraven.net · nolus-grpc.polkachu.com:19790
```

Explorers kept: Nodes Guru, staking-explorer.com, KJ Nodes.

## Two things deliberately left alone

**No peers were removed.** All five seeds and the persistent peer look closed from my audit host, but so do control peers whose providers are demonstrably healthy, for example `cosmoshub.rpc.kjnodes.com:11359` and `osmosis-mainnet-seed.autostake.com:26716`. This host cannot reach p2p ports at all, so those probes prove nothing and I would rather leave the entries than remove them on bad evidence. Happy to revisit from a host with p2p egress.

**KJ Nodes Explorer stays** even though that provider's Nolus RPC has been down for 630 days. Its `/nolus/config.json` and `/zzz-not-a-chain-999/config.json` return byte identical responses, so it is a catch all single page app and HTTP 200 carries no information either way. Suspicious but not demonstrable.

## Note on the AutoStake 404

Worth recording for future endpoint audits: `acrechain-mainnet-rpc.autostake.com/status` also returns 404, and that is a chain AutoStake is listed for. The status code alone is not evidence. The 556 day figure from an independent prober is what makes this removal safe.

## Validation

```
node .github/workflows/utility/validate_data.mjs NO_API
→ exit 0
```
