### PR TITLE
Add AxiomeScan explorer to axiome

### DIFF
--- a/axiome/chain.json
+++ b/axiome/chain.json
@@ -67,6 +67,14 @@
       "url": "https://axiomechain.pro",
       "tx_page": "https://axiomechain.pro/transactions/${txHash}",
       "account_page": "https://axiomechain.pro/address/${accountAddress}"
+    },
+    {
+      "kind": "AxiomeScan",
+      "url": "https://axiomescan.pro",
+      "tx_page": "https://axiomescan.pro/tx/${txHash}",
+      "account_page": "https://axiomescan.pro/address/${accountAddress}",
+      "validator_page": "https://axiomescan.pro/validators/${validatorAddress}",
+      "block_page": "https://axiomescan.pro/blocks/${blockHeight}"
     }
   ],
   "images": [


### PR DESCRIPTION
Adds AxiomeScan as a second block explorer for the `axiome` chain.

AxiomeScan is a public explorer for Axiome Chain (chain-id `axiome-1`): blocks, transactions, accounts, validators, CW20 tokens, CW721 collections, pools and contracts. It runs its own indexer over the chain, is available in 7 languages, and has been live at https://axiomescan.pro since 2026.

Link patterns follow the existing entry style:

- `tx_page`: https://axiomescan.pro/tx/${txHash}
- `account_page`: https://axiomescan.pro/address/${accountAddress}
- `validator_page`: https://axiomescan.pro/validators/${validatorAddress}
- `block_page`: https://axiomescan.pro/blocks/${blockHeight}

All four paths resolve without a locale prefix and redirect to the visitor's language.

Only `axiome/chain.json` is touched, the existing explorer entry is left unchanged.