### PR TITLE
Add ZIGChain testnet v5.0.0 (azig redenomination)

### DIFF
--- a/testnets/zigchaintestnet/assetlist.json
+++ b/testnets/zigchaintestnet/assetlist.json
@@ -6,25 +6,15 @@
       "description": "The native token of ZIGChain",
       "denom_units": [
         {
-          "denom": "uzig",
-          "exponent": 0,
-          "aliases": [
-            "microzig"
-          ]
-        },
-        {
-          "denom": "mzig",
-          "exponent": 3,
-          "aliases": [
-            "millizig"
-          ]
+          "denom": "azig",
+          "exponent": 0
         },
         {
           "denom": "zig",
-          "exponent": 6
+          "exponent": 18
         }
       ],
-      "base": "uzig",
+      "base": "azig",
       "name": "ZIG",
       "display": "zig",
       "symbol": "ZIG",
@@ -33,7 +23,7 @@
           "type": "test-mintage",
           "counterparty": {
             "chain_name": "zigchain",
-            "base_denom": "uzig"
+            "base_denom": "azig"
           },
           "provider": "ZIGChain"
         }
@@ -55,7 +45,7 @@
         {
           "image_sync": {
             "chain_name": "zigchain",
-            "base_denom": "uzig"
+            "base_denom": "azig"
           },
           "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/zigchain/images/zigchain.png",
           "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/zigchain/images/zigchain.svg"
@@ -69,6 +59,30 @@
         "medium": "https://medium.com/zignaly",
         "x": "https://x.com/zigchain"
       }
+    },
+    {
+      "description": "Legacy pre-v5 base denomination retained for IBC escrow vouchers after the azig redenomination",
+      "denom_units": [
+        {
+          "denom": "uzig",
+          "exponent": 0
+        }
+      ],
+      "base": "uzig",
+      "name": "Legacy ZIG",
+      "display": "uzig",
+      "symbol": "UZIG",
+      "logo_URIs": {
+        "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/zigchain/images/zigchain.png",
+        "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/zigchain/images/zigchain.svg"
+      },
+      "images": [
+        {
+          "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/zigchain/images/zigchain.png",
+          "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/zigchain/images/zigchain.svg"
+        }
+      ],
+      "type_asset": "sdk.coin"
     },
     {
       "description": "Staked Zig Token by Valdora Finance - Decentralized staking with stZIG",

--- a/testnets/zigchaintestnet/assetlist.json
+++ b/testnets/zigchaintestnet/assetlist.json
@@ -23,7 +23,7 @@
           "type": "test-mintage",
           "counterparty": {
             "chain_name": "zigchain",
-            "base_denom": "azig"
+            "base_denom": "uzig"
           },
           "provider": "ZIGChain"
         }
@@ -45,7 +45,7 @@
         {
           "image_sync": {
             "chain_name": "zigchain",
-            "base_denom": "azig"
+            "base_denom": "uzig"
           },
           "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/zigchain/images/zigchain.png",
           "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/zigchain/images/zigchain.svg"
@@ -61,28 +61,57 @@
       }
     },
     {
-      "description": "Legacy pre-v5 base denomination retained for IBC escrow vouchers after the azig redenomination",
+      "description": "Legacy pre-v5 base denomination of ZIG (6 decimals), retained only as IBC escrow backing after the uzig to azig redenomination.",
+      "deprecated": true,
       "denom_units": [
         {
           "denom": "uzig",
-          "exponent": 0
+          "exponent": 0,
+          "aliases": [
+            "microzig"
+          ]
+        },
+        {
+          "denom": "mzig",
+          "exponent": 3,
+          "aliases": [
+            "millizig"
+          ]
+        },
+        {
+          "denom": "zig",
+          "exponent": 6
         }
       ],
+      "type_asset": "sdk.coin",
       "base": "uzig",
-      "name": "Legacy ZIG",
-      "display": "uzig",
-      "symbol": "UZIG",
+      "name": "ZIG",
+      "display": "zig",
+      "symbol": "ZIG.legacy",
+      "traces": [
+        {
+          "type": "legacy-mintage",
+          "counterparty": {
+            "chain_name": "zigchaintestnet",
+            "base_denom": "azig"
+          },
+          "provider": "ZIGChain"
+        }
+      ],
       "logo_URIs": {
         "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/zigchain/images/zigchain.png",
         "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/zigchain/images/zigchain.svg"
       },
       "images": [
         {
+          "image_sync": {
+            "chain_name": "zigchaintestnet",
+            "base_denom": "azig"
+          },
           "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/zigchain/images/zigchain.png",
           "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/zigchain/images/zigchain.svg"
         }
-      ],
-      "type_asset": "sdk.coin"
+      ]
     },
     {
       "description": "Staked Zig Token by Valdora Finance - Decentralized staking with stZIG",

--- a/testnets/zigchaintestnet/chain.json
+++ b/testnets/zigchaintestnet/chain.json
@@ -22,18 +22,18 @@
   "fees": {
     "fee_tokens": [
       {
-        "denom": "uzig",
-        "fixed_min_gas_price": 0.0025,
-        "low_gas_price": 0.0025,
-        "average_gas_price": 0.025,
-        "high_gas_price": 0.05
+        "denom": "azig",
+        "fixed_min_gas_price": 2500000000,
+        "low_gas_price": 2500000000,
+        "average_gas_price": 25000000000,
+        "high_gas_price": 50000000000
       }
     ]
   },
   "staking": {
     "staking_tokens": [
       {
-        "denom": "uzig"
+        "denom": "azig"
       }
     ],
     "lock_duration": {
@@ -205,7 +205,7 @@
     {
       "image_sync": {
         "chain_name": "zigchaintestnet",
-        "base_denom": "uzig"
+        "base_denom": "azig"
       },
       "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/zigchain/images/zigchain.png",
       "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/zigchain/images/zigchain.svg"

--- a/testnets/zigchaintestnet/chain.json
+++ b/testnets/zigchaintestnet/chain.json
@@ -100,11 +100,11 @@
     ],
     "consensus": {
       "type": "cometbft",
-      "version": "0.38.21"
+      "version": "0.38.25"
     },
     "sdk": {
       "type": "cosmos",
-      "version": "0.53.5"
+      "version": "0.53.8"
     },
     "ibc": {
       "type": "go",
@@ -125,7 +125,7 @@
     "tag": "v5.0.0",
     "language": {
       "type": "go",
-      "version": "1.25.9"
+      "version": "1.25.13"
     }
   },
   "peers": {

--- a/testnets/zigchaintestnet/chain.json
+++ b/testnets/zigchaintestnet/chain.json
@@ -94,9 +94,9 @@
   },
   "codebase": {
     "git_repo": "https://github.com/ZIGChain/zigchain",
-    "recommended_version": "4.1.0",
+    "recommended_version": "5.0.0",
     "compatible_versions": [
-      "4.1.0"
+      "5.0.0"
     ],
     "consensus": {
       "type": "cometbft",
@@ -118,11 +118,11 @@
       "genesis_url": "https://github.com/ZIGChain/networks/raw/main/zig-test-2/genesis.json"
     },
     "binaries": {
-      "linux/amd64": "https://github.com/ZIGChain/networks/raw/refs/heads/main/binaries/zigchaind-v4.1.0-linux-amd64.tar.gz?checksum=sha256:1a64152e48fb25c990bfcf52c0578171137470b78a79859e3c861714e099cd5e",
-      "darwin/amd64": "https://github.com/ZIGChain/networks/raw/refs/heads/main/binaries/zigchaind-v4.1.0-darwin-amd64.tar.gz?checksum=sha256:adb639e7e1496ec30de54f7dbcd8a8110548b95ca3b3b1d20ca65ec4ad2bfaa0",
-      "darwin/arm64": "https://github.com/ZIGChain/networks/raw/refs/heads/main/binaries/zigchaind-v4.1.0-darwin-arm64.tar.gz?checksum=sha256:a27cb748c8b4c90724378109e518fd730f8471d9e28fbea56bb963b3757fd6da"
+      "linux/amd64": "https://github.com/ZIGChain/networks/raw/refs/heads/main/binaries/zigchaind-v5.0.0-linux-amd64.tar.gz?checksum=sha256:3cf12ad3d40e861d6d8302317fb42695d2994def3bd57cc64f69407a6c21e80d",
+      "darwin/amd64": "https://github.com/ZIGChain/networks/raw/refs/heads/main/binaries/zigchaind-v5.0.0-darwin-amd64.tar.gz?checksum=sha256:a7c4e675b70fb2d2023937491fc3cecc2d3e6fc22bc501d55151cf8f1743e51f",
+      "darwin/arm64": "https://github.com/ZIGChain/networks/raw/refs/heads/main/binaries/zigchaind-v5.0.0-darwin-arm64.tar.gz?checksum=sha256:7cd3e5deeec6be8c959f11e295bb4f3dca0d7493e6dd23006774e9ebe4cb3714"
     },
-    "tag": "v4.1.0",
+    "tag": "v5.0.0",
     "language": {
       "type": "go",
       "version": "1.25.9"

--- a/testnets/zigchaintestnet/chain.json
+++ b/testnets/zigchaintestnet/chain.json
@@ -94,9 +94,9 @@
   },
   "codebase": {
     "git_repo": "https://github.com/ZIGChain/zigchain",
-    "recommended_version": "5.0.0",
+    "recommended_version": "5.0.0-patch-1",
     "compatible_versions": [
-      "5.0.0"
+      "5.0.0-patch-1"
     ],
     "consensus": {
       "type": "cometbft",
@@ -118,11 +118,11 @@
       "genesis_url": "https://github.com/ZIGChain/networks/raw/main/zig-test-2/genesis.json"
     },
     "binaries": {
-      "linux/amd64": "https://github.com/ZIGChain/networks/raw/refs/heads/main/binaries/zigchaind-v5.0.0-linux-amd64.tar.gz?checksum=sha256:3cf12ad3d40e861d6d8302317fb42695d2994def3bd57cc64f69407a6c21e80d",
-      "darwin/amd64": "https://github.com/ZIGChain/networks/raw/refs/heads/main/binaries/zigchaind-v5.0.0-darwin-amd64.tar.gz?checksum=sha256:a7c4e675b70fb2d2023937491fc3cecc2d3e6fc22bc501d55151cf8f1743e51f",
-      "darwin/arm64": "https://github.com/ZIGChain/networks/raw/refs/heads/main/binaries/zigchaind-v5.0.0-darwin-arm64.tar.gz?checksum=sha256:7cd3e5deeec6be8c959f11e295bb4f3dca0d7493e6dd23006774e9ebe4cb3714"
+      "linux/amd64": "https://github.com/ZIGChain/networks/raw/refs/heads/main/binaries/v5.0.0-patch-1/zigchaind-v5.0.0-patch-1-linux-amd64.tar.gz?checksum=sha256:002c1edb1db0f32ac16bc3faaa96438b1720f9330b2fca438108f19cd49586ee",
+      "darwin/amd64": "https://github.com/ZIGChain/networks/raw/refs/heads/main/binaries/v5.0.0-patch-1/zigchaind-v5.0.0-patch-1-darwin-amd64.tar.gz?checksum=sha256:3b9dfc2cfd290fe2cf8e7a2f6ba6cff5f93f9a2f1fb1c2565ca27b17803e9b28",
+      "darwin/arm64": "https://github.com/ZIGChain/networks/raw/refs/heads/main/binaries/v5.0.0-patch-1/zigchaind-v5.0.0-patch-1-darwin-arm64.tar.gz?checksum=sha256:408972867f66ae17fcf6730c5e5c96432f2175a96a36d991b6e0f26d7fa567ef"
     },
-    "tag": "v5.0.0",
+    "tag": "v5.0.0-patch-1",
     "language": {
       "type": "go",
       "version": "1.25.13"

--- a/testnets/zigchaintestnet/versions.json
+++ b/testnets/zigchaintestnet/versions.json
@@ -316,7 +316,7 @@
       ],
       "consensus": {
         "type": "cometbft",
-        "version": "0.38.21"
+        "version": "0.38.25"
       },
       "cosmwasm": {
         "version": "0.55.1",
@@ -324,7 +324,7 @@
       },
       "sdk": {
         "type": "cosmos",
-        "version": "0.53.5"
+        "version": "0.53.8"
       },
       "ibc": {
         "type": "go",
@@ -332,7 +332,7 @@
       },
       "language": {
         "type": "go",
-        "version": "1.25.9"
+        "version": "1.25.13"
       },
       "binaries": {
         "linux/amd64": "https://github.com/ZIGChain/networks/raw/refs/heads/main/binaries/zigchaind-v5.0.0-linux-amd64.tar.gz?checksum=sha256:3cf12ad3d40e861d6d8302317fb42695d2994def3bd57cc64f69407a6c21e80d",

--- a/testnets/zigchaintestnet/versions.json
+++ b/testnets/zigchaintestnet/versions.json
@@ -298,11 +298,48 @@
         "version": "1.25.9"
       },
       "binaries": {
-        "linux/amd64": "https://github.com/ZIGChain/networks/raw/refs/heads/main/binaries/zigchaind-v4.1.0-linux-amd64.tar.gz?checksum=sha256:1a64152e48fb25c990bfcf52c0578171137470b78a79859e3c861714e099cd5e",
-        "darwin/amd64": "https://github.com/ZIGChain/networks/raw/refs/heads/main/binaries/zigchaind-v4.1.0-darwin-amd64.tar.gz?checksum=sha256:adb639e7e1496ec30de54f7dbcd8a8110548b95ca3b3b1d20ca65ec4ad2bfaa0",
-        "darwin/arm64": "https://github.com/ZIGChain/networks/raw/refs/heads/main/binaries/zigchaind-v4.1.0-darwin-arm64.tar.gz?checksum=sha256:a27cb748c8b4c90724378109e518fd730f8471d9e28fbea56bb963b3757fd6da"
+        "linux/amd64": "https://github.com/ZIGChain/networks/raw/refs/heads/main/binaries/archive/zigchaind-v4.1.0-linux-amd64.tar.gz?checksum=sha256:1a64152e48fb25c990bfcf52c0578171137470b78a79859e3c861714e099cd5e",
+        "darwin/amd64": "https://github.com/ZIGChain/networks/raw/refs/heads/main/binaries/archive/zigchaind-v4.1.0-darwin-amd64.tar.gz?checksum=sha256:adb639e7e1496ec30de54f7dbcd8a8110548b95ca3b3b1d20ca65ec4ad2bfaa0",
+        "darwin/arm64": "https://github.com/ZIGChain/networks/raw/refs/heads/main/binaries/archive/zigchaind-v4.1.0-darwin-arm64.tar.gz?checksum=sha256:a27cb748c8b4c90724378109e518fd730f8471d9e28fbea56bb963b3757fd6da"
       },
       "previous_version_name": "v4",
+      "next_version_name": "v5"
+    },
+    {
+      "name": "v5",
+      "tag": "v5.0.0",
+      "height": 7669200,
+      "proposal": 118,
+      "recommended_version": "5.0.0",
+      "compatible_versions": [
+        "5.0.0"
+      ],
+      "consensus": {
+        "type": "cometbft",
+        "version": "0.38.21"
+      },
+      "cosmwasm": {
+        "version": "0.55.1",
+        "enabled": true
+      },
+      "sdk": {
+        "type": "cosmos",
+        "version": "0.53.5"
+      },
+      "ibc": {
+        "type": "go",
+        "version": "10.1.1"
+      },
+      "language": {
+        "type": "go",
+        "version": "1.25.9"
+      },
+      "binaries": {
+        "linux/amd64": "https://github.com/ZIGChain/networks/raw/refs/heads/main/binaries/zigchaind-v5.0.0-linux-amd64.tar.gz?checksum=sha256:3cf12ad3d40e861d6d8302317fb42695d2994def3bd57cc64f69407a6c21e80d",
+        "darwin/amd64": "https://github.com/ZIGChain/networks/raw/refs/heads/main/binaries/zigchaind-v5.0.0-darwin-amd64.tar.gz?checksum=sha256:a7c4e675b70fb2d2023937491fc3cecc2d3e6fc22bc501d55151cf8f1743e51f",
+        "darwin/arm64": "https://github.com/ZIGChain/networks/raw/refs/heads/main/binaries/zigchaind-v5.0.0-darwin-arm64.tar.gz?checksum=sha256:7cd3e5deeec6be8c959f11e295bb4f3dca0d7493e6dd23006774e9ebe4cb3714"
+      },
+      "previous_version_name": "v4.1",
       "next_version_name": ""
     }
   ]

--- a/testnets/zigchaintestnet/versions.json
+++ b/testnets/zigchaintestnet/versions.json
@@ -117,9 +117,9 @@
       },
       "tag": "1.2.2",
       "binaries": {
-        "linux/amd64": "https://github.com/ZIGChain/networks/raw/refs/heads/main/zig-test-2/binaries/zigchaind-v1.2.2-linux-amd64.tar.gz",
-        "darwin/amd64": "https://github.com/ZIGChain/networks/raw/refs/heads/main/zig-test-2/binaries/zigchaind-v1.2.2-darwin-amd64.tar.gz",
-        "darwin/arm64": "https://github.com/ZIGChain/networks/raw/refs/heads/main/zig-test-2/binaries/zigchaind-v1.2.2-darwin-amd64.tar.gz"
+        "linux/amd64": "https://github.com/ZIGChain/networks/raw/refs/heads/main/binaries/v1.x/zigchaind-v1.2.2-linux-amd64.tar.gz",
+        "darwin/amd64": "https://github.com/ZIGChain/networks/raw/refs/heads/main/binaries/v1.x/zigchaind-v1.2.2-darwin-amd64.tar.gz",
+        "darwin/arm64": "https://github.com/ZIGChain/networks/raw/refs/heads/main/binaries/v1.x/zigchaind-v1.2.2-darwin-arm64.tar.gz"
       },
       "ibc": {
         "type": "go",
@@ -156,9 +156,9 @@
         "version": "1.25.4"
       },
       "binaries": {
-        "linux/amd64": "https://github.com/ZIGChain/networks/raw/refs/heads/main/zig-test-2/binaries/zigchaind-v2.0.0-linux-amd64.tar.gz?checksum=sha256:8f2a4a51fa2d73b7bc61c33d30332fb61e76ed0be4a381a37d27aa17115a9040",
-        "darwin/amd64": "https://github.com/ZIGChain/networks/raw/refs/heads/main/zig-test-2/binaries/zigchaind-v2.0.0-darwin-amd64.tar.gz?checksum=sha256:6269882ccb1caf0af7600f2d24f5aeae7710290aba299d0d4ed607c6e63da803",
-        "darwin/arm64": "https://github.com/ZIGChain/networks/raw/refs/heads/main/zig-test-2/binaries/zigchaind-v2.0.0-darwin-arm64.tar.gz?checksum=sha256:07f59514973d67e0d09c27b1be50da78f3b824518f1ee4735c09322ec1bd3789"
+        "linux/amd64": "https://github.com/ZIGChain/networks/raw/refs/heads/main/binaries/v2.x/zigchaind-v2.0.0-linux-amd64.tar.gz?checksum=sha256:8f2a4a51fa2d73b7bc61c33d30332fb61e76ed0be4a381a37d27aa17115a9040",
+        "darwin/amd64": "https://github.com/ZIGChain/networks/raw/refs/heads/main/binaries/v2.x/zigchaind-v2.0.0-darwin-amd64.tar.gz?checksum=sha256:6269882ccb1caf0af7600f2d24f5aeae7710290aba299d0d4ed607c6e63da803",
+        "darwin/arm64": "https://github.com/ZIGChain/networks/raw/refs/heads/main/binaries/v2.x/zigchaind-v2.0.0-darwin-arm64.tar.gz?checksum=sha256:07f59514973d67e0d09c27b1be50da78f3b824518f1ee4735c09322ec1bd3789"
       },
       "previous_version_name": "1.2.2",
       "next_version_name": "v2.0.1"
@@ -191,9 +191,9 @@
         "version": "1.25.4"
       },
       "binaries": {
-        "linux/amd64": "https://github.com/ZIGChain/networks/raw/refs/heads/main/binaries/archive/zigchaind-v2.0.1-linux-amd64.tar.gz?checksum=sha256:3f534611a1a07b5aea1b393703e5d05ee903ceebdf0fc09a80a0352e1c54c619",
-        "darwin/amd64": "https://github.com/ZIGChain/networks/raw/refs/heads/main/binaries/archive/zigchaind-v2.0.1-darwin-amd64.tar.gz?checksum=sha256:b00fed37405605a271ae7a7b924111edf4a7f208321b268110f2d9e291e5c5f9",
-        "darwin/arm64": "https://github.com/ZIGChain/networks/raw/refs/heads/main/binaries/archive/zigchaind-v2.0.1-darwin-arm64.tar.gz?checksum=sha256:948f91b481bf88a259ff93164ac710b32d19dbdfc7f670ac06b352dd589dc2a0"
+        "linux/amd64": "https://github.com/ZIGChain/networks/raw/refs/heads/main/binaries/v2.x/zigchaind-v2.0.1-linux-amd64.tar.gz?checksum=sha256:3f534611a1a07b5aea1b393703e5d05ee903ceebdf0fc09a80a0352e1c54c619",
+        "darwin/amd64": "https://github.com/ZIGChain/networks/raw/refs/heads/main/binaries/v2.x/zigchaind-v2.0.1-darwin-amd64.tar.gz?checksum=sha256:b00fed37405605a271ae7a7b924111edf4a7f208321b268110f2d9e291e5c5f9",
+        "darwin/arm64": "https://github.com/ZIGChain/networks/raw/refs/heads/main/binaries/v2.x/zigchaind-v2.0.1-darwin-arm64.tar.gz?checksum=sha256:948f91b481bf88a259ff93164ac710b32d19dbdfc7f670ac06b352dd589dc2a0"
       },
       "previous_version_name": "v2",
       "next_version_name": "v3"
@@ -226,9 +226,9 @@
         "version": "1.25.5"
       },
       "binaries": {
-        "linux/amd64": "https://github.com/ZIGChain/networks/raw/refs/heads/main/binaries/archive/zigchaind-v3.0.0-linux-amd64.tar.gz?checksum=sha256:9ed9c97a9f2edf86404b9d0b47b6bf6bc72c04de6293f193775fd93b123d336d",
-        "darwin/amd64": "https://github.com/ZIGChain/networks/raw/refs/heads/main/binaries/archive/zigchaind-v3.0.0-darwin-amd64.tar.gz?checksum=sha256:0710ad5f9b9db0731c3e498acbdb476c0b8610a88770b617a3c28026edb55e28",
-        "darwin/arm64": "https://github.com/ZIGChain/networks/raw/refs/heads/main/binaries/archive/zigchaind-v3.0.0-darwin-arm64.tar.gz?checksum=sha256:14a735463fd946f36a783e5e72f56d1303e0165493b178168fba7739bbe6a9f0"
+        "linux/amd64": "https://github.com/ZIGChain/networks/raw/refs/heads/main/binaries/v3.x/zigchaind-v3.0.0-linux-amd64.tar.gz?checksum=sha256:9ed9c97a9f2edf86404b9d0b47b6bf6bc72c04de6293f193775fd93b123d336d",
+        "darwin/amd64": "https://github.com/ZIGChain/networks/raw/refs/heads/main/binaries/v3.x/zigchaind-v3.0.0-darwin-amd64.tar.gz?checksum=sha256:0710ad5f9b9db0731c3e498acbdb476c0b8610a88770b617a3c28026edb55e28",
+        "darwin/arm64": "https://github.com/ZIGChain/networks/raw/refs/heads/main/binaries/v3.x/zigchaind-v3.0.0-darwin-arm64.tar.gz?checksum=sha256:14a735463fd946f36a783e5e72f56d1303e0165493b178168fba7739bbe6a9f0"
       },
       "previous_version_name": "v2.0.1",
       "next_version_name": "v4"
@@ -261,9 +261,9 @@
         "version": "1.25.9"
       },
       "binaries": {
-        "linux/amd64": "https://github.com/ZIGChain/networks/raw/refs/heads/main/binaries/archive/zigchaind-v4.0.0-linux-amd64.tar.gz?checksum=sha256:afc9f73f4c4e006363c4d7468d1d59483babef11129e1f2d4bddf6b0a4ca5807",
-        "darwin/amd64": "https://github.com/ZIGChain/networks/raw/refs/heads/main/binaries/archive/zigchaind-v4.0.0-darwin-amd64.tar.gz?checksum=sha256:06d36ba8fa32236140478b8633215e5c585570dccbef508c5ec84fc79dddaa10",
-        "darwin/arm64": "https://github.com/ZIGChain/networks/raw/refs/heads/main/binaries/archive/zigchaind-v4.0.0-darwin-arm64.tar.gz?checksum=sha256:21b31af4213cb51a05de3190fb2c4b2cf9710e5aef568aaf1c1361f95088f023"
+        "linux/amd64": "https://github.com/ZIGChain/networks/raw/refs/heads/main/binaries/v4.x/zigchaind-v4.0.0-linux-amd64.tar.gz?checksum=sha256:afc9f73f4c4e006363c4d7468d1d59483babef11129e1f2d4bddf6b0a4ca5807",
+        "darwin/amd64": "https://github.com/ZIGChain/networks/raw/refs/heads/main/binaries/v4.x/zigchaind-v4.0.0-darwin-amd64.tar.gz?checksum=sha256:06d36ba8fa32236140478b8633215e5c585570dccbef508c5ec84fc79dddaa10",
+        "darwin/arm64": "https://github.com/ZIGChain/networks/raw/refs/heads/main/binaries/v4.x/zigchaind-v4.0.0-darwin-arm64.tar.gz?checksum=sha256:21b31af4213cb51a05de3190fb2c4b2cf9710e5aef568aaf1c1361f95088f023"
       },
       "previous_version_name": "v3",
       "next_version_name": "v4.1"
@@ -298,21 +298,21 @@
         "version": "1.25.9"
       },
       "binaries": {
-        "linux/amd64": "https://github.com/ZIGChain/networks/raw/refs/heads/main/binaries/archive/zigchaind-v4.1.0-linux-amd64.tar.gz?checksum=sha256:1a64152e48fb25c990bfcf52c0578171137470b78a79859e3c861714e099cd5e",
-        "darwin/amd64": "https://github.com/ZIGChain/networks/raw/refs/heads/main/binaries/archive/zigchaind-v4.1.0-darwin-amd64.tar.gz?checksum=sha256:adb639e7e1496ec30de54f7dbcd8a8110548b95ca3b3b1d20ca65ec4ad2bfaa0",
-        "darwin/arm64": "https://github.com/ZIGChain/networks/raw/refs/heads/main/binaries/archive/zigchaind-v4.1.0-darwin-arm64.tar.gz?checksum=sha256:a27cb748c8b4c90724378109e518fd730f8471d9e28fbea56bb963b3757fd6da"
+        "linux/amd64": "https://github.com/ZIGChain/networks/raw/refs/heads/main/binaries/v4.x/zigchaind-v4.1.0-linux-amd64.tar.gz?checksum=sha256:1a64152e48fb25c990bfcf52c0578171137470b78a79859e3c861714e099cd5e",
+        "darwin/amd64": "https://github.com/ZIGChain/networks/raw/refs/heads/main/binaries/v4.x/zigchaind-v4.1.0-darwin-amd64.tar.gz?checksum=sha256:adb639e7e1496ec30de54f7dbcd8a8110548b95ca3b3b1d20ca65ec4ad2bfaa0",
+        "darwin/arm64": "https://github.com/ZIGChain/networks/raw/refs/heads/main/binaries/v4.x/zigchaind-v4.1.0-darwin-arm64.tar.gz?checksum=sha256:a27cb748c8b4c90724378109e518fd730f8471d9e28fbea56bb963b3757fd6da"
       },
       "previous_version_name": "v4",
       "next_version_name": "v5"
     },
     {
       "name": "v5",
-      "tag": "v5.0.0",
+      "tag": "v5.0.0-patch-1",
       "height": 7669200,
       "proposal": 118,
-      "recommended_version": "5.0.0",
+      "recommended_version": "5.0.0-patch-1",
       "compatible_versions": [
-        "5.0.0"
+        "5.0.0-patch-1"
       ],
       "consensus": {
         "type": "cometbft",
@@ -335,9 +335,9 @@
         "version": "1.25.13"
       },
       "binaries": {
-        "linux/amd64": "https://github.com/ZIGChain/networks/raw/refs/heads/main/binaries/zigchaind-v5.0.0-linux-amd64.tar.gz?checksum=sha256:3cf12ad3d40e861d6d8302317fb42695d2994def3bd57cc64f69407a6c21e80d",
-        "darwin/amd64": "https://github.com/ZIGChain/networks/raw/refs/heads/main/binaries/zigchaind-v5.0.0-darwin-amd64.tar.gz?checksum=sha256:a7c4e675b70fb2d2023937491fc3cecc2d3e6fc22bc501d55151cf8f1743e51f",
-        "darwin/arm64": "https://github.com/ZIGChain/networks/raw/refs/heads/main/binaries/zigchaind-v5.0.0-darwin-arm64.tar.gz?checksum=sha256:7cd3e5deeec6be8c959f11e295bb4f3dca0d7493e6dd23006774e9ebe4cb3714"
+        "linux/amd64": "https://github.com/ZIGChain/networks/raw/refs/heads/main/binaries/v5.0.0-patch-1/zigchaind-v5.0.0-patch-1-linux-amd64.tar.gz?checksum=sha256:002c1edb1db0f32ac16bc3faaa96438b1720f9330b2fca438108f19cd49586ee",
+        "darwin/amd64": "https://github.com/ZIGChain/networks/raw/refs/heads/main/binaries/v5.0.0-patch-1/zigchaind-v5.0.0-patch-1-darwin-amd64.tar.gz?checksum=sha256:3b9dfc2cfd290fe2cf8e7a2f6ba6cff5f93f9a2f1fb1c2565ca27b17803e9b28",
+        "darwin/arm64": "https://github.com/ZIGChain/networks/raw/refs/heads/main/binaries/v5.0.0-patch-1/zigchaind-v5.0.0-patch-1-darwin-arm64.tar.gz?checksum=sha256:408972867f66ae17fcf6730c5e5c96432f2175a96a36d991b6e0f26d7fa567ef"
       },
       "previous_version_name": "v4.1",
       "next_version_name": ""


### PR DESCRIPTION
Adds the v5 version entry to testnets/zigchaintestnet/versions.json (upgrade height 7669200, governance proposal #118) and updates chain.json codebase to v5.0.0, following the merged binaries and testnet version.txt update in ZIGChain/networks.

This  PR should be merged only after proposal 118 is passed at 08.09.2026 around 9:00 UTC