### PR TITLE
genesisl1: add GL1Infra RPC/REST/EVM endpoints and persistent peers

### DIFF
--- a/genesisl1/chain.json
+++ b/genesisl1/chain.json
@@ -122,6 +122,16 @@
         "id": "1d07c049908e614f5d00bf64539581178a2a7f0d",
         "address": "192.99.5.180:26656",
         "provider": "genesismint"
+      },
+      {
+        "id": "814ad290aae4f10b4764b5d52f1e92d17de4e099",
+        "address": "162.250.190.64:36656",
+        "provider": "GL1Infra"
+      },
+      {
+        "id": "f61bd5785f60eee7b5fe165330352789165dd632",
+        "address": "162.250.191.184:36656",
+        "provider": "GL1Infra"
       }
     ]
   },
@@ -130,6 +140,14 @@
       {
         "address": "https://26657.genesisl1.org",
         "provider": "GenesisL1"
+      },
+      {
+        "address": "https://rpc.gl1infra.online",
+        "provider": "GL1Infra"
+      },
+      {
+        "address": "https://rpc.vicky.gl1infra.online",
+        "provider": "GL1Infra"
       }
     ],
     "rest": [
@@ -140,12 +158,28 @@
       {
         "address": "https://1317.genesisl1.org",
         "provider": "GenesisL1"
+      },
+      {
+        "address": "https://api.gl1infra.online",
+        "provider": "GL1Infra"
+      },
+      {
+        "address": "https://api.vicky.gl1infra.online",
+        "provider": "GL1Infra"
       }
     ],
     "evm-http-jsonrpc": [
       {
         "address": "https://rpc.genesisl1.org",
         "provider": "GenesisL1"
+      },
+      {
+        "address": "https://evm.gl1infra.online",
+        "provider": "GL1Infra"
+      },
+      {
+        "address": "https://evm.vicky.gl1infra.online",
+        "provider": "GL1Infra"
       }
     ]
   },


### PR DESCRIPTION
Adding GL1Infra's two independent GenesisL1 nodes as public API endpoints and persistent peers.

**Endpoints added**

| Type | Node 1 | Node 2 |
|---|---|---|
| RPC | https://rpc.gl1infra.online | https://rpc.vicky.gl1infra.online |
| REST | https://api.gl1infra.online | https://api.vicky.gl1infra.online |
| EVM JSON-RPC | https://evm.gl1infra.online | https://evm.vicky.gl1infra.online |

**Peers added**

- `814ad290aae4f10b4764b5d52f1e92d17de4e099@162.250.190.64:36656`
- `f61bd5785f60eee7b5fe165330352789165dd632@162.250.191.184:36656`

**Notes**

- Two physically separate servers, both fully synced on `genesis_29-2`
- CORS enabled on all HTTP endpoints
- `timeout_commit` set to the network standard of 14s
- GenesisL1 P2P runs on port 36656 (not the default 26656); both verified externally reachable
- The single deletion is the missing trailing newline at end of file, added by the GitHub web editor
- Operated by GL1Infra (Vicky_Pulsican)