### PR TITLE
chore(ci): name the Sync Versions workflow correctly

### DIFF
--- a/.github/workflows/sync_versions.yml
+++ b/.github/workflows/sync_versions.yml
@@ -3,10 +3,10 @@ on:
   schedule:
     - cron: '0 0 1,15 * *'  # runs at midnight on the 1st and 15th
 
-name: Sync Images
+name: Sync Versions
 jobs:
-  sync_images:
-    name: Sync Images
+  sync_versions:
+    name: Sync Versions
     runs-on: ubuntu-latest
     
     defaults:
@@ -48,7 +48,7 @@ jobs:
           target_branch: master
           title: Sync Versions
           body: "**Automated pull request** If closing, remember to delete the branch!"
-          old_string: "**THIS IS AN AUTOMATED UPDATE OF IMAGES**"
+          old_string: "**THIS IS AN AUTOMATED UPDATE OF VERSIONS**"
           new_string: "** Automatic pull request**"
           get_diff: true
           ignore_users: "dependabot"


### PR DESCRIPTION
### Problem

`.github/workflows/sync_versions.yml` was copied from `sync_images.yml` and kept its top-level `name: Sync Images`. GitHub Actions uses that key as the workflow's display title, so both workflows register under the same name:

```
Sync Images   .github/workflows/sync_images.yml     id=70964786
Sync Images   .github/workflows/sync_versions.yml   id=198234964
```

Every run inherits it too — the last several runs of `sync_versions.yml` all report `name="Sync Images"`. The result is two indistinguishable "Sync Images" entries in the Actions sidebar, and run history for either one is ambiguous at a glance.

### Change

Four leftover strings in `sync_versions.yml`:

- top-level `name:` → `Sync Versions`
- job key `sync_images:` → `sync_versions:`
- job `name:` → `Sync Versions`
- `old_string` input: `...UPDATE OF IMAGES` → `...UPDATE OF VERSIONS`

### No functional change

The workflow already did the right work — only the labels were wrong. It runs `node sync_versions.mjs`, commits `Sync Versions`, targets `update/versions`, and opens PRs titled `Sync Versions` (e.g. #7810). Its cron is also already distinct from the images one (1st & 15th vs 8th & 22nd).

Two notes on safety:
- the job key is not referenced by any `needs:`, and nothing else in `.github/` references `sync_images` outside `sync_images.yml`/`sync_images.mjs`, so renaming it is inert
- `old_string` never matched the configured PR body, so that input was already a no-op; it is updated only for consistency

YAML re-parsed after the edit to confirm the job key, job name and `run:` step resolve as expected.