### PR TITLE
Add Amitis <> Noble IBC connection

### DIFF
--- a/_IBC/amitis-noble.json
+++ b/_IBC/amitis-noble.json
@@ -1,0 +1,32 @@
+{
+  "$schema": "../ibc_data.schema.json",
+  "chain_1": {
+    "chain_name": "amitis",
+    "chain_id": "amitis-network",
+    "client_id": "07-tendermint-4",
+    "connection_id": "connection-3"
+  },
+  "chain_2": {
+    "chain_name": "noble",
+    "chain_id": "noble-1",
+    "client_id": "07-tendermint-233",
+    "connection_id": "connection-216"
+  },
+  "channels": [
+    {
+      "chain_1": {
+        "channel_id": "channel-4",
+        "port_id": "transfer"
+      },
+      "chain_2": {
+        "channel_id": "channel-635",
+        "port_id": "transfer"
+      },
+      "ordering": "unordered",
+      "version": "ics20-1",
+      "tags": {
+        "preferred": true
+      }
+    }
+  ]
+}


### PR DESCRIPTION
Registers a new, verified IBC connection between Amitis Network (amitis-network) and Noble (noble-1).

This channel enables native Circle-issued USDC to flow directly onto Amitis Network without routing through an intermediary chain.

**Details:**
- Amitis channel: `channel-4`
- Noble channel: `channel-635`
- Client IDs: `07-tendermint-4` (Amitis) / `07-tendermint-233` (Noble)
- Connection IDs: `connection-3` (Amitis) / `connection-216` (Noble)
- Port: `transfer` on both sides, unordered, `ics20-1`

**Verification:**
All four IBC handshake steps (client creation x2, connection Init/Try/Ack/Confirm, channel Init/Try/Ack/Confirm) completed as individually verified on-chain transactions. A test transfer of 1 USDC from Noble to Amitis was completed successfully end-to-end, with confirmed balance receipt and acknowledgement.

The Amitis <> Osmosis connection was previously merged in #7928.