### PR TITLE
dungeon: add Injective IBC connection and USDC.inj asset

### DIFF
--- a/_IBC/dungeon-injective.json
+++ b/_IBC/dungeon-injective.json
@@ -1,0 +1,33 @@
+{
+  "$schema": "../ibc_data.schema.json",
+  "chain_1": {
+    "chain_name": "dungeon",
+    "chain_id": "dungeon-1",
+    "client_id": "07-tendermint-40",
+    "connection_id": "connection-8641"
+  },
+  "chain_2": {
+    "chain_name": "injective",
+    "chain_id": "injective-1",
+    "client_id": "07-tendermint-350",
+    "connection_id": "connection-349"
+  },
+  "channels": [
+    {
+      "chain_1": {
+        "channel_id": "channel-5320",
+        "port_id": "transfer"
+      },
+      "chain_2": {
+        "channel_id": "channel-490",
+        "port_id": "transfer"
+      },
+      "ordering": "unordered",
+      "version": "ics20-1",
+      "tags": {
+        "preferred": true,
+        "status": "ACTIVE"
+      }
+    }
+  ]
+}

--- a/dungeon/assetlist.json
+++ b/dungeon/assetlist.json
@@ -291,6 +291,56 @@
       "coingecko_id": "usd-coin"
     },
     {
+      "description": "USD Coin issued natively on Injective by Circle",
+      "denom_units": [
+        {
+          "denom": "ibc/873B9E8BAA6E423691F506F6F9AC3151AA390F67D2B655A02EF406175F04FC4F",
+          "exponent": 0
+        },
+        {
+          "denom": "usdc",
+          "exponent": 6
+        }
+      ],
+      "type_asset": "ics20",
+      "base": "ibc/873B9E8BAA6E423691F506F6F9AC3151AA390F67D2B655A02EF406175F04FC4F",
+      "name": "Injective USDC",
+      "display": "usdc",
+      "symbol": "USDC.inj",
+      "traces": [
+        {
+          "type": "ibc",
+          "counterparty": {
+            "chain_name": "injective",
+            "base_denom": "erc20:0xa00C59fF5a080D2b954d0c75e46E22a0c371235a",
+            "channel_id": "channel-490"
+          },
+          "chain": {
+            "channel_id": "channel-5320",
+            "path": "transfer/channel-5320/erc20:0xa00C59fF5a080D2b954d0c75e46E22a0c371235a"
+          }
+        }
+      ],
+      "images": [
+        {
+          "image_sync": {
+            "chain_name": "injective",
+            "base_denom": "erc20:0xa00C59fF5a080D2b954d0c75e46E22a0c371235a"
+          },
+          "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/_non-cosmos/ethereum/images/usdc.png",
+          "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/_non-cosmos/ethereum/images/usdc.svg",
+          "theme": {
+            "circle": true
+          }
+        }
+      ],
+      "logo_URIs": {
+        "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/_non-cosmos/ethereum/images/usdc.png",
+        "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/_non-cosmos/ethereum/images/usdc.svg"
+      },
+      "coingecko_id": "usd-coin"
+    },
+    {
       "description": "Passage (PASG) transferred to Dungeon Chain over IBC.",
       "denom_units": [
         {


### PR DESCRIPTION
Adds the dungeon-1 ↔ injective-1 IBC connection and lists USDC.inj on Dungeon Chain ahead of the Noble USDC sunset.

- `_IBC/dungeon-injective.json`: `channel-5320` (dungeon-1, client `07-tendermint-40`, `connection-8641`) ↔ `channel-490` (injective-1, client `07-tendermint-350`, `connection-349`), transfer / ics20-1 / unordered. Open and relayed (Hermes) by the Dungeon team.
- `dungeon/assetlist.json`: `USDC.inj` = `ibc/873B9E8BAA6E423691F506F6F9AC3151AA390F67D2B655A02EF406175F04FC4F` (`transfer/channel-5320/erc20:0xa00C59fF5a080D2b954d0c75e46E22a0c371235a`), mirroring the Osmosis entry's shape. `USDC.n` stays listed until Circle's 2027-01-12 snapshot.

Verification: `curl https://api.dungeongames.io/ibc/apps/transfer/v1/denoms/873B9E8BAA6E423691F506F6F9AC3151AA390F67D2B655A02EF406175F04FC4F` → the path above; supply is non-zero (live DGN/USDC.inj pool).

🤖 Generated with [Claude Code](https://claude.com/claude-code)