### PR TITLE
fix(endpoints): remove dead Quasar (quasarstaking.ai) endpoints registry-wide

### DIFF
--- a/cosmoshub/chain.json
+++ b/cosmoshub/chain.json
@@ -267,10 +267,6 @@
         "provider": "ITRocket"
       },
       {
-        "address": "https://cosmoshub.rpc.quasarstaking.ai",
-        "provider": "Quasar"
-      },
-      {
         "address": "https://cosmos.ibs.team:443/rpc",
         "provider": "Inter Blockchain Services"
       },
@@ -390,10 +386,6 @@
         "provider": "ITRocket"
       },
       {
-        "address": "https://cosmoshub.api.quasarstaking.ai",
-        "provider": "Quasar"
-      },
-      {
         "address": "https://cosmos.ibs.team:443/api",
         "provider": "Inter Blockchain Services"
       },
@@ -479,10 +471,6 @@
       {
         "address": "cosmoshub-mainnet-grpc.itrocket.net:443",
         "provider": "ITRocket"
-      },
-      {
-        "address": "https://cosmoshub.grpc.quasarstaking.ai",
-        "provider": "Quasar"
       },
       {
         "address": "grpc.cosmoshub-4-archive.citizenweb3.com:443",

--- a/dungeon/chain.json
+++ b/dungeon/chain.json
@@ -27,10 +27,6 @@
         "provider": "Dungeon Games"
       },
       {
-        "address": "https://dungeon-wallet.rpc.quasarstaking.ai",
-        "provider": "Quasar"
-      },
-      {
         "address": "https://rpc-dungeon-1.seraphim.zone",
         "provider": "Seraphim"
       },
@@ -47,10 +43,6 @@
       {
         "address": "https://api.dungeongames.io",
         "provider": "Dungeon Games"
-      },
-      {
-        "address": "https://dungeon-wallet.api.quasarstaking.ai",
-        "provider": "Quasar"
       },
       {
         "address": "https://api-dungeon-1.seraphim.zone",
@@ -70,10 +62,6 @@
       }
     ],
     "grpc": [
-      {
-        "address": "dungeon.grpc.quasarstaking.ai:80",
-        "provider": "Quasar"
-      },
       {
         "address": "grpc.dungeon.chaintools.tech:443",
         "provider": "ChainTools"

--- a/dungeon1/chain.json
+++ b/dungeon1/chain.json
@@ -23,10 +23,6 @@
   "apis": {
     "rpc": [
       {
-        "address": "https://dungeon-wallet.rpc.quasarstaking.ai",
-        "provider": "Quasar"
-      },
-      {
         "address": "https://rpc-dungeon-1.seraphim.zone",
         "provider": "Seraphim"
       },
@@ -36,10 +32,6 @@
       }
     ],
     "rest": [
-      {
-        "address": "https://dungeon-wallet.api.quasarstaking.ai",
-        "provider": "Quasar"
-      },
       {
         "address": "https://api-dungeon-1.seraphim.zone",
         "provider": "Seraphim"

--- a/initia/chain.json
+++ b/initia/chain.json
@@ -98,10 +98,6 @@
         "provider": "Initia Labs"
       },
       {
-        "address": "https://initia.rpc.quasarstaking.ai:443",
-        "provider": "Quasar"
-      },
-      {
         "address": "https://initia-mainnet-rpc.autostake.com:443",
         "provider": "AutoStake 🛡️ Slash Protected"
       },
@@ -116,10 +112,6 @@
         "provider": "Initia Labs"
       },
       {
-        "address": "https://initia.api.quasarstaking.ai:443",
-        "provider": "Quasar"
-      },
-      {
         "address": "https://initia-mainnet-lcd.autostake.com:443",
         "provider": "AutoStake 🛡️ Slash Protected"
       },
@@ -132,10 +124,6 @@
       {
         "address": "grpc.initia.xyz:443",
         "provider": "Initia Labs"
-      },
-      {
-        "address": "initia.grpc.quasarstaking.ai:80",
-        "provider": "Quasar"
       },
       {
         "address": "initia-mainnet-grpc.autostake.com:443",

--- a/kopi/chain.json
+++ b/kopi/chain.json
@@ -171,10 +171,6 @@
       {
         "address": "https://kopi-rpc.node39.top:443",
         "provider": "Node39"
-      },
-      {
-        "address": "https://kopi.rpc.quasarstaking.ai:443",
-        "provider": "Quasar"
       }
     ],
     "rest": [
@@ -229,10 +225,6 @@
       {
         "address": "https://kopi-api.node39.top:443",
         "provider": "Node39"
-      },
-      {
-        "address": "https://kopi.api.quasarstaking.ai:443",
-        "provider": "Quasar"
       }
     ],
     "grpc": [
@@ -267,10 +259,6 @@
       {
         "address": "https://kopi-grpc.node39.top:15090",
         "provider": "Node39"
-      },
-      {
-        "address": "kopi.grpc.quasarstaking.ai:80",
-        "provider": "Quasar"
       }
     ]
   },

--- a/sentinel/chain.json
+++ b/sentinel/chain.json
@@ -317,10 +317,6 @@
         "provider": "chainvibes"
       },
       {
-        "address": "https://sentinel.rpc.quasarstaking.ai:443",
-        "provider": "Quasar"
-      },
-      {
         "address": "https://rpc.sentinel.validatus.com",
         "provider": "Validatus"
       },
@@ -391,10 +387,6 @@
         "provider": "chainvibes"
       },
       {
-        "address": "https://sentinel.api.quasarstaking.ai:443",
-        "provider": "Quasar"
-      },
-      {
         "address": "https://api.sentinel.validatus.com",
         "provider": "Validatus"
       },
@@ -447,10 +439,6 @@
       {
         "address": "https://grpc.noncompliant.network:9090",
         "provider": "Noncompliant Network (Insecure)"
-      },
-      {
-        "address": "sentinel.grpc.quasarstaking.ai:80",
-        "provider": "Quasar"
       },
       {
         "address": "grpc.sentinel.validatus.com:443",


### PR DESCRIPTION
The **quasarstaking.ai** domain no longer resolves. This removes all **17** Quasar RPC/REST/gRPC entries across **6 chains**.

### Verification (2026-08-27)

**DNS — two independent resolvers, root domain included:**

| Host | Google DoH | Cloudflare DoH |
|---|---|---|
| `quasarstaking.ai` (root) | Status 3 (NXDOMAIN) | Status 3 (NXDOMAIN) |
| all 15 registry hostnames | Status 3 | Status 3 |

The root domain itself is gone, so this is a wound-down provider rather than a per-chain decommission.

**Independent second source** — `status.cosmos.directory/initia` reports both Quasar entries as `DOWN` with `lastSuccessAt: never` and `lastError: "Socket closed before the connection was established"`.

### Removed

| Chain | Entries | Array sizes after |
|---|---|---|
| cosmoshub | rpc, rest, grpc | 33 / 29 / 19 |
| sentinel | rpc, rest, grpc | 19 / 17 / 13 |
| kopi | rpc, rest, grpc | 14 / 13 / 8 |
| dungeon | rpc, rest, grpc | 4 / 5 / 1 |
| initia | rpc, rest, grpc | 3 / 3 / 3 |
| dungeon1 | rpc, rest | 2 / 3 |

**No array is emptied on any chain.** Entries were matched by hostname rather than by provider label.

### Scope notes

- **`peers[]` deliberately untouched.** The audit host cannot reach any p2p port — confirmed by negative control against a known-live peer endpoint, which also read closed. The three Quasar-labelled `persistent_peers` on `91.223.3.148` are therefore not provable from here and are held back rather than guessed at.
- **AutoStake was examined and excluded.** Its endpoints 404 on these chains, but they 404 identically on cosmos/osmosis/akash/celestia and on `autostake.com` itself, with gRPC returning 403 across chains. That is an infra-wide condition, not something to fix chain-by-chain here.
- **Polkachu was checked and kept.** Its gRPC first appeared dead under a TLS probe (`tls: first record does not look like a TLS handshake`); port 25790 is plaintext, and it answers correctly as `interwoven-1` when probed that way.

Pure deletion: **+0 / −68**, no reformatting. Each file was verified to round-trip byte-identically through `json.dumps(indent=2)` before editing, with per-file trailing-newline preserved.
