### PR TITLE
terpnetwork: v6.0.1 recommended, add v6.1/v6.2 sequence

### DIFF
--- a/terpnetwork/chain.json
+++ b/terpnetwork/chain.json
@@ -9,24 +9,36 @@
   "bech32_prefix": "terp",
   "slip44": 118,
   "daemon_name": "terp",
-  "node_home": "$HOME/.terp",
+  "node_home": "$HOME/.terpd",
   "codebase": {
     "git_repo": "https://github.com/terpnetwork/terp-core.git",
     "genesis": {
       "genesis_url": "https://raw.githubusercontent.com/terpnetwork/networks/main/mainnet/morocco-1/genesis.json"
     },
-    "recommended_version": "v5.0.3",
+    "recommended_version": "v6.0.1",
     "compatible_versions": [
-      "v5.0.2",
-      "v5.0.3"
+      "v6.0.1"
     ],
     "consensus": {
       "type": "cometbft",
-      "version": "0.38.21"
+      "version": "0.39.3"
+    },
+    "sdk": {
+      "type": "cosmos",
+      "version": "0.54.3"
+    },
+    "ibc": {
+      "type": "go",
+      "version": "v11.2.0"
+    },
+    "cosmwasm": {
+      "version": "0.70.3",
+      "enabled": true,
+      "path": "$HOME/.terpd/data/wasm"
     },
     "binaries": {
-      "linux/amd64": "https://github.com/terpnetwork/terp-core/releases/download/v5.0.3/terpd-linux-amd64",
-      "linux/arm64": "https://github.com/terpnetwork/terp-core/releases/download/v5.0.3/terpd-linux-arm64"
+      "linux/amd64": "https://s3.terp.network/releases/terp-core/v6.0.1/terpd-6.0.1-linux-amd64.tar.gz?checksum=sha256:e4dd72f5a6cba3af602b49e51ee79229432f5de02dc23e586c5c6b7768dc285c",
+      "linux/arm64": "https://s3.terp.network/releases/terp-core/v6.0.1/terpd-6.0.1-linux-arm64.tar.gz?checksum=sha256:0b8d21b0bbe3cb593fb77c5cdd413d712aaf9465981180e2ca1f074f81c5cbc8"
     }
   },
   "fees": {

--- a/terpnetwork/chain.json
+++ b/terpnetwork/chain.json
@@ -8,7 +8,7 @@
   "chain_id": "morocco-1",
   "bech32_prefix": "terp",
   "slip44": 118,
-  "daemon_name": "terp",
+  "daemon_name": "terpd",
   "node_home": "$HOME/.terpd",
   "codebase": {
     "git_repo": "https://github.com/terpnetwork/terp-core.git",
@@ -35,10 +35,6 @@
       "version": "0.70.3",
       "enabled": true,
       "path": "$HOME/.terpd/data/wasm"
-    },
-    "binaries": {
-      "linux/amd64": "https://s3.terp.network/releases/terp-core/v6.0.1/terpd-6.0.1-linux-amd64.tar.gz?checksum=sha256:e4dd72f5a6cba3af602b49e51ee79229432f5de02dc23e586c5c6b7768dc285c",
-      "linux/arm64": "https://s3.terp.network/releases/terp-core/v6.0.1/terpd-6.0.1-linux-arm64.tar.gz?checksum=sha256:0b8d21b0bbe3cb593fb77c5cdd413d712aaf9465981180e2ca1f074f81c5cbc8"
     }
   },
   "fees": {

--- a/terpnetwork/versions.json
+++ b/terpnetwork/versions.json
@@ -143,7 +143,183 @@
         "type": "cometbft",
         "version": "0.38.21"
       },
-      "next_version_name": ""
+      "next_version_name": "v5.1.0"
+    },
+    {
+      "name": "v5.1.0",
+      "recommended_version": "v5.1.1",
+      "compatible_versions": [
+        "v5.1.0",
+        "v5.1.1"
+      ],
+      "consensus": {
+        "type": "cometbft",
+        "version": "0.38.21"
+      },
+      "next_version_name": "v5.2.0",
+      "binaries": {
+        "linux/amd64": "https://github.com/terpnetwork/terp-core/releases/download/v5.1.1/terpd-linux-amd64",
+        "linux/arm64": "https://github.com/terpnetwork/terp-core/releases/download/v5.1.1/terpd-linux-arm64"
+      }
+    },
+    {
+      "name": "v5.2.0",
+      "height": 21725359,
+      "recommended_version": "v5.2.0",
+      "compatible_versions": [
+        "v5.2.0"
+      ],
+      "consensus": {
+        "type": "cometbft",
+        "version": "0.38.21"
+      },
+      "sdk": {
+        "type": "cosmos",
+        "version": "0.53.4"
+      },
+      "ibc": {
+        "type": "go",
+        "version": "v10.5.0"
+      },
+      "cosmwasm": {
+        "version": "0.61.8",
+        "enabled": true,
+        "path": "$HOME/.terpd/data/wasm"
+      },
+      "next_version_name": "v6",
+      "binaries": {
+        "linux/amd64": "https://s3.terp.network/releases/terp-core/v5.2.0/terpd-5.2.0-linux-amd64.tar.gz",
+        "linux/arm64": "https://s3.terp.network/releases/terp-core/v5.2.0/terpd-5.2.0-linux-arm64.tar.gz",
+        "darwin/arm64": "https://s3.terp.network/releases/terp-core/v5.2.0/terpd-5.2.0-darwin-arm64.tar.gz"
+      }
+    },
+    {
+      "name": "v6",
+      "height": 22611000,
+      "recommended_version": "v6.0.0",
+      "compatible_versions": [
+        "v6.0.0"
+      ],
+      "consensus": {
+        "type": "cometbft",
+        "version": "0.39.3"
+      },
+      "sdk": {
+        "type": "cosmos",
+        "version": "0.54.3"
+      },
+      "ibc": {
+        "type": "go",
+        "version": "v11.2.0"
+      },
+      "cosmwasm": {
+        "version": "0.70.3",
+        "enabled": true,
+        "path": "$HOME/.terpd/data/wasm"
+      },
+      "next_version_name": "v6.0.1",
+      "binaries": {
+        "linux/amd64": "https://s3.terp.network/releases/terp-core/v6.0.0/terpd-6.0.0-linux-amd64.tar.gz",
+        "linux/arm64": "https://s3.terp.network/releases/terp-core/v6.0.0/terpd-6.0.0-linux-arm64.tar.gz",
+        "darwin/arm64": "https://s3.terp.network/releases/terp-core/v6.0.0/terpd-6.0.0-darwin-arm64.tar.gz"
+      },
+      "tag": "v6.0.0",
+      "previous_version_name": "v5.2.0"
+    },
+    {
+      "name": "v6.0.1",
+      "recommended_version": "v6.0.1",
+      "compatible_versions": [
+        "v6.0.1"
+      ],
+      "consensus": {
+        "type": "cometbft",
+        "version": "0.39.3"
+      },
+      "sdk": {
+        "type": "cosmos",
+        "version": "0.54.3"
+      },
+      "ibc": {
+        "type": "go",
+        "version": "v11.2.0"
+      },
+      "cosmwasm": {
+        "version": "0.70.3",
+        "enabled": true,
+        "path": "$HOME/.terpd/data/wasm"
+      },
+      "next_version_name": "v6.1",
+      "binaries": {
+        "linux/amd64": "https://s3.terp.network/releases/terp-core/v6.0.1/terpd-6.0.1-linux-amd64.tar.gz?checksum=sha256:e4dd72f5a6cba3af602b49e51ee79229432f5de02dc23e586c5c6b7768dc285c",
+        "linux/arm64": "https://s3.terp.network/releases/terp-core/v6.0.1/terpd-6.0.1-linux-arm64.tar.gz?checksum=sha256:0b8d21b0bbe3cb593fb77c5cdd413d712aaf9465981180e2ca1f074f81c5cbc8"
+      },
+      "tag": "v6.0.1",
+      "previous_version_name": "v6"
+    },
+    {
+      "name": "v6.1",
+      "proposal": 59,
+      "height": 23191300,
+      "recommended_version": "v6.1.0",
+      "compatible_versions": [
+        "v6.1.0"
+      ],
+      "consensus": {
+        "type": "cometbft",
+        "version": "0.40.0"
+      },
+      "sdk": {
+        "type": "cosmos",
+        "version": "0.55.0"
+      },
+      "ibc": {
+        "type": "go",
+        "version": "v11.2.0"
+      },
+      "cosmwasm": {
+        "version": "0.70.3",
+        "enabled": true,
+        "path": "$HOME/.terpd/data/wasm"
+      },
+      "next_version_name": "v6.2",
+      "binaries": {
+        "linux/amd64": "https://s3.terp.network/releases/terp-core/v6.1.0/terpd-6.1.0-linux-amd64.tar.gz?checksum=sha256:18a073f5d189f823987bd73d1ee6d410f9f48bbdcc92258fcbf8ae800780ebd2",
+        "linux/arm64": "https://s3.terp.network/releases/terp-core/v6.1.0/terpd-6.1.0-linux-arm64.tar.gz?checksum=sha256:4249119ebdbf75535c6852226fb7dee477373d65d2b721708bbb5265e8fdd8b4"
+      },
+      "tag": "v6.1.0",
+      "previous_version_name": "v6.0.1"
+    },
+    {
+      "name": "v6.2",
+      "height": 23191302,
+      "recommended_version": "v6.2.0",
+      "compatible_versions": [
+        "v6.2.0"
+      ],
+      "consensus": {
+        "type": "cometbft",
+        "version": "0.40.0"
+      },
+      "sdk": {
+        "type": "cosmos",
+        "version": "0.55.0"
+      },
+      "ibc": {
+        "type": "go",
+        "version": "v11.2.0"
+      },
+      "cosmwasm": {
+        "version": "0.70.3",
+        "enabled": true,
+        "path": "$HOME/.terpd/data/wasm"
+      },
+      "binaries": {
+        "linux/amd64": "https://s3.terp.network/releases/terp-core/v6.2.0/terpd-6.2.0-linux-amd64.tar.gz?checksum=sha256:38c15e1f54bc8234d07883c05e665ded68fdc0434c1c9db08de796d15ef491f6",
+        "linux/arm64": "https://s3.terp.network/releases/terp-core/v6.2.0/terpd-6.2.0-linux-arm64.tar.gz?checksum=sha256:148eedb6e8f1dd97e2436bc1b36dfebdbc915d23c14e6bad483924b0a4052c3d"
+      },
+      "tag": "v6.2.0",
+      "previous_version_name": "v6.1"
     }
   ]
 }

--- a/terpnetwork/versions.json
+++ b/terpnetwork/versions.json
@@ -156,14 +156,15 @@
         "type": "cometbft",
         "version": "0.38.21"
       },
-      "next_version_name": "v5.2.0",
+      "next_version_name": "v520",
       "binaries": {
         "linux/amd64": "https://github.com/terpnetwork/terp-core/releases/download/v5.1.1/terpd-linux-amd64",
         "linux/arm64": "https://github.com/terpnetwork/terp-core/releases/download/v5.1.1/terpd-linux-arm64"
       }
     },
     {
-      "name": "v5.2.0",
+      "name": "v520",
+      "proposal": 57,
       "height": 21725359,
       "recommended_version": "v5.2.0",
       "compatible_versions": [
@@ -188,14 +189,15 @@
       },
       "next_version_name": "v6",
       "binaries": {
-        "linux/amd64": "https://s3.terp.network/releases/terp-core/v5.2.0/terpd-5.2.0-linux-amd64.tar.gz",
-        "linux/arm64": "https://s3.terp.network/releases/terp-core/v5.2.0/terpd-5.2.0-linux-arm64.tar.gz",
-        "darwin/arm64": "https://s3.terp.network/releases/terp-core/v5.2.0/terpd-5.2.0-darwin-arm64.tar.gz"
-      }
+        "linux/amd64": "https://github.com/terpnetwork/terp-core/releases/download/v5.2.0/terpd-linux-amd64",
+        "linux/arm64": "https://github.com/terpnetwork/terp-core/releases/download/v5.2.0/terpd-linux-arm64"
+      },
+      "tag": "v5.2.0"
     },
     {
       "name": "v6",
-      "height": 22611000,
+      "proposal": 58,
+      "height": 22810000,
       "recommended_version": "v6.0.0",
       "compatible_versions": [
         "v6.0.0"
@@ -219,12 +221,12 @@
       },
       "next_version_name": "v6.0.1",
       "binaries": {
-        "linux/amd64": "https://s3.terp.network/releases/terp-core/v6.0.0/terpd-6.0.0-linux-amd64.tar.gz",
-        "linux/arm64": "https://s3.terp.network/releases/terp-core/v6.0.0/terpd-6.0.0-linux-arm64.tar.gz",
-        "darwin/arm64": "https://s3.terp.network/releases/terp-core/v6.0.0/terpd-6.0.0-darwin-arm64.tar.gz"
+        "linux/amd64": "https://github.com/terpnetwork/terp-core/releases/download/v6.0.0/terpd-linux-amd64",
+        "linux/arm64": "https://github.com/terpnetwork/terp-core/releases/download/v6.0.0/terpd-linux-arm64",
+        "darwin/arm64": "https://github.com/terpnetwork/terp-core/releases/download/v6.0.0/terpd-darwin-arm64"
       },
       "tag": "v6.0.0",
-      "previous_version_name": "v5.2.0"
+      "previous_version_name": "v520"
     },
     {
       "name": "v6.0.1",
@@ -250,10 +252,6 @@
         "path": "$HOME/.terpd/data/wasm"
       },
       "next_version_name": "v6.1",
-      "binaries": {
-        "linux/amd64": "https://s3.terp.network/releases/terp-core/v6.0.1/terpd-6.0.1-linux-amd64.tar.gz?checksum=sha256:e4dd72f5a6cba3af602b49e51ee79229432f5de02dc23e586c5c6b7768dc285c",
-        "linux/arm64": "https://s3.terp.network/releases/terp-core/v6.0.1/terpd-6.0.1-linux-arm64.tar.gz?checksum=sha256:0b8d21b0bbe3cb593fb77c5cdd413d712aaf9465981180e2ca1f074f81c5cbc8"
-      },
       "tag": "v6.0.1",
       "previous_version_name": "v6"
     },
@@ -283,10 +281,6 @@
         "path": "$HOME/.terpd/data/wasm"
       },
       "next_version_name": "v6.2",
-      "binaries": {
-        "linux/amd64": "https://s3.terp.network/releases/terp-core/v6.1.0/terpd-6.1.0-linux-amd64.tar.gz?checksum=sha256:18a073f5d189f823987bd73d1ee6d410f9f48bbdcc92258fcbf8ae800780ebd2",
-        "linux/arm64": "https://s3.terp.network/releases/terp-core/v6.1.0/terpd-6.1.0-linux-arm64.tar.gz?checksum=sha256:4249119ebdbf75535c6852226fb7dee477373d65d2b721708bbb5265e8fdd8b4"
-      },
       "tag": "v6.1.0",
       "previous_version_name": "v6.0.1"
     },
@@ -313,10 +307,6 @@
         "version": "0.70.3",
         "enabled": true,
         "path": "$HOME/.terpd/data/wasm"
-      },
-      "binaries": {
-        "linux/amd64": "https://s3.terp.network/releases/terp-core/v6.2.0/terpd-6.2.0-linux-amd64.tar.gz?checksum=sha256:38c15e1f54bc8234d07883c05e665ded68fdc0434c1c9db08de796d15ef491f6",
-        "linux/arm64": "https://s3.terp.network/releases/terp-core/v6.2.0/terpd-6.2.0-linux-arm64.tar.gz?checksum=sha256:148eedb6e8f1dd97e2436bc1b36dfebdbc915d23c14e6bad483924b0a4052c3d"
       },
       "tag": "v6.2.0",
       "previous_version_name": "v6.1"


### PR DESCRIPTION
## Summary

Update `terpnetwork` (`morocco-1`) from the terp-core source of truth (`networks/chain-registry/terpnetwork/` on [terpnetwork/terp-core](https://github.com/terpnetwork/terp-core)).

`chain.json` `recommended_version` is **v6.0.1** until the v6.1 halt. Do not run v6.1.0 / v6.2.0 before height 23191300.

| step | version | height | proposal | artifacts |
|------|---------|--------|----------|-----------|
| now (rolling CosmWasm halt patch) | **v6.0.1** | none | none | https://s3.terp.network/releases/terp-core/v6.0.1/ |
| gov plan `v6.1` | **v6.1.0** | **23191300** | **59** | https://s3.terp.network/releases/terp-core/v6.1.0/ |
| handler arms `v6.2` at apply+2 | **v6.2.0** | **23191302** | none (not a second gov plan) | https://s3.terp.network/releases/terp-core/v6.2.0/ |

Linux amd64/arm64 Cosmovisor tarballs include `?checksum=sha256:…` matching the published `sha256sum.txt` files.

Also:
- `node_home` is `$HOME/.terpd` (matches `DefaultNodeHomeDir` and the wasm path)
- ibc-go **v11.2.0**, SDK **0.54.3** / CometBFT **0.39.3** on v6.0.x; SDK **0.55.0** / CometBFT **0.40.0** on v6.1/v6.2
- CosmWasm **0.70.3** (schema cannot encode our `-zk` guest tag)

Supersedes stale draft https://github.com/cosmos/chain-registry/pull/7552 (`Terpnetwork@v5.0.4`).

## Files

- `terpnetwork/chain.json`
- `terpnetwork/versions.json`