### PR TITLE
Add Injective USDC (USDC.inj) to Initia

### DIFF
--- a/_IBC/initia-injective.json
+++ b/_IBC/initia-injective.json
@@ -3,23 +3,23 @@
   "chain_1": {
     "chain_name": "initia",
     "chain_id": "interwoven-1",
-    "client_id": "07-tendermint-64",
-    "connection_id": "connection-55"
+    "client_id": "07-tendermint-65",
+    "connection_id": "connection-57"
   },
   "chain_2": {
     "chain_name": "injective",
     "chain_id": "injective-1",
-    "client_id": "07-tendermint-329",
-    "connection_id": "connection-334"
+    "client_id": "07-tendermint-349",
+    "connection_id": "connection-348"
   },
   "channels": [
     {
       "chain_1": {
-        "channel_id": "channel-112",
+        "channel_id": "channel-113",
         "port_id": "transfer"
       },
       "chain_2": {
-        "channel_id": "channel-455",
+        "channel_id": "channel-488",
         "port_id": "transfer"
       },
       "ordering": "unordered",

--- a/initia/assetlist.json
+++ b/initia/assetlist.json
@@ -90,6 +90,56 @@
           }
         }
       ]
+    },
+    {
+      "description": "USD Coin issued natively on Injective by Circle",
+      "denom_units": [
+        {
+          "denom": "ibc/A64E1233F240D4B886413A12CF0300D6EC6FA0554DBD176119C399D0E2CA8048",
+          "exponent": 0
+        },
+        {
+          "denom": "usdc",
+          "exponent": 6
+        }
+      ],
+      "base": "ibc/A64E1233F240D4B886413A12CF0300D6EC6FA0554DBD176119C399D0E2CA8048",
+      "name": "Injective USDC",
+      "display": "usdc",
+      "symbol": "USDC.inj",
+      "logo_URIs": {
+        "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/_non-cosmos/ethereum/images/usdc.png",
+        "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/_non-cosmos/ethereum/images/usdc.svg"
+      },
+      "traces": [
+        {
+          "type": "ibc",
+          "counterparty": {
+            "chain_name": "injective",
+            "base_denom": "erc20:0xa00C59fF5a080D2b954d0c75e46E22a0c371235a",
+            "channel_id": "channel-488"
+          },
+          "chain": {
+            "channel_id": "channel-113",
+            "path": "transfer/channel-113/erc20:0xa00C59fF5a080D2b954d0c75e46E22a0c371235a"
+          }
+        }
+      ],
+      "type_asset": "ics20",
+      "images": [
+        {
+          "image_sync": {
+            "chain_name": "injective",
+            "base_denom": "erc20:0xa00C59fF5a080D2b954d0c75e46E22a0c371235a"
+          },
+          "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/_non-cosmos/ethereum/images/usdc.png",
+          "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/_non-cosmos/ethereum/images/usdc.svg",
+          "theme": {
+            "circle": true
+          }
+        }
+      ],
+      "coingecko_id": "usd-coin"
     }
   ]
 }


### PR DESCRIPTION
Adds Injective-originated USDC (`USDC.inj`) to Initia's assetlist,
reaching Initia via a direct channel to Injective
(transfer/channel-113/erc20:0xa00C59fF5a080D2b954d0c75e46E22a0c371235a).

While verifying the channel, found that Initia and Injective actually
have two separate IBC connections open between them (channel-112/455
on the original connection, and channel-113/488 on a newer one). Since
this repo's `_IBC` schema ties one connection to one file, and
channel-113/488 is the pair actually used for this asset, updated
`_IBC/initia-injective.json` to declare that connection at the top
level and keep only the matching channel.

## Verification
- Recomputed the SHA-256 denom hash from `traces[].chain.path` and
  confirmed it matches the declared `base`.
- Queried both chains' live IBC channel state (`STATE_OPEN`, correct
  counterparty channel/client/connection IDs) via REST, confirming
  channel-113 (Initia) ↔ channel-488 (Injective) share connection-57 /
  connection-348 — distinct from the connection channel-112/455 uses.