### PR TITLE
chore(juno): remove Cogwheel endpoints

### DIFF
--- a/juno/chain.json
+++ b/juno/chain.json
@@ -203,10 +203,6 @@
         "provider": "Validatus"
       },
       {
-        "address": "https://juno-rpc.cogwheel.zone",
-        "provider": "Cogwheel"
-      },
-      {
         "address": "https://juno.api.pocket.network",
         "provider": "Pocket Network"
       },
@@ -249,10 +245,6 @@
         "provider": "Validatus"
       },
       {
-        "address": "https://juno-api.cogwheel.zone",
-        "provider": "Cogwheel"
-      },
-      {
         "address": "https://juno.api.pocket.network",
         "provider": "Pocket Network"
       }
@@ -277,10 +269,6 @@
       {
         "address": "juno-grpc.publicnode.com:443",
         "provider": "Allnodes ⚡️ Nodes & Staking"
-      },
-      {
-        "address": "juno-grpc.cogwheel.zone:443",
-        "provider": "Cogwheel"
       },
       {
         "address": "grpc.juno.validatus.com:443",


### PR DESCRIPTION
Cogwheel will no longer provide endpoints for the Juno Network. This is just a cleanup operation so no one attempts to use these endpoints in production.