### PR TITLE
feat(beezee): update to v8.1.1

### DIFF
--- a/beezee/chain.json
+++ b/beezee/chain.json
@@ -34,32 +34,32 @@
   },
   "codebase": {
     "git_repo": "https://github.com/bze-alphateam/bze",
-    "recommended_version": "v8.0.0",
+    "recommended_version": "v8.1.1",
     "compatible_versions": [
-      "v8.0.0"
+      "v8.1.1"
     ],
     "binaries": {
-      "darwin/amd64": "https://github.com/bze-alphateam/bze/releases/download/v8.0.0/bze-8.0.0-darwin-amd64.tar.gz",
-      "darwin/arm64": "https://github.com/bze-alphateam/bze/releases/download/v8.0.0/bze-8.0.0-darwin-arm64.tar.gz",
-      "linux/amd64": "https://github.com/bze-alphateam/bze/releases/download/v8.0.0/bze-8.0.0-linux-amd64.tar.gz",
-      "linux/arm64": "https://github.com/bze-alphateam/bze/releases/download/v8.0.0/bze-8.0.0-linux-arm64.tar.gz",
-      "windows/amd64": "https://github.com/bze-alphateam/bze/releases/download/v8.0.0/bze-8.0.0-win64.zip"
+      "darwin/amd64": "https://github.com/bze-alphateam/bze/releases/download/v8.1.1/bze-8.1.1-darwin-amd64.tar.gz",
+      "darwin/arm64": "https://github.com/bze-alphateam/bze/releases/download/v8.1.1/bze-8.1.1-darwin-arm64.tar.gz",
+      "linux/amd64": "https://github.com/bze-alphateam/bze/releases/download/v8.1.1/bze-8.1.1-linux-amd64.tar.gz",
+      "linux/arm64": "https://github.com/bze-alphateam/bze/releases/download/v8.1.1/bze-8.1.1-linux-arm64.tar.gz",
+      "windows/amd64": "https://github.com/bze-alphateam/bze/releases/download/v8.1.1/bze-8.1.1-win64.zip"
     },
     "genesis": {
       "genesis_url": "https://raw.githubusercontent.com/bze-alphateam/bze/main/genesis.json"
     },
-    "tag": "v8.0.0",
+    "tag": "v8.1.1",
     "sdk": {
       "type": "cosmos",
-      "version": "v0.50.14"
+      "version": "v0.50.15"
     },
     "consensus": {
       "type": "cometbft",
-      "version": "v0.38.17"
+      "version": "v0.38.23"
     },
     "ibc": {
       "type": "go",
-      "version": "v8.7.0"
+      "version": "v8.8.0"
     }
   },
   "logo_URIs": {

--- a/beezee/versions.json
+++ b/beezee/versions.json
@@ -280,6 +280,7 @@
         "linux/arm64": "https://github.com/bze-alphateam/bze/releases/download/v8.0.0/bze-8.0.0-linux-arm64.tar.gz",
         "windows/amd64": "https://github.com/bze-alphateam/bze/releases/download/v8.0.0/bze-8.0.0-win64.zip"
       },
+      "next_version_name": "v8.1.0",
       "sdk": {
         "type": "cosmos",
         "version": "v0.50.14"
@@ -287,6 +288,63 @@
       "ibc": {
         "type": "go",
         "version": "v8.7.0"
+      }
+    },
+    {
+      "name": "v8.1.0",
+      "recommended_version": "v8.1.0",
+      "tag": "v8.1.0",
+      "compatible_versions": [
+        "v8.1.0"
+      ],
+      "consensus": {
+        "type": "cometbft",
+        "version": "v0.38.21"
+      },
+      "height": 22551810,
+      "binaries": {
+        "darwin/amd64": "https://github.com/bze-alphateam/bze/releases/download/v8.1.0/bze-8.1.0-darwin-amd64.tar.gz",
+        "darwin/arm64": "https://github.com/bze-alphateam/bze/releases/download/v8.1.0/bze-8.1.0-darwin-arm64.tar.gz",
+        "linux/amd64": "https://github.com/bze-alphateam/bze/releases/download/v8.1.0/bze-8.1.0-linux-amd64.tar.gz",
+        "linux/arm64": "https://github.com/bze-alphateam/bze/releases/download/v8.1.0/bze-8.1.0-linux-arm64.tar.gz",
+        "windows/amd64": "https://github.com/bze-alphateam/bze/releases/download/v8.1.0/bze-8.1.0-win64.zip"
+      },
+      "next_version_name": "v8.1.1",
+      "sdk": {
+        "type": "cosmos",
+        "version": "v0.50.15"
+      },
+      "ibc": {
+        "type": "go",
+        "version": "v8.7.0"
+      }
+    },
+    {
+      "name": "v8.1.1",
+      "recommended_version": "v8.1.1",
+      "tag": "v8.1.1",
+      "compatible_versions": [
+        "v8.1.1"
+      ],
+      "consensus": {
+        "type": "cometbft",
+        "version": "v0.38.23"
+      },
+      "height": 23855000,
+      "binaries": {
+        "darwin/amd64": "https://github.com/bze-alphateam/bze/releases/download/v8.1.1/bze-8.1.1-darwin-amd64.tar.gz",
+        "darwin/arm64": "https://github.com/bze-alphateam/bze/releases/download/v8.1.1/bze-8.1.1-darwin-arm64.tar.gz",
+        "linux/amd64": "https://github.com/bze-alphateam/bze/releases/download/v8.1.1/bze-8.1.1-linux-amd64.tar.gz",
+        "linux/arm64": "https://github.com/bze-alphateam/bze/releases/download/v8.1.1/bze-8.1.1-linux-arm64.tar.gz",
+        "windows/amd64": "https://github.com/bze-alphateam/bze/releases/download/v8.1.1/bze-8.1.1-win64.zip"
+      },
+      "sdk": {
+        "type": "cosmos",
+        "version": "v0.50.15"
+      },
+      "ibc": {
+        "type": "go",
+        "version": "v8.8.0"
       }
     }
   ]


### PR DESCRIPTION
Updates the `beezee` entry to the latest released chain version, **v8.1.1** (tagged 2026-07-05).

Since v8.0.0, mainnet `beezee-1` has completed two coordinated upgrades — v8.1.0 (height 22551810) and v8.1.1 (height 23855000). v8.0.1/v8.0.2 were non-consensus-breaking patch releases (no upgrade handler) and are intentionally not added to `versions.json`.

### versions.json
- Set `next_version_name: v8.1.0` on the existing v8.0.0 entry.
- Added **v8.1.0** — height 22551810, cometbft v0.38.21, cosmos-sdk v0.50.15, ibc-go v8.7.0, `next_version_name: v8.1.1`.
- Added **v8.1.1** — height 23855000, cometbft v0.38.23, cosmos-sdk v0.50.15, ibc-go v8.8.0.

### chain.json (codebase)
- `recommended_version` / `compatible_versions` → v8.1.1
- Binaries repointed at the v8.1.1 release assets (all 5 platforms)
- sdk v0.50.15, consensus (cometbft) v0.38.23, ibc-go v8.8.0

All binary download URLs return HTTP 200. Validated locally with `chain-registry validate` (@chain-registry/cli@1.47.0) — passes.
