### PR TITLE
terpnetwork: v6.2.0 recommended after v6.1/v6.2 upgrade (supersedes #7949)

### DIFF
--- a/terpnetwork/chain.json
+++ b/terpnetwork/chain.json
@@ -9,24 +9,36 @@
   "bech32_prefix": "terp",
   "slip44": 118,
   "daemon_name": "terp",
-  "node_home": "$HOME/.terp",
+  "node_home": "$HOME/.terpd",
   "codebase": {
     "git_repo": "https://github.com/terpnetwork/terp-core.git",
     "genesis": {
       "genesis_url": "https://raw.githubusercontent.com/terpnetwork/networks/main/mainnet/morocco-1/genesis.json"
     },
-    "recommended_version": "v5.0.3",
+    "recommended_version": "v6.0.1",
     "compatible_versions": [
-      "v5.0.2",
-      "v5.0.3"
+      "v6.0.1"
     ],
     "consensus": {
       "type": "cometbft",
-      "version": "0.38.21"
+      "version": "0.39.3"
+    },
+    "sdk": {
+      "type": "cosmos",
+      "version": "0.54.3"
+    },
+    "ibc": {
+      "type": "go",
+      "version": "v11.2.0"
+    },
+    "cosmwasm": {
+      "version": "0.70.3",
+      "enabled": true,
+      "path": "$HOME/.terpd/data/wasm"
     },
     "binaries": {
-      "linux/amd64": "https://github.com/terpnetwork/terp-core/releases/download/v5.0.3/terpd-linux-amd64",
-      "linux/arm64": "https://github.com/terpnetwork/terp-core/releases/download/v5.0.3/terpd-linux-arm64"
+      "linux/amd64": "https://s3.terp.network/releases/terp-core/v6.0.1/terpd-6.0.1-linux-amd64.tar.gz?checksum=sha256:e4dd72f5a6cba3af602b49e51ee79229432f5de02dc23e586c5c6b7768dc285c",
+      "linux/arm64": "https://s3.terp.network/releases/terp-core/v6.0.1/terpd-6.0.1-linux-arm64.tar.gz?checksum=sha256:0b8d21b0bbe3cb593fb77c5cdd413d712aaf9465981180e2ca1f074f81c5cbc8"
     }
   },
   "fees": {

--- a/terpnetwork/chain.json
+++ b/terpnetwork/chain.json
@@ -8,7 +8,7 @@
   "chain_id": "morocco-1",
   "bech32_prefix": "terp",
   "slip44": 118,
-  "daemon_name": "terp",
+  "daemon_name": "terpd",
   "node_home": "$HOME/.terpd",
   "codebase": {
     "git_repo": "https://github.com/terpnetwork/terp-core.git",
@@ -35,10 +35,6 @@
       "version": "0.70.3",
       "enabled": true,
       "path": "$HOME/.terpd/data/wasm"
-    },
-    "binaries": {
-      "linux/amd64": "https://s3.terp.network/releases/terp-core/v6.0.1/terpd-6.0.1-linux-amd64.tar.gz?checksum=sha256:e4dd72f5a6cba3af602b49e51ee79229432f5de02dc23e586c5c6b7768dc285c",
-      "linux/arm64": "https://s3.terp.network/releases/terp-core/v6.0.1/terpd-6.0.1-linux-arm64.tar.gz?checksum=sha256:0b8d21b0bbe3cb593fb77c5cdd413d712aaf9465981180e2ca1f074f81c5cbc8"
     }
   },
   "fees": {

--- a/terpnetwork/versions.json
+++ b/terpnetwork/versions.json
@@ -143,7 +143,183 @@
         "type": "cometbft",
         "version": "0.38.21"
       },
-      "next_version_name": ""
+      "next_version_name": "v5.1.0"
+    },
+    {
+      "name": "v5.1.0",
+      "recommended_version": "v5.1.1",
+      "compatible_versions": [
+        "v5.1.0",
+        "v5.1.1"
+      ],
+      "consensus": {
+        "type": "cometbft",
+        "version": "0.38.21"
+      },
+      "next_version_name": "v5.2.0",
+      "binaries": {
+        "linux/amd64": "https://github.com/terpnetwork/terp-core/releases/download/v5.1.1/terpd-linux-amd64",
+        "linux/arm64": "https://github.com/terpnetwork/terp-core/releases/download/v5.1.1/terpd-linux-arm64"
+      }
+    },
+    {
+      "name": "v5.2.0",
+      "height": 21725359,
+      "recommended_version": "v5.2.0",
+      "compatible_versions": [
+        "v5.2.0"
+      ],
+      "consensus": {
+        "type": "cometbft",
+        "version": "0.38.21"
+      },
+      "sdk": {
+        "type": "cosmos",
+        "version": "0.53.4"
+      },
+      "ibc": {
+        "type": "go",
+        "version": "v10.5.0"
+      },
+      "cosmwasm": {
+        "version": "0.61.8",
+        "enabled": true,
+        "path": "$HOME/.terpd/data/wasm"
+      },
+      "next_version_name": "v6",
+      "binaries": {
+        "linux/amd64": "https://s3.terp.network/releases/terp-core/v5.2.0/terpd-5.2.0-linux-amd64.tar.gz",
+        "linux/arm64": "https://s3.terp.network/releases/terp-core/v5.2.0/terpd-5.2.0-linux-arm64.tar.gz",
+        "darwin/arm64": "https://s3.terp.network/releases/terp-core/v5.2.0/terpd-5.2.0-darwin-arm64.tar.gz"
+      }
+    },
+    {
+      "name": "v6",
+      "height": 22611000,
+      "recommended_version": "v6.0.0",
+      "compatible_versions": [
+        "v6.0.0"
+      ],
+      "consensus": {
+        "type": "cometbft",
+        "version": "0.39.3"
+      },
+      "sdk": {
+        "type": "cosmos",
+        "version": "0.54.3"
+      },
+      "ibc": {
+        "type": "go",
+        "version": "v11.2.0"
+      },
+      "cosmwasm": {
+        "version": "0.70.3",
+        "enabled": true,
+        "path": "$HOME/.terpd/data/wasm"
+      },
+      "next_version_name": "v6.0.1",
+      "binaries": {
+        "linux/amd64": "https://s3.terp.network/releases/terp-core/v6.0.0/terpd-6.0.0-linux-amd64.tar.gz",
+        "linux/arm64": "https://s3.terp.network/releases/terp-core/v6.0.0/terpd-6.0.0-linux-arm64.tar.gz",
+        "darwin/arm64": "https://s3.terp.network/releases/terp-core/v6.0.0/terpd-6.0.0-darwin-arm64.tar.gz"
+      },
+      "tag": "v6.0.0",
+      "previous_version_name": "v5.2.0"
+    },
+    {
+      "name": "v6.0.1",
+      "recommended_version": "v6.0.1",
+      "compatible_versions": [
+        "v6.0.1"
+      ],
+      "consensus": {
+        "type": "cometbft",
+        "version": "0.39.3"
+      },
+      "sdk": {
+        "type": "cosmos",
+        "version": "0.54.3"
+      },
+      "ibc": {
+        "type": "go",
+        "version": "v11.2.0"
+      },
+      "cosmwasm": {
+        "version": "0.70.3",
+        "enabled": true,
+        "path": "$HOME/.terpd/data/wasm"
+      },
+      "next_version_name": "v6.1",
+      "binaries": {
+        "linux/amd64": "https://s3.terp.network/releases/terp-core/v6.0.1/terpd-6.0.1-linux-amd64.tar.gz?checksum=sha256:e4dd72f5a6cba3af602b49e51ee79229432f5de02dc23e586c5c6b7768dc285c",
+        "linux/arm64": "https://s3.terp.network/releases/terp-core/v6.0.1/terpd-6.0.1-linux-arm64.tar.gz?checksum=sha256:0b8d21b0bbe3cb593fb77c5cdd413d712aaf9465981180e2ca1f074f81c5cbc8"
+      },
+      "tag": "v6.0.1",
+      "previous_version_name": "v6"
+    },
+    {
+      "name": "v6.1",
+      "proposal": 59,
+      "height": 23191300,
+      "recommended_version": "v6.1.0",
+      "compatible_versions": [
+        "v6.1.0"
+      ],
+      "consensus": {
+        "type": "cometbft",
+        "version": "0.40.0"
+      },
+      "sdk": {
+        "type": "cosmos",
+        "version": "0.55.0"
+      },
+      "ibc": {
+        "type": "go",
+        "version": "v11.2.0"
+      },
+      "cosmwasm": {
+        "version": "0.70.3",
+        "enabled": true,
+        "path": "$HOME/.terpd/data/wasm"
+      },
+      "next_version_name": "v6.2",
+      "binaries": {
+        "linux/amd64": "https://s3.terp.network/releases/terp-core/v6.1.0/terpd-6.1.0-linux-amd64.tar.gz?checksum=sha256:18a073f5d189f823987bd73d1ee6d410f9f48bbdcc92258fcbf8ae800780ebd2",
+        "linux/arm64": "https://s3.terp.network/releases/terp-core/v6.1.0/terpd-6.1.0-linux-arm64.tar.gz?checksum=sha256:4249119ebdbf75535c6852226fb7dee477373d65d2b721708bbb5265e8fdd8b4"
+      },
+      "tag": "v6.1.0",
+      "previous_version_name": "v6.0.1"
+    },
+    {
+      "name": "v6.2",
+      "height": 23191302,
+      "recommended_version": "v6.2.0",
+      "compatible_versions": [
+        "v6.2.0"
+      ],
+      "consensus": {
+        "type": "cometbft",
+        "version": "0.40.0"
+      },
+      "sdk": {
+        "type": "cosmos",
+        "version": "0.55.0"
+      },
+      "ibc": {
+        "type": "go",
+        "version": "v11.2.0"
+      },
+      "cosmwasm": {
+        "version": "0.70.3",
+        "enabled": true,
+        "path": "$HOME/.terpd/data/wasm"
+      },
+      "binaries": {
+        "linux/amd64": "https://s3.terp.network/releases/terp-core/v6.2.0/terpd-6.2.0-linux-amd64.tar.gz?checksum=sha256:38c15e1f54bc8234d07883c05e665ded68fdc0434c1c9db08de796d15ef491f6",
+        "linux/arm64": "https://s3.terp.network/releases/terp-core/v6.2.0/terpd-6.2.0-linux-arm64.tar.gz?checksum=sha256:148eedb6e8f1dd97e2436bc1b36dfebdbc915d23c14e6bad483924b0a4052c3d"
+      },
+      "tag": "v6.2.0",
+      "previous_version_name": "v6.1"
     }
   ]
 }

--- a/terpnetwork/versions.json
+++ b/terpnetwork/versions.json
@@ -156,14 +156,15 @@
         "type": "cometbft",
         "version": "0.38.21"
       },
-      "next_version_name": "v5.2.0",
+      "next_version_name": "v520",
       "binaries": {
         "linux/amd64": "https://github.com/terpnetwork/terp-core/releases/download/v5.1.1/terpd-linux-amd64",
         "linux/arm64": "https://github.com/terpnetwork/terp-core/releases/download/v5.1.1/terpd-linux-arm64"
       }
     },
     {
-      "name": "v5.2.0",
+      "name": "v520",
+      "proposal": 57,
       "height": 21725359,
       "recommended_version": "v5.2.0",
       "compatible_versions": [
@@ -188,14 +189,15 @@
       },
       "next_version_name": "v6",
       "binaries": {
-        "linux/amd64": "https://s3.terp.network/releases/terp-core/v5.2.0/terpd-5.2.0-linux-amd64.tar.gz",
-        "linux/arm64": "https://s3.terp.network/releases/terp-core/v5.2.0/terpd-5.2.0-linux-arm64.tar.gz",
-        "darwin/arm64": "https://s3.terp.network/releases/terp-core/v5.2.0/terpd-5.2.0-darwin-arm64.tar.gz"
-      }
+        "linux/amd64": "https://github.com/terpnetwork/terp-core/releases/download/v5.2.0/terpd-linux-amd64",
+        "linux/arm64": "https://github.com/terpnetwork/terp-core/releases/download/v5.2.0/terpd-linux-arm64"
+      },
+      "tag": "v5.2.0"
     },
     {
       "name": "v6",
-      "height": 22611000,
+      "proposal": 58,
+      "height": 22810000,
       "recommended_version": "v6.0.0",
       "compatible_versions": [
         "v6.0.0"
@@ -219,12 +221,12 @@
       },
       "next_version_name": "v6.0.1",
       "binaries": {
-        "linux/amd64": "https://s3.terp.network/releases/terp-core/v6.0.0/terpd-6.0.0-linux-amd64.tar.gz",
-        "linux/arm64": "https://s3.terp.network/releases/terp-core/v6.0.0/terpd-6.0.0-linux-arm64.tar.gz",
-        "darwin/arm64": "https://s3.terp.network/releases/terp-core/v6.0.0/terpd-6.0.0-darwin-arm64.tar.gz"
+        "linux/amd64": "https://github.com/terpnetwork/terp-core/releases/download/v6.0.0/terpd-linux-amd64",
+        "linux/arm64": "https://github.com/terpnetwork/terp-core/releases/download/v6.0.0/terpd-linux-arm64",
+        "darwin/arm64": "https://github.com/terpnetwork/terp-core/releases/download/v6.0.0/terpd-darwin-arm64"
       },
       "tag": "v6.0.0",
-      "previous_version_name": "v5.2.0"
+      "previous_version_name": "v520"
     },
     {
       "name": "v6.0.1",
@@ -250,10 +252,6 @@
         "path": "$HOME/.terpd/data/wasm"
       },
       "next_version_name": "v6.1",
-      "binaries": {
-        "linux/amd64": "https://s3.terp.network/releases/terp-core/v6.0.1/terpd-6.0.1-linux-amd64.tar.gz?checksum=sha256:e4dd72f5a6cba3af602b49e51ee79229432f5de02dc23e586c5c6b7768dc285c",
-        "linux/arm64": "https://s3.terp.network/releases/terp-core/v6.0.1/terpd-6.0.1-linux-arm64.tar.gz?checksum=sha256:0b8d21b0bbe3cb593fb77c5cdd413d712aaf9465981180e2ca1f074f81c5cbc8"
-      },
       "tag": "v6.0.1",
       "previous_version_name": "v6"
     },
@@ -283,10 +281,6 @@
         "path": "$HOME/.terpd/data/wasm"
       },
       "next_version_name": "v6.2",
-      "binaries": {
-        "linux/amd64": "https://s3.terp.network/releases/terp-core/v6.1.0/terpd-6.1.0-linux-amd64.tar.gz?checksum=sha256:18a073f5d189f823987bd73d1ee6d410f9f48bbdcc92258fcbf8ae800780ebd2",
-        "linux/arm64": "https://s3.terp.network/releases/terp-core/v6.1.0/terpd-6.1.0-linux-arm64.tar.gz?checksum=sha256:4249119ebdbf75535c6852226fb7dee477373d65d2b721708bbb5265e8fdd8b4"
-      },
       "tag": "v6.1.0",
       "previous_version_name": "v6.0.1"
     },
@@ -313,10 +307,6 @@
         "version": "0.70.3",
         "enabled": true,
         "path": "$HOME/.terpd/data/wasm"
-      },
-      "binaries": {
-        "linux/amd64": "https://s3.terp.network/releases/terp-core/v6.2.0/terpd-6.2.0-linux-amd64.tar.gz?checksum=sha256:38c15e1f54bc8234d07883c05e665ded68fdc0434c1c9db08de796d15ef491f6",
-        "linux/arm64": "https://s3.terp.network/releases/terp-core/v6.2.0/terpd-6.2.0-linux-arm64.tar.gz?checksum=sha256:148eedb6e8f1dd97e2436bc1b36dfebdbc915d23c14e6bad483924b0a4052c3d"
       },
       "tag": "v6.2.0",
       "previous_version_name": "v6.1"


### PR DESCRIPTION
## Summary

Carries the two commits from #7949 by @hard-nett unchanged, plus one commit that catches `terpnetwork` (`morocco-1`) up with the upgrade that executed on 2026-09-13.

The v6.1 plan (proposal 59) applied at height 23191300 and the v6.1.0 handler armed `v6.2` at 23191302, so nodes now run **v6.2.0** (commit `0c24074e`, which is the v6.2.0 tag). #7949 could not be updated in place because the fork is org-owned and does not accept maintainer pushes.

### On top of #7949

`chain.json`
- `recommended_version` / `compatible_versions`: v6.0.1 to **v6.2.0**
- `consensus.version`: 0.39.3 to **0.40.0**
- `sdk.version`: 0.54.3 to **0.55.0**
- `binaries`: restored, pointing at the checksummed v6.2.0 S3 tarballs (linux/amd64, linux/arm64, darwin/arm64)

`versions.json`
- `binaries` added to the `v6.0.1`, `v6.1` and `v6.2` rows (S3 tarballs with `?checksum=sha256:` matching the published `sha256sum.txt`). No other rows changed.

### Verified
- `applied_plan/v6.1` = 23191300, `applied_plan/v6.2` = 23191302, proposal 59 PASSED
- `node_info`: version 6.2.0, git_commit `0c24074e` == tag v6.2.0, cometbft v0.40.0, sdk v0.55.0, ibc-go v11.2.0, wasmd v0.70.3
- all 8 new binary URLs return 200; the v6.2.0 linux-amd64 tarball was downloaded and its sha256 matches `sha256sum.txt`; the v6.1.0 checksums equal the proposal 59 plan checksums
- `chain-registry validate` and `validate_data.mjs` pass locally

Closes #7949.